### PR TITLE
Fix ArgoCD URL to use variable instead of hardcoded IP

### DIFF
--- a/terraform/environments/dev/argocd.tf
+++ b/terraform/environments/dev/argocd.tf
@@ -21,7 +21,7 @@ resource "helm_release" "argocd" {
       # dev/test: true (Traefik will terminate TLS later)
       # staging/prod: false (TLS at ArgoCD level)
       config = {
-        url = "http://192.168.208.71"   # TODO: a corrigé pour utiliser une variable
+        url = "http://${var.argocd_loadbalancer_ip}"
       }
       extraArgs = concat(
         var.argocd_insecure ? ["--insecure"] : [],
@@ -130,8 +130,8 @@ resource "helm_release" "argocd" {
       }
       cm = {
         "users.anonymous.enabled" = var.argocd_anonymous_enabled ? "true" : "false"
-        
-        "url" = "http://192.168.208.71" # TODO: a corrigé pour utiliser une variable
+
+        "url" = "http://${var.argocd_loadbalancer_ip}"
         "policy.csv" = <<-EOT
           p, role:readonly, applications, get, */*, allow
           p, role:readonly, applications, list, */*, allow

--- a/terraform/environments/test/argocd.tf
+++ b/terraform/environments/test/argocd.tf
@@ -21,7 +21,7 @@ resource "helm_release" "argocd" {
       # dev/test: true (Traefik will terminate TLS later)
       # staging/prod: false (TLS at ArgoCD level)
       config = {
-        url = "http://192.168.208.71"   # TODO: a corrigé pour utiliser une variable
+        url = "http://${var.argocd_loadbalancer_ip}"
       }
       extraArgs = concat(
         var.argocd_insecure ? ["--insecure"] : [],
@@ -130,8 +130,8 @@ resource "helm_release" "argocd" {
       }
       cm = {
         "users.anonymous.enabled" = var.argocd_anonymous_enabled ? "true" : "false"
-        
-        "url" = "http://192.168.208.71" # TODO: a corrigé pour utiliser une variable
+
+        "url" = "http://${var.argocd_loadbalancer_ip}"
         "policy.csv" = <<-EOT
           p, role:readonly, applications, get, */*, allow
           p, role:readonly, applications, list, */*, allow


### PR DESCRIPTION
## Objectif
Corriger l'URL ArgoCD pour utiliser la variable `argocd_loadbalancer_ip` au lieu d'IPs hardcodées.

## 🚨 Problème identifié

**DEV argocd.tf:**
- Ligne 24: `url = "http://192.168.208.71"` (hardcodé)
- Ligne 134: `"url" = "http://192.168.208.71"` (hardcodé)

**TEST argocd.tf:**
- Ligne 24: `url = "http://192.168.208.71"` (IP de DEV en dur! ❌)
- Ligne 134: `"url" = "http://192.168.208.71"` (IP de DEV en dur! ❌)

**Conséquence:**
- Test utilisait l'IP de dev (`192.168.208.71`) au lieu de `192.168.209.71`
- ArgoCD test obtenait une IP auto du pool (`.81` au lieu de `.71`)

## ✅ Solution

Utiliser `var.argocd_loadbalancer_ip` pour configuration dynamique :

```hcl
# Avant
url = "http://192.168.208.71"

# Après  
url = "http://${var.argocd_loadbalancer_ip}"
```

**Résultat:**
- Dev: `http://192.168.208.71` (depuis tfvars)
- Test: `http://192.168.209.71` (depuis tfvars) ✅

## 📋 Impact

Après `terraform apply` dans test :
- ArgoCD LoadBalancer obtiendra l'IP `192.168.209.71` (pool assigned)
- URL ArgoCD config correspondra à l'IP LoadBalancer
- Alignement dev/test correct

## Fichiers modifiés
- ✅ `terraform/environments/dev/argocd.tf` (2 lignes)
- ✅ `terraform/environments/test/argocd.tf` (2 lignes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)