### PR TITLE
fix(homeassistant): correct Infisical projectSlug and secretsPath for prod/staging

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/infisical-filebrowser-auth.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/infisical-filebrowser-auth.yaml
@@ -13,10 +13,9 @@ spec:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        projectSlug: 9f90e1c8-a85d-4613-88a6-0eb2ff1d3cdb
+        projectSlug: vixens
         envSlug: prod
-        secretsPath: /vixens/prod/homeassistant-filebrowser-auth
-        recursive: false
+        secretsPath: /homeassistant/filebrowser
   managedSecretReference:
     secretName: filebrowser-auth
     secretNamespace: homeassistant

--- a/apps/10-home/homeassistant/overlays/staging/infisical-filebrowser-auth.yaml
+++ b/apps/10-home/homeassistant/overlays/staging/infisical-filebrowser-auth.yaml
@@ -13,10 +13,9 @@ spec:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        projectSlug: 9f90e1c8-a85d-4613-88a6-0eb2ff1d3cdb
+        projectSlug: vixens
         envSlug: staging
-        secretsPath: /vixens/staging/homeassistant-filebrowser-auth
-        recursive: false
+        secretsPath: /homeassistant/filebrowser
   managedSecretReference:
     secretName: filebrowser-auth
     secretNamespace: homeassistant


### PR DESCRIPTION
**FINAL FIX** for InfisicalSecret authentication issue in prod/staging.

## Root Cause Analysis

After fixing the namespace issue (PR #160), discovered that:
1. **Invalid projectSlug**: Using UUID `9f90e1c8-a85d-4613-88a6-0eb2ff1d3cdb` instead of project name `vixens`
2. **Wrong secretsPath**: Using environment-specific paths instead of standard path

## Changes

### Prod \& Staging
- `projectSlug: 9f90e1c8-a85d-4613-88a6-0eb2ff1d3cdb` → `vixens`
- `secretsPath: /vixens/{env}/homeassistant-filebrowser-auth` → `/homeassistant/filebrowser`
- Removed `recursive: false` (not needed)

### Alignment
Now matches working dev/test configuration and other InfisicalSecrets (cert-manager, synology-csi).

## Validation

InfisicalSecret authentication now works:
✅ Token loaded successfully
❌ Was failing with: "Project with slug '9f90e1c8-a85d-4613-88a6-0eb2ff1d3cdb' not found"

## Expected Result

- InfisicalSecret fetches secrets from Infisical
- Secret `filebrowser-auth` created in homeassistant namespace
- homeassistant pod starts successfully
- https://homeassistant-fb.truxonline.com becomes accessible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication configuration settings for filebrowser services across both production and staging environments.
  * Modified credential namespace and secret management path mappings to align with infrastructure requirements.
  * Adjusted secret scope configuration for improved credential handling consistency.
  * Enhanced secret creation policy settings in staging environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->