### PR TITLE
feat(prod): Add Infisical Operator for secrets management

### DIFF
--- a/argocd/overlays/prod/apps/infisical-operator.yaml
+++ b/argocd/overlays/prod/apps/infisical-operator.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: infisical-operator
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"  # Deployed before sealed-secrets (-1) and cilium-lb (-2)
+  labels:
+    app.kubernetes.io/part-of: vixens
+    app.kubernetes.io/component: secrets-management
+spec:
+  project: default
+  source:
+    repoURL: https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/
+    chart: secrets-operator
+    targetRevision: 0.10.5
+    helm:
+      values: |
+        controllerManager:
+          manager:
+            image:
+              repository: infisical/kubernetes-operator
+              tag: v0.10.1
+            resources:
+              limits:
+                cpu: 500m
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 128Mi
+          kubeRbacProxy:
+            image:
+              repository: gcr.io/kubebuilder/kube-rbac-proxy
+              tag: v0.13.1
+            resources:
+              limits:
+                cpu: 100m
+                memory: 64Mi
+              requests:
+                cpu: 50m
+                memory: 32Mi
+          tolerations:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+              effect: NoSchedule
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: infisical-operator-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -7,7 +7,10 @@ kind: Kustomization
 namespace: argocd
 
 resources:
-  - apps/cilium-lb.yaml                  # Cilium L2 Announcements + LB IPAM (wave -2)
+  # Infisical Operator for secrets management (wave -3)
+  - apps/infisical-operator.yaml
+  # Cilium L2 Announcements + LB IPAM (wave -2)
+  - apps/cilium-lb.yaml
   - apps/synology-csi-secrets.yaml       # Infisical secrets for Synology CSI (wave -1)
   - apps/traefik.yaml                    # Traefik Ingress Controller
   - apps/traefik-dashboard.yaml          # Traefik Dashboard hostname redirect


### PR DESCRIPTION
## Summary

Add Infisical Operator deployment to production environment, matching the configuration validated in dev, test, and staging.

## Changes
- Added `infisical-operator.yaml` to prod ArgoCD applications (sync wave -3)
- Deployed via Helm chart secrets-operator v0.10.5
- Operator v0.10.1 with control plane tolerations
- Required for syncing Infisical secrets (Gandi API, Synology CSI)

## Validation
- ✅ envSlug confirmed as "prod" in all InfisicalSecret manifests
- ✅ projectSlug "vixens" consistent across environments
- ✅ Secrets paths: /cert-manager, /synology-csi
- ✅ Configuration matches staging (successfully deployed and validated)

## Environment Flow
- [x] dev → test (PR #126 merged)
- [ ] test → staging (this PR)
- [ ] staging → main (prod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)