### PR TITLE
fix(homeassistant): correct Infisical secret namespace for prod/staging

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/infisical-filebrowser-auth.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/infisical-filebrowser-auth.yaml
@@ -11,7 +11,7 @@ spec:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
-        secretNamespace: homeassistant
+        secretNamespace: argocd
       secretsScope:
         projectSlug: 9f90e1c8-a85d-4613-88a6-0eb2ff1d3cdb
         envSlug: prod

--- a/apps/10-home/homeassistant/overlays/staging/infisical-filebrowser-auth.yaml
+++ b/apps/10-home/homeassistant/overlays/staging/infisical-filebrowser-auth.yaml
@@ -11,7 +11,7 @@ spec:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
-        secretNamespace: homeassistant
+        secretNamespace: argocd
       secretsScope:
         projectSlug: 9f90e1c8-a85d-4613-88a6-0eb2ff1d3cdb
         envSlug: staging


### PR DESCRIPTION
## Summary

Fixes the Infisical authentication error preventing homeassistant pod from starting in prod.

## Root Cause

The `infisical-universal-auth` secret is centralized in the `argocd` namespace to be shared across all Infisical operators. However, the staging and prod InfisicalSecret configurations were pointing to the wrong namespace (`homeassistant`).

## Changes

**Files modified:**
- `apps/10-home/homeassistant/overlays/prod/infisical-filebrowser-auth.yaml`
- `apps/10-home/homeassistant/overlays/staging/infisical-filebrowser-auth.yaml`

**Change:**
```yaml
credentialsRef:
  secretName: infisical-universal-auth
  secretNamespace: homeassistant  # ❌ Wrong
  secretNamespace: argocd         # ✅ Correct
```

## Impact

**Before:**
- InfisicalSecret status: `Failed to load Infisical Token: no authentication method provided`
- Secret `filebrowser-auth` not created
- Pod status: `Init:CreateContainerConfigError`
- Service: https://homeassistant-fb.truxonline.com → 404

**After (once merged to main):**
- ✅ InfisicalSecret will authenticate successfully
- ✅ Secret `filebrowser-auth` will be created
- ✅ Pod will start normally
- ✅ Service will be accessible

## Testing

In dev/test environments where this was already correct:
```bash
kubectl get secret -n argocd infisical-universal-auth  # ✅ Exists
kubectl describe infisicalsecret -n homeassistant filebrowser-auth  # ✅ Working
```

## Dependencies

This is a **hotfix** for the previous PR #157 deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)