### PR TITLE
fix(homeassistant): Use port 8123 for service with hostNetwork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ current_state.json
 *.lock
 .envrc
 .envrc.example
+.serena

--- a/apps/homeassistant/base/service.yaml
+++ b/apps/homeassistant/base/service.yaml
@@ -13,5 +13,5 @@ spec:
   ports:
     - name: http
       protocol: TCP
-      port: 80
+      port: 8123
       targetPort: 8123


### PR DESCRIPTION
Fixes 404 errors when accessing HomeAssistant via Ingress.

When using `hostNetwork: true`, the pod listens on the host IP directly. The ClusterIP service must use the same port (8123) as the container instead of trying to map 80 → 8123.

This PR merges the fix from dev into test with resolved .gitignore conflicts.

**Changes:**
- `apps/homeassistant/base/service.yaml`: Change service port from 80 to 8123
- `.gitignore`: Add `.serena` entry (merge conflict resolution)

**Testing:**
After merge, https://homeassistant.test.truxonline.com should be accessible without 404 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>