### PR TITLE
fix: ArgoCD prod paths + mail-gateway staging domain

### DIFF
--- a/apps/40-network/mail-gateway/overlays/staging/ingress.yaml
+++ b/apps/40-network/mail-gateway/overlays/staging/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-    - host: mail.staging.truxonline.com
+    - host: mail.stg.truxonline.com
       http:
         paths:
           - path: /
@@ -35,7 +35,7 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-    - host: mail.staging.truxonline.com
+    - host: mail.stg.truxonline.com
       http:
         paths:
           - path: /
@@ -47,5 +47,5 @@ spec:
                   number: 80
   tls:
     - hosts:
-        - mail.staging.truxonline.com
+        - mail.stg.truxonline.com
       secretName: mail-gateway-tls-staging

--- a/argocd/overlays/prod/apps/argocd.yaml
+++ b/argocd/overlays/prod/apps/argocd.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     repoURL: https://github.com/charchess/vixens.git
     targetRevision: main
-    path: apps/argocd/overlays/prod
+    path: apps/00-infra/argocd/overlays/prod
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd

--- a/argocd/overlays/prod/apps/cert-manager-config.yaml
+++ b/argocd/overlays/prod/apps/cert-manager-config.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     repoURL: https://github.com/charchess/vixens.git
     targetRevision: main
-    path: apps/cert-manager/overlays/prod
+    path: apps/00-infra/cert-manager/overlays/prod
   destination:
     server: https://kubernetes.default.svc
     namespace: cert-manager

--- a/argocd/overlays/prod/apps/cert-manager-secrets.yaml
+++ b/argocd/overlays/prod/apps/cert-manager-secrets.yaml
@@ -14,7 +14,7 @@ spec:
   source:
     repoURL: https://github.com/charchess/vixens.git
     targetRevision: main  # Production branch
-    path: apps/cert-manager-webhook-gandi/overlays/prod
+    path: apps/00-infra/cert-manager-webhook-gandi/overlays/prod
   syncPolicy:
     automated:
       prune: true

--- a/argocd/overlays/prod/apps/cilium-lb.yaml
+++ b/argocd/overlays/prod/apps/cilium-lb.yaml
@@ -14,7 +14,7 @@ spec:
   source:
     repoURL: https://github.com/charchess/vixens.git
     targetRevision: main
-    path: apps/cilium-lb/overlays/prod
+    path: apps/00-infra/cilium-lb/overlays/prod
 
   destination:
     server: https://kubernetes.default.svc

--- a/argocd/overlays/prod/apps/homeassistant.yaml
+++ b/argocd/overlays/prod/apps/homeassistant.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     repoURL: https://github.com/charchess/vixens.git
     targetRevision: main
-    path: apps/homeassistant/overlays/prod
+    path: apps/10-home/homeassistant/overlays/prod
   destination:
     server: https://kubernetes.default.svc
     namespace: homeassistant

--- a/argocd/overlays/prod/apps/mail-gateway.yaml
+++ b/argocd/overlays/prod/apps/mail-gateway.yaml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/charchess/vixens.git
-    path: apps/mail-gateway/overlays/prod
+    path: apps/40-network/mail-gateway/overlays/prod
     targetRevision: main
   destination:
     server: https://kubernetes.default.svc

--- a/argocd/overlays/prod/apps/mosquitto.yaml
+++ b/argocd/overlays/prod/apps/mosquitto.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     repoURL: https://github.com/charchess/vixens.git
     targetRevision: main
-    path: apps/mosquitto/overlays/prod
+    path: apps/10-home/mosquitto/overlays/prod
   destination:
     server: https://kubernetes.default.svc
     namespace: mosquitto

--- a/argocd/overlays/prod/apps/nfs-storage.yaml
+++ b/argocd/overlays/prod/apps/nfs-storage.yaml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/charchess/vixens
-    path: apps/nfs-storage/overlays/prod
+    path: apps/01-storage/nfs-storage/overlays/prod
     targetRevision: main
   destination:
     server: https://kubernetes.default.svc

--- a/argocd/overlays/prod/apps/synology-csi-secrets.yaml
+++ b/argocd/overlays/prod/apps/synology-csi-secrets.yaml
@@ -14,7 +14,7 @@ spec:
   source:
     repoURL: https://github.com/charchess/vixens.git
     targetRevision: main  # Production branch
-    path: apps/synology-csi/infisical/overlays/prod
+    path: apps/01-storage/synology-csi/infisical/overlays/prod
   syncPolicy:
     automated:
       prune: true

--- a/argocd/overlays/prod/apps/synology-csi.yaml
+++ b/argocd/overlays/prod/apps/synology-csi.yaml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/charchess/vixens
-    path: apps/synology-csi/overlays/prod
+    path: apps/01-storage/synology-csi/overlays/prod
     targetRevision: main
   destination:
     server: https://kubernetes.default.svc

--- a/argocd/overlays/prod/apps/traefik-dashboard.yaml
+++ b/argocd/overlays/prod/apps/traefik-dashboard.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     repoURL: https://github.com/charchess/vixens.git
     targetRevision: main
-    path: apps/traefik-dashboard/overlays/prod
+    path: apps/00-infra/traefik-dashboard/overlays/prod
   destination:
     server: https://kubernetes.default.svc
     namespace: traefik

--- a/argocd/overlays/prod/apps/whoami.yaml
+++ b/argocd/overlays/prod/apps/whoami.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     repoURL: https://github.com/charchess/vixens.git
     targetRevision: main
-    path: apps/whoami/overlays/prod
+    path: apps/99-test/whoami/overlays/prod
   destination:
     server: https://kubernetes.default.svc
     namespace: whoami


### PR DESCRIPTION
## Summary

Propagating fixes from test environment:

1. **ArgoCD prod application paths** - Updates all 12 ArgoCD prod applications to use the new functional domain structure
2. **mail-gateway staging domain** - Corrects domain from `mail.staging.truxonline.com` to `mail.stg.truxonline.com`

## Changes

### Commit 1: mail-gateway staging domain
- File: `apps/40-network/mail-gateway/overlays/staging/ingress.yaml`
- **Direct impact on staging environment**
- Fixes: `mail.staging.truxonline.com` → `mail.stg.truxonline.com`

### Commit 2: ArgoCD prod paths (12 apps)
Updated paths in `argocd/overlays/prod/apps/` (affects prod after main merge):
- ✅ 00-infra: argocd, cert-manager (config+secrets), cilium-lb, traefik-dashboard
- ✅ 10-home: homeassistant, mosquitto
- ✅ 01-storage: nfs-storage, synology-csi (+infisical)
- ✅ 40-network: mail-gateway
- ✅ 99-test: whoami

## Validation in Staging

After merge, the mail-gateway domain will be corrected automatically by ArgoCD.

## Dependencies

- ✅ PR #155 (dev → test) merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)