### PR TITLE
fix(loadbalancer): Use Cilium IPAM annotation for fixed IP assignment

### DIFF
--- a/argocd/overlays/dev/traefik-app.yaml
+++ b/argocd/overlays/dev/traefik-app.yaml
@@ -40,7 +40,8 @@ spec:
             effect: "NoSchedule"
         service:
           type: LoadBalancer
-          loadBalancerIP: "192.168.208.70"
+          annotations:
+            io.cilium/lb-ipam-ips: "192.168.208.70"
 
         ports:
           web:

--- a/argocd/overlays/test/traefik-app.yaml
+++ b/argocd/overlays/test/traefik-app.yaml
@@ -37,7 +37,8 @@ spec:
             effect: "NoSchedule"
         service:
           type: LoadBalancer
-          loadBalancerIP: "192.168.209.70"
+          annotations:
+            io.cilium/lb-ipam-ips: "192.168.209.70"
 
         ports:
           web:


### PR DESCRIPTION
## Problem

LoadBalancer services were getting auto-assigned IPs instead of the configured static IPs:
- **ArgoCD**: Got 192.168.209.81 instead of 192.168.209.71
- **Traefik**: Got 192.168.209.82 instead of 192.168.209.70

Root cause: `loadBalancerIP` field is deprecated in K8s 1.24+ and ignored by Cilium IPAM.

## Solution

Replace `loadBalancerIP` with Cilium-specific annotation `io.cilium/lb-ipam-ips`.

### Changes

**ArgoCD (Terraform managed):**
- `terraform/environments/dev/argocd.tf`: Use `io.cilium/lb-ipam-ips` annotation
- `terraform/environments/test/argocd.tf`: Use `io.cilium/lb-ipam-ips` annotation
- Target IPs: 192.168.208.71 (dev), 192.168.209.71 (test)

**Traefik (ArgoCD managed):**
- `argocd/overlays/dev/traefik-app.yaml`: Use `service.annotations` with Cilium IPAM
- `argocd/overlays/test/traefik-app.yaml`: Use `service.annotations` with Cilium IPAM  
- Target IPs: 192.168.208.70 (dev), 192.168.209.70 (test)

## Deployment Impact

⚠️ **Requires service recreation:**
- ArgoCD: Terraform will recreate the Helm release (downtime ~1-2 min)
- Traefik: ArgoCD will sync and recreate service (downtime ~30s)

After deployment, services will have stable, predictable IPs.

## Test Plan

**For test environment:**
1. Merge PR to test branch
2. Run `terraform apply` in test environment to recreate ArgoCD
3. Wait for ArgoCD auto-sync to recreate Traefik service
4. Verify IPs:
   - `kubectl get svc -n argocd argocd-server` → 192.168.209.71
   - `kubectl get svc -n traefik traefik` → 192.168.209.70

🤖 Generated with [Claude Code](https://claude.com/claude-code)