### PR TITLE
dev to test

### DIFF
--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -33,10 +33,7 @@ spec:
               value: "1000"
             - name: TZ
               value: "Europe/Paris"
-            - name: HOST_WHITELIST_ENTRIES
-              value: "sabnzbd.dev.truxonline.com,sabnzbd,sabnzbd.media,sabnzbd.media.svc.cluster.local" # Adapted per environment
-            - name: SABNZBD_HOST
-              value: "sabnzbd.dev.truxonline.com" # Set the host explicitly
+            # HOST_WHITELIST_ENTRIES and SABNZBD_HOST are set per environment via overlays
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/20-media/sabnzbd/overlays/dev/deployment-patch.yaml
+++ b/apps/20-media/sabnzbd/overlays/dev/deployment-patch.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sabnzbd
+spec:
+  template:
+    spec:
+      containers:
+        - name: sabnzbd
+          env:
+            - name: HOST_WHITELIST_ENTRIES
+              value: "sabnzbd.dev.truxonline.com,sabnzbd,sabnzbd.media,sabnzbd.media.svc.cluster.local"
+            - name: SABNZBD_HOST
+              value: "sabnzbd.dev.truxonline.com"

--- a/apps/20-media/sabnzbd/overlays/dev/kustomization.yaml
+++ b/apps/20-media/sabnzbd/overlays/dev/kustomization.yaml
@@ -7,3 +7,9 @@ resources:
   - ../../base
   - http-redirect.yaml
   - ingress.yaml
+
+patches:
+  - path: deployment-patch.yaml
+    target:
+      kind: Deployment
+      name: sabnzbd

--- a/apps/20-media/sabnzbd/overlays/prod/deployment-patch.yaml
+++ b/apps/20-media/sabnzbd/overlays/prod/deployment-patch.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sabnzbd
+spec:
+  template:
+    spec:
+      containers:
+        - name: sabnzbd
+          env:
+            - name: HOST_WHITELIST_ENTRIES
+              value: "sabnzbd.truxonline.com,sabnzbd,sabnzbd.media,sabnzbd.media.svc.cluster.local"
+            - name: SABNZBD_HOST
+              value: "sabnzbd.truxonline.com"

--- a/apps/20-media/sabnzbd/overlays/prod/kustomization.yaml
+++ b/apps/20-media/sabnzbd/overlays/prod/kustomization.yaml
@@ -12,3 +12,7 @@ patches:
     target:
       kind: InfisicalSecret
       name: sabnzbd-secrets-sync
+  - path: deployment-patch.yaml
+    target:
+      kind: Deployment
+      name: sabnzbd

--- a/apps/20-media/sabnzbd/overlays/staging/deployment-patch.yaml
+++ b/apps/20-media/sabnzbd/overlays/staging/deployment-patch.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sabnzbd
+spec:
+  template:
+    spec:
+      containers:
+        - name: sabnzbd
+          env:
+            - name: HOST_WHITELIST_ENTRIES
+              value: "sabnzbd.staging.truxonline.com,sabnzbd,sabnzbd.media,sabnzbd.media.svc.cluster.local"
+            - name: SABNZBD_HOST
+              value: "sabnzbd.staging.truxonline.com"

--- a/apps/20-media/sabnzbd/overlays/staging/kustomization.yaml
+++ b/apps/20-media/sabnzbd/overlays/staging/kustomization.yaml
@@ -12,3 +12,7 @@ patches:
     target:
       kind: InfisicalSecret
       name: sabnzbd-secrets-sync
+  - path: deployment-patch.yaml
+    target:
+      kind: Deployment
+      name: sabnzbd

--- a/apps/20-media/sabnzbd/overlays/test/deployment-patch.yaml
+++ b/apps/20-media/sabnzbd/overlays/test/deployment-patch.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sabnzbd
+spec:
+  template:
+    spec:
+      containers:
+        - name: sabnzbd
+          env:
+            - name: HOST_WHITELIST_ENTRIES
+              value: "sabnzbd.test.truxonline.com,sabnzbd,sabnzbd.media,sabnzbd.media.svc.cluster.local"
+            - name: SABNZBD_HOST
+              value: "sabnzbd.test.truxonline.com"

--- a/apps/20-media/sabnzbd/overlays/test/kustomization.yaml
+++ b/apps/20-media/sabnzbd/overlays/test/kustomization.yaml
@@ -12,3 +12,7 @@ patches:
     target:
       kind: InfisicalSecret
       name: sabnzbd-secrets-sync
+  - path: deployment-patch.yaml
+    target:
+      kind: Deployment
+      name: sabnzbd


### PR DESCRIPTION
- Remove hardcoded SABNZBD_HOST and HOST_WHITELIST_ENTRIES from base deployment
- Add deployment-patch.yaml to each overlay (dev, test, staging, prod)
- Each environment now has its own hostname configuration:
  - dev: sabnzbd.dev.truxonline.com
  - test: sabnzbd.test.truxonline.com
  - staging: sabnzbd.staging.truxonline.com
  - prod: sabnzbd.truxonline.com
- Update kustomization.yaml in all overlays to apply deployment patches

This follows the Kustomize best practice of keeping environment-agnostic
configuration in base and environment-specific config in overlays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
