### PR TITLE
chore: sync prod applications from dev to test

### DIFF
--- a/argocd/overlays/prod/apps/authentik.yaml
+++ b/argocd/overlays/prod/apps/authentik.yaml
@@ -5,7 +5,7 @@ metadata:
   name: authentik
   namespace: argocd
   labels:
-    vixens.lab/environment: dev
+    vixens.lab/environment: prod
     vixens.lab/managed-by: terraform
   finalizers:
     - resources-finalizer.argocd.argoproj.io

--- a/argocd/overlays/prod/apps/loki.yaml
+++ b/argocd/overlays/prod/apps/loki.yaml
@@ -5,7 +5,7 @@ metadata:
   name: loki
   namespace: argocd
   labels:
-    vixens.lab/environment: dev
+    vixens.lab/environment: prod
     vixens.lab/managed-by: terraform
   finalizers:
     - resources-finalizer.argocd.argoproj.io

--- a/argocd/overlays/prod/apps/promtail.yaml
+++ b/argocd/overlays/prod/apps/promtail.yaml
@@ -5,7 +5,7 @@ metadata:
   name: promtail
   namespace: argocd
   labels:
-    vixens.lab/environment: dev
+    vixens.lab/environment: prod
     vixens.lab/managed-by: terraform
   finalizers:
     - resources-finalizer.argocd.argoproj.io


### PR DESCRIPTION
## Summary
Synchronize production application definitions from dev to test environment.

This PR adds 20 applications to the prod overlay that are currently missing in test/staging/main:
- Infrastructure: alertmanager, metrics-server, reloader, goldilocks, vpa
- Monitoring: loki, promtail
- Security: authentik, headlamp
- Databases: postgresql-shared, redis-shared
- Media: jellyfin, jellyseerr, frigate
- Network: hubble-ui, netvisor
- Tools: linkwarden, netbox, gitops-revision-controller
- Base: cloudnative-pg-crds, changedetection, booklore

## Changes
- Added 20 application definitions to argocd/overlays/prod/kustomization.yaml
- Fixed environment labels for authentik, loki, promtail (dev → prod)

## Validation
- [ ] Applications deploy successfully in test environment
- [ ] No regressions in existing applications
- [ ] ArgoCD app-of-apps syncs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)