### PR TITLE
Fix(test): Pin kubectl provider to 1.14.0

### DIFF
--- a/terraform/environments/test/versions.tf
+++ b/terraform/environments/test/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     kubectl = {
       source  = "gavinbunney/kubectl"
-      version = "~> 1.14"
+      version = "1.14.0"
     }
   }
 }


### PR DESCRIPTION
Pins the kubectl provider version to 1.14.0 to match the dev environment. This should resolve the silent failure issue with the kubectl_manifest resource.