### PR TITLE
fix(homeassistant): point to prod secrets in production overlay

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -248,6 +248,11 @@ jobs:
             exit 1
           fi
 
+          if grep -r "envSlug: dev" apps/*/*/overlays/prod; then
+            echo "::error::Found 'envSlug: dev' in apps/*/*/overlays/prod. Please use 'prod' for production."
+            exit 1
+          fi
+
           if grep -r "vixens-new.git" argocd; then
             echo "::error::Found 'vixens-new.git references' in argocd. Please use 'vixens.git', vixens-new is deprecated."
             exit 1

--- a/apps/10-home/homeassistant/overlays/prod/infisical-config-patch.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/infisical-config-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: homeassistant-config-sync
+  namespace: homeassistant
+spec:
+  authentication:
+    universalAuth:
+      secretsScope:
+        envSlug: prod

--- a/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
@@ -7,3 +7,6 @@ resources:
   - ingress.yaml
   - ingressroute-udp.yaml
   - infisical-filebrowser-auth.yaml
+
+patches:
+  - path: infisical-config-patch.yaml


### PR DESCRIPTION
Investigation showed that Home Assistant in production was crashing because it was attempting to sync configuration secrets from the 'dev' Infisical environment instead of 'prod', resulting in an empty secret and a mount error. This PR adds the necessary patch to the production overlay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented stricter validation checks in the production deployment pipeline to catch configuration errors before deployments reach end users
  * Integrated secure secrets management for Home Assistant production environment to improve handling and protection of sensitive credentials

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->