### PR TITLE
fix(traefik,homeassistant): revert problematic Gemini changes

### DIFF
--- a/apps/00-infra/traefik/values/common.yaml
+++ b/apps/00-infra/traefik/values/common.yaml
@@ -41,18 +41,22 @@ tolerations:
 ports:
   web:
     port: 80
+    exposedPort: 80
     expose: true
   websecure:
     port: 443
+    exposedPort: 443
     expose: true
     tls:
       enabled: true
   mqtt: # New entrypoint for Mosquitto
     port: 1883
+    exposedPort: 1883
     expose: true
     protocol: TCP
   coiot: # New entrypoint for Home Assistant CoIoT (Shelly devices)
     port: 5683
+    exposedPort: 5683
     expose: true
     protocol: UDP
   traefik:

--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
         app: homeassistant
     spec:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: "OnRootMismatch"
       hostNetwork: true  # Required for mDNS/UPnP local discovery
       dnsPolicy: ClusterFirstWithHostNet  # Use cluster DNS even with hostNetwork
       tolerations:


### PR DESCRIPTION
## Summary
Reverts problematic changes made by Gemini that broke Traefik LoadBalancer and HomeAssistant PVC permissions.

## Changes

### Traefik Configuration (CRITICAL)
- ✅ Restore `exposedPort` parameters for all entrypoints:
  - `exposedPort: 80` for web
  - `exposedPort: 443` for websecure
  - `exposedPort: 1883` for mqtt (Mosquitto)
  - `exposedPort: 5683` for coiot (HomeAssistant Shelly devices)

**Impact:** Without `exposedPort`, Traefik LoadBalancer service doesn't properly expose these ports, breaking external access to MQTT and CoIoT protocols.

### HomeAssistant Deployment
- ✅ Restore `securityContext.fsGroup: 1000`
- ✅ Restore `fsGroupChangePolicy: "OnRootMismatch"`

**Impact:** Prevents PVC permission issues when mounting persistent volumes.

## Validation
- Configuration now matches validated staging environment
- All changes verified against `origin/staging` branch
- No functional changes, only reverting problematic deletions

## Files Changed
- `apps/00-infra/traefik/values/common.yaml` (+4 lines)
- `apps/10-home/homeassistant/base/deployment.yaml` (+3 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration to expose additional ports for MQTT and CoIoT protocols.
  * Enhanced Home Assistant deployment security with improved file system group permissions and policies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->