### PR TITLE
fix(terraform): Add infisical_secret path to all environments

### DIFF
--- a/terraform/environments/prod/terraform.tfvars
+++ b/terraform/environments/prod/terraform.tfvars
@@ -133,4 +133,5 @@ paths = {
   talosconfig           = "./talosconfig-prod"
   cilium_ip_pool_yaml   = "../../../apps/cilium-lb/overlays/prod/ippool.yaml"
   cilium_l2_policy_yaml = "../../../apps/cilium-lb/overlays/prod/l2policy.yaml"
+  infisical_secret      = "../../../.secrets/prod/infisical-universal-auth.yaml"
 }

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -165,12 +165,14 @@ variable "paths" {
     talosconfig           = string
     cilium_ip_pool_yaml   = string
     cilium_l2_policy_yaml = string
+    infisical_secret      = string
   })
 
   default = {
-    kubeconfig            = "./kubeconfig-dev"
-    talosconfig           = "./talosconfig-dev"
-    cilium_ip_pool_yaml   = "../../../apps/cilium-lb/overlays/dev/ippool.yaml"
+    kubeconfig            = "./kubeconfig-prod"
+    talosconfig           = "./talosconfig-prod"
+    cilium_ip_pool_yaml   = "../../../apps/cilium-lb/overlays/prod/ippool.yaml"
     cilium_l2_policy_yaml = "../../../apps/cilium-lb/base/l2policy.yaml"
+    infisical_secret      = "../../../.secrets/prod/infisical-universal-auth.yaml"
   }
 }

--- a/terraform/environments/staging/terraform.tfvars
+++ b/terraform/environments/staging/terraform.tfvars
@@ -132,4 +132,5 @@ paths = {
   talosconfig           = "./talosconfig-staging"
   cilium_ip_pool_yaml   = "../../../apps/cilium-lb/overlays/staging/ippool.yaml"
   cilium_l2_policy_yaml = "../../../apps/cilium-lb/overlays/staging/l2policy.yaml"
+  infisical_secret      = "../../../.secrets/staging/infisical-universal-auth.yaml"
 }

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -165,12 +165,14 @@ variable "paths" {
     talosconfig           = string
     cilium_ip_pool_yaml   = string
     cilium_l2_policy_yaml = string
+    infisical_secret      = string
   })
 
   default = {
-    kubeconfig            = "./kubeconfig-dev"
-    talosconfig           = "./talosconfig-dev"
-    cilium_ip_pool_yaml   = "../../../apps/cilium-lb/overlays/dev/ippool.yaml"
+    kubeconfig            = "./kubeconfig-staging"
+    talosconfig           = "./talosconfig-staging"
+    cilium_ip_pool_yaml   = "../../../apps/cilium-lb/overlays/staging/ippool.yaml"
     cilium_l2_policy_yaml = "../../../apps/cilium-lb/base/l2policy.yaml"
+    infisical_secret      = "../../../.secrets/staging/infisical-universal-auth.yaml"
   }
 }

--- a/terraform/environments/test/terraform.tfvars
+++ b/terraform/environments/test/terraform.tfvars
@@ -132,4 +132,5 @@ paths = {
   talosconfig           = "./talosconfig-test"
   cilium_ip_pool_yaml   = "../../../apps/cilium-lb/overlays/test/ippool.yaml"
   cilium_l2_policy_yaml = "../../../apps/cilium-lb/base/l2policy.yaml"
+  infisical_secret      = "../../../.secrets/test/infisical-universal-auth.yaml"
 }

--- a/terraform/environments/test/variables.tf
+++ b/terraform/environments/test/variables.tf
@@ -165,12 +165,14 @@ variable "paths" {
     talosconfig           = string
     cilium_ip_pool_yaml   = string
     cilium_l2_policy_yaml = string
+    infisical_secret      = string
   })
 
   default = {
-    kubeconfig            = "./kubeconfig-dev"
-    talosconfig           = "./talosconfig-dev"
-    cilium_ip_pool_yaml   = "../../../apps/cilium-lb/overlays/dev/ippool.yaml"
+    kubeconfig            = "./kubeconfig-test"
+    talosconfig           = "./talosconfig-test"
+    cilium_ip_pool_yaml   = "../../../apps/cilium-lb/overlays/test/ippool.yaml"
     cilium_l2_policy_yaml = "../../../apps/cilium-lb/base/l2policy.yaml"
+    infisical_secret      = "../../../.secrets/test/infisical-universal-auth.yaml"
   }
 }


### PR DESCRIPTION
## Summary

Fixes missing `infisical_secret` path configuration for test, staging, and prod environments.

## Problem

The previous Infisical bootstrap implementation only updated the dev environment.
When running `terraform destroy/apply` on test/staging/prod, this error occurred:

```
Error: Invalid value for input variable
attribute "infisical_secret" is required
```

## Solution

Added `infisical_secret` path to:
- `terraform/environments/test/variables.tf` + `terraform.tfvars`
- `terraform/environments/staging/variables.tf` + `terraform.tfvars`
- `terraform/environments/prod/variables.tf` + `terraform.tfvars`

Also fixed default path values in `variables.tf` to match each environment
(e.g., `kubeconfig-test` instead of `kubeconfig-dev`).

## Testing

✅ `terraform validate` - Success on test environment

## Impact

Test environment can now complete `terraform destroy/apply` cycle without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)