### PR TITLE
feat(traefik): Add Traefik dashboard Ingress for hostname access

### DIFF
--- a/apps/traefik-dashboard/base/ingress.yaml
+++ b/apps/traefik-dashboard/base/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+    name: traefik-dashboard
+    namespace: traefik
+    annotations:
+        traefik.ingress.kubernetes.io/router.entrypoints: web
+spec:
+    ingressClassName: traefik
+    rules:
+        - host: traefik.ENVIRONMENT.truxonline.com
+          http:
+              paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: traefik
+                            port:
+                                name: traefik

--- a/apps/traefik-dashboard/base/kustomization.yaml
+++ b/apps/traefik-dashboard/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+    - ingress.yaml

--- a/apps/traefik-dashboard/overlays/dev/ingress-patch.yaml
+++ b/apps/traefik-dashboard/overlays/dev/ingress-patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+    name: traefik-dashboard
+    namespace: traefik
+spec:
+    rules:
+        - host: traefik.dev.truxonline.com
+          http:
+              paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: traefik
+                            port:
+                                name: traefik

--- a/apps/traefik-dashboard/overlays/dev/kustomization.yaml
+++ b/apps/traefik-dashboard/overlays/dev/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: traefik
+
+resources:
+    - ../../base
+
+patches:
+    - path: ingress-patch.yaml
+      target:
+          kind: Ingress
+          name: traefik-dashboard

--- a/apps/traefik-dashboard/overlays/test/ingress-patch.yaml
+++ b/apps/traefik-dashboard/overlays/test/ingress-patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+    name: traefik-dashboard
+    namespace: traefik
+spec:
+    rules:
+        - host: traefik.test.truxonline.com
+          http:
+              paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: traefik
+                            port:
+                                name: traefik

--- a/apps/traefik-dashboard/overlays/test/kustomization.yaml
+++ b/apps/traefik-dashboard/overlays/test/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: traefik
+
+resources:
+    - ../../base
+
+patches:
+    - path: ingress-patch.yaml
+      target:
+          kind: Ingress
+          name: traefik-dashboard

--- a/argocd/overlays/dev/kustomization.yaml
+++ b/argocd/overlays/dev/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: argocd
 resources:
   - cilium-lb-app.yaml         # Cilium L2 Announcements + LB IPAM (wave -2)
   - traefik-app.yaml           # Traefik Ingress Controller
+  - traefik-dashboard-app.yaml # Traefik Dashboard Ingress
   - argocd-app.yaml            # ArgoCD Ingress for UI
   - whoami-app.yaml            # Test application
   # - cert-manager-app.yaml

--- a/argocd/overlays/dev/traefik-dashboard-app.yaml
+++ b/argocd/overlays/dev/traefik-dashboard-app.yaml
@@ -1,20 +1,26 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: traefik-dashboard
-  namespace: argocd
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
+    name: traefik-dashboard
+    namespace: argocd
+    finalizers:
+        - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
-  source:
-    repoURL: https://github.com/charchess/vixens.git
-    targetRevision: dev
-    path: apps/traefik/overlays/dev
-  destination:
-    server: https://kubernetes.default.svc
-    namespace: traefik
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    project: default
+    source:
+        repoURL: https://github.com/charchess/vixens.git
+        targetRevision: dev
+        path: apps/traefik-dashboard/overlays/dev
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: traefik
+    syncPolicy:
+        automated:
+            prune: true
+            selfHeal: true
+        retry:
+            limit: 5
+            backoff:
+                duration: 5s
+                factor: 2
+                maxDuration: 3m

--- a/argocd/overlays/test/kustomization.yaml
+++ b/argocd/overlays/test/kustomization.yaml
@@ -6,5 +6,6 @@ namespace: argocd
 resources:
   - cilium-lb-app.yaml         # Cilium L2 Announcements + LB IPAM (wave -2)
   - traefik-app.yaml           # Traefik Ingress Controller
+  - traefik-dashboard-app.yaml # Traefik Dashboard Ingress
   - argocd-app.yaml            # ArgoCD Ingress for UI
   - whoami-app.yaml            # Test application

--- a/argocd/overlays/test/traefik-dashboard-app.yaml
+++ b/argocd/overlays/test/traefik-dashboard-app.yaml
@@ -1,20 +1,26 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: traefik-dashboard
-  namespace: argocd
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
+    name: traefik-dashboard
+    namespace: argocd
+    finalizers:
+        - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
-  source:
-    repoURL: https://github.com/charchess/vixens.git
-    targetRevision: test
-    path: apps/traefik/overlays/test
-  destination:
-    server: https://kubernetes.default.svc
-    namespace: traefik
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    project: default
+    source:
+        repoURL: https://github.com/charchess/vixens.git
+        targetRevision: test
+        path: apps/traefik-dashboard/overlays/test
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: traefik
+    syncPolicy:
+        automated:
+            prune: true
+            selfHeal: true
+        retry:
+            limit: 5
+            backoff:
+                duration: 5s
+                factor: 2
+                maxDuration: 3m


### PR DESCRIPTION
## Summary

Add dedicated Ingress resources to expose Traefik dashboard via hostname:
- **traefik.dev.truxonline.com** (dev environment)
- **traefik.test.truxonline.com** (test environment)

This complements the existing `/dashboard/` path accessible via LoadBalancer IP,
providing a cleaner hostname-based access method.

## Changes

**New Structure:**
- `apps/traefik-dashboard/base`: Base Ingress definition
- `apps/traefik-dashboard/overlays/dev`: Dev-specific hostname
- `apps/traefik-dashboard/overlays/test`: Test-specific hostname

**ArgoCD Integration:**
- Created `traefik-dashboard` Application for both dev and test
- Auto-sync enabled with retry policy
- Integrated into root-app kustomization

**Technical Details:**
- Uses standard Kubernetes Ingress (traefik provider)
- Routes to `traefik` service on port `traefik` (9000)
- Path: `/` (all requests to hostname go to dashboard)
- Entry point: `web` (HTTP)

## Testing

- [ ] Verify traefik.dev.truxonline.com resolves to dashboard
- [ ] Verify traefik.test.truxonline.com resolves to dashboard (after promotion to test)
- [ ] Confirm existing /dashboard/ access still works

## Fixes

Resolves the 404 error when accessing http://traefik.test.truxonline.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)