### PR TITLE
fix(homeassistant): correct Infisical secret namespace for prod/staging

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/infisical-filebrowser-auth.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/infisical-filebrowser-auth.yaml
@@ -11,7 +11,7 @@ spec:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
-        secretNamespace: homeassistant
+        secretNamespace: argocd
       secretsScope:
         projectSlug: 9f90e1c8-a85d-4613-88a6-0eb2ff1d3cdb
         envSlug: prod

--- a/apps/10-home/homeassistant/overlays/staging/infisical-filebrowser-auth.yaml
+++ b/apps/10-home/homeassistant/overlays/staging/infisical-filebrowser-auth.yaml
@@ -11,7 +11,7 @@ spec:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
-        secretNamespace: homeassistant
+        secretNamespace: argocd
       secretsScope:
         projectSlug: 9f90e1c8-a85d-4613-88a6-0eb2ff1d3cdb
         envSlug: staging


### PR DESCRIPTION
Fix InfisicalSecret authentication issue in prod/staging by correcting secretNamespace reference from homeassistant to argocd.

The `infisical-universal-auth` secret is centralized in the argocd namespace for use by all Infisical operators across the cluster.

**Changes:**
- apps/10-home/homeassistant/overlays/prod/infisical-filebrowser-auth.yaml
- apps/10-home/homeassistant/overlays/staging/infisical-filebrowser-auth.yaml

**Expected Result:**
- InfisicalSecret will authenticate successfully
- Secret `filebrowser-auth` will be created
- homeassistant pod will start
- https://homeassistant-fb.truxonline.com will be accessible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication credential configuration namespace references across production and staging environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->