### PR TITLE
Harmonize test configuration with dev reference

### DIFF
--- a/apps/cilium-lb/overlays/test/ippool.yaml
+++ b/apps/cilium-lb/overlays/test/ippool.yaml
@@ -1,10 +1,16 @@
-apiVersion: "cilium.io/v2alpha1"
+apiVersion: cilium.io/v2alpha1
 kind: CiliumLoadBalancerIPPool
 metadata:
-  name: "vixens-test-pool"
+  name: vixens-test-pool
 spec:
   blocks:
+    # Assigned pool for static IPs (192.168.209.70-79)
     - start: "192.168.209.70"
+      stop: "192.168.209.79"
+    # Auto pool for dynamic allocation (192.168.209.80-89)
+    - start: "192.168.209.80"
       stop: "192.168.209.89"
+
+  # Allow all LoadBalancer services to use this pool
   serviceSelector:
     matchLabels: {}

--- a/argocd/overlays/test/kustomization.yaml
+++ b/argocd/overlays/test/kustomization.yaml
@@ -6,6 +6,5 @@ namespace: argocd
 resources:
   - cilium-lb-app.yaml         # Cilium L2 Announcements + LB IPAM (wave -2)
   - traefik-app.yaml           # Traefik Ingress Controller
-  - traefik-dashboard-app.yaml # Traefik Dashboard Ingress
   - argocd-app.yaml            # ArgoCD Ingress for UI
   - whoami-app.yaml            # Test application

--- a/argocd/overlays/test/traefik-app.yaml
+++ b/argocd/overlays/test/traefik-app.yaml
@@ -3,17 +3,18 @@ kind: Application
 metadata:
   name: traefik
   namespace: argocd
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   destination:
     server: https://kubernetes.default.svc
     namespace: traefik
   source:
+    # Point directly to the Helm chart repository
     repoURL: https://helm.traefik.io/traefik
     chart: traefik
     targetRevision: "v25.0.0"
+
+    # Define Helm values directly here
     helm:
       values: |
         providers:
@@ -55,6 +56,7 @@ spec:
             port: 9000
             expose: false
             exposedPort: 9000
+
   syncPolicy:
     automated:
       prune: true

--- a/terraform/environments/test/terraform.tfvars
+++ b/terraform/environments/test/terraform.tfvars
@@ -3,7 +3,8 @@ environment = "test"
 vlan_services_subnet = "192.168.209.0/24"
 argocd_service_type = "LoadBalancer"
 argocd_loadbalancer_ip = "192.168.209.71"
-
+argocd_disable_auth = true
+argocd_hostname = "argocd.test.truxonline.com"
 
 # Talos Cluster Configuration
 cluster_name = "vixens-test"


### PR DESCRIPTION
## Objectif
Corriger 7 incohérences de configuration entre test et dev pour aligner test sur la référence dev validée.

## 🚨 Corrections critiques
1. ✅ **Supprimer référence traefik-dashboard-app.yaml** - Le fichier n'existe pas, causait erreur Kustomize

## ⚠️ Configurations manquantes
2. ✅ **Ajouter argocd_hostname** = `argocd.test.truxonline.com`
3. ✅ **Ajouter argocd_disable_auth** = `true`

## 🔧 Alignement architectural
4. ✅ **Séparer pools IP Cilium** :
   - Assigned: 192.168.209.70-79 (IPs statiques)
   - Auto: 192.168.209.80-89 (allocation dynamique)
   - Correspond à la philosophie dev (pools séparés)

5. ✅ **Supprimer finalizers traefik-app** :
   - Dev n'a pas de finalizers sur traefik (Helm chart standard)
   - cilium-lb garde les finalizers (CRDs critiques)

## 📝 Documentation
6. ✅ **Commentaires ippool.yaml** - Documente assigned vs auto pools
7. ✅ **Commentaires traefik-app.yaml** - Explique sections Helm

## Validation
- ✅ Aucune modification de dev (référence intacte)
- ✅ Test s'aligne sur l'architecture dev validée
- ✅ 4 fichiers modifiés : ippool, kustomization, traefik-app, terraform.tfvars

🤖 Generated with [Claude Code](https://claude.com/claude-code)