### PR TITLE
fix(test-env): Harmonize test environment configuration with dev patterns

### DIFF
--- a/argocd/overlays/test/cilium-lb-app.yaml
+++ b/argocd/overlays/test/cilium-lb-app.yaml
@@ -4,7 +4,9 @@ metadata:
   name: cilium-lb
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: "-2" # Deploy before other apps
+    argocd.argoproj.io/sync-wave: "-2"  # Deploy before metallb-config (wave -1)
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:
@@ -13,10 +15,15 @@ spec:
     path: apps/cilium-lb/overlays/test
   destination:
     server: https://kubernetes.default.svc
-    namespace: kube-system # Cilium resources are in kube-system
+    namespace: kube-system  # Cilium CRDs are cluster-scoped, but convention is kube-system
+
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
-    syncOptions:
-      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/argocd/overlays/test/traefik-app.yaml
+++ b/argocd/overlays/test/traefik-app.yaml
@@ -19,6 +19,8 @@ spec:
         providers:
           kubernetesCRD:
             enabled: true
+          kubernetesIngress:
+            enabled: true
 
         # Enable API and Dashboard
         api:

--- a/terraform/environments/test/terraform.tfvars
+++ b/terraform/environments/test/terraform.tfvars
@@ -2,15 +2,15 @@ git_branch = "test"
 environment = "test"
 vlan_services_subnet = "192.168.209.0/24"
 argocd_service_type = "LoadBalancer"
-argocd_loadbalancer_ip = "192.168.209.81"
+argocd_loadbalancer_ip = "192.168.209.71"
 
 
 # Talos Cluster Configuration
 cluster_name = "vixens-test"
 cluster_endpoint = "https://192.168.111.170:6443"
 control_plane_nodes = {
-  "topaze" = {
-    hostname = "topaze"
+  "citrine" = {
+    hostname = "citrine"
     ip_address = "192.168.111.172"
     install_disk = "/dev/sda"
     nameservers = ["1.1.1.1", "8.8.8.8"]
@@ -23,8 +23,8 @@ control_plane_nodes = {
       }
     ]
   },
-  "turquoise" = {
-    hostname = "turquoise"
+  "carny" = {
+    hostname = "carny"
     ip_address = "192.168.111.173"
     install_disk = "/dev/sda"
     nameservers = ["1.1.1.1", "8.8.8.8"]
@@ -37,8 +37,8 @@ control_plane_nodes = {
       }
     ]
   },
-  "tanzanite" = {
-    hostname = "tanzanite"
+  "celesty" = {
+    hostname = "celesty"
     ip_address = "192.168.111.174"
     install_disk = "/dev/sda"
     nameservers = ["1.1.1.1", "8.8.8.8"]
@@ -56,11 +56,11 @@ worker_nodes = {}
 
 # Cilium L2 Announcement
 l2_pool_name = "test-pool"
-l2_pool_ips = ["192.168.209.80-192.168.209.90"]
+l2_pool_ips = ["192.168.209.70-192.168.209.89"]
 l2_policy_name = "test-l2-policy"
 l2_policy_interfaces = ["eth1"]
 l2_policy_node_selector_labels = {
-  "kubernetes.io/hostname" = "topaze"
+  "kubernetes.io/hostname" = "citrine"
 }
 argocd_insecure = true
 argocd_anonymous_enabled = true


### PR DESCRIPTION
## Summary

Critical corrections to align test environment with dev standards and fix configuration inconsistencies discovered during environment comparison.

## Changes

### terraform/environments/test/terraform.tfvars
- **Fix node names**: topaze/turquoise/tanzanite → citrine/carny/celesty (match actual deployed cluster)
- **Fix IP pool range**: 192.168.209.80-90 → 192.168.209.70-89 (20 IPs, aligned with dev)
- **Fix ArgoCD LoadBalancer IP**: 192.168.209.81 → 192.168.209.71 (first IP in pool)
- **Fix L2 policy node selector**: topaze → citrine

### argocd/overlays/test/traefik-app.yaml
- **Add missing kubernetesIngress provider** (lost after PR #43)
- Ensures standard Kubernetes Ingress resources are processed

### argocd/overlays/test/cilium-lb-app.yaml
- Add finalizers for proper cleanup on deletion
- Add retry policy with exponential backoff (5 retries, 2x factor, 3m max)
- Update comments for consistency with dev

## Impact

- Test environment now follows same patterns as dev for consistency
- LoadBalancer IPs will be correctly assigned (.70 for Traefik, .71 for ArgoCD)
- Standard Kubernetes Ingress resources will work in test environment
- Terraform configuration matches actual deployed infrastructure

## Testing Plan

- [ ] Terraform plan/apply on test environment
- [ ] Validate ArgoCD gets correct IP (192.168.209.71)
- [ ] Validate Traefik gets correct IP (192.168.209.70)
- [ ] Validate standard Ingress resources are processed

🤖 Generated with [Claude Code](https://claude.com/claude-code)