### PR TITLE
fix(homeassistant): correct Infisical projectSlug and secretsPath for prod/staging

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/infisical-filebrowser-auth.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/infisical-filebrowser-auth.yaml
@@ -13,10 +13,9 @@ spec:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        projectSlug: 9f90e1c8-a85d-4613-88a6-0eb2ff1d3cdb
+        projectSlug: vixens
         envSlug: prod
-        secretsPath: /vixens/prod/homeassistant-filebrowser-auth
-        recursive: false
+        secretsPath: /homeassistant/filebrowser
   managedSecretReference:
     secretName: filebrowser-auth
     secretNamespace: homeassistant

--- a/apps/10-home/homeassistant/overlays/staging/infisical-filebrowser-auth.yaml
+++ b/apps/10-home/homeassistant/overlays/staging/infisical-filebrowser-auth.yaml
@@ -13,10 +13,9 @@ spec:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        projectSlug: 9f90e1c8-a85d-4613-88a6-0eb2ff1d3cdb
+        projectSlug: vixens
         envSlug: staging
-        secretsPath: /vixens/staging/homeassistant-filebrowser-auth
-        recursive: false
+        secretsPath: /homeassistant/filebrowser
   managedSecretReference:
     secretName: filebrowser-auth
     secretNamespace: homeassistant


### PR DESCRIPTION
Fix InfisicalSecret configuration to use correct projectSlug and secretsPath.

**Root Cause:**
- prod/staging were using invalid UUID `9f90e1c8-a85d-4613-88a6-0eb2ff1d3cdb` instead of project name `vixens`
- secretsPath was environment-specific instead of standard path

**Changes:**
- `projectSlug: 9f90e1c8-a85d-4613-88a6-0eb2ff1d3cdb` → `vixens`
- `secretsPath: /vixens/{env}/homeassistant-filebrowser-auth` → `/homeassistant/filebrowser`
- Removed `recursive: false` (not needed)

**Aligns with:**
- Working dev/test configuration
- Other InfisicalSecrets (cert-manager, synology-csi)

**Expected Result:**
- InfisicalSecret will fetch secrets successfully
- Secret `filebrowser-auth` will be created
- homeassistant pod will start
- https://homeassistant-fb.truxonline.com will be accessible