### PR TITLE
fix(netbox,netvisor): resolve health check and DaemonSet deployment issues

### DIFF
--- a/apps/40-network/netvisor/base/kustomization.yaml
+++ b/apps/40-network/netvisor/base/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 namespace: networking
 
 resources:
+  - namespace.yaml
   - server-deployment.yaml
   - daemon-daemonset.yaml
   - server-service.yaml

--- a/apps/40-network/netvisor/base/namespace.yaml
+++ b/apps/40-network/netvisor/base/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: networking
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/apps/70-tools/netbox/overlays/prod/deployment-patch.yaml
+++ b/apps/70-tools/netbox/overlays/prod/deployment-patch.yaml
@@ -9,4 +9,4 @@ spec:
         - name: netbox
           env:
             - name: ALLOWED_HOSTS
-              value: "netbox.truxonline.com"
+              value: "netbox.truxonline.com,127.0.0.1,localhost"


### PR DESCRIPTION
## Summary
- **netbox**: Add localhost/127.0.0.1 to ALLOWED_HOSTS for probe health checks
- **netvisor**: Add privileged PodSecurity labels to networking namespace

## Details

### netbox Issue
Django's ALLOWED_HOSTS was rejecting liveness/readiness probes because they don't send Host headers, causing HTTP 400 responses and pod restarts every ~90 seconds.

**Fix**: Add `127.0.0.1,localhost` to ALLOWED_HOSTS alongside production hostname

### netvisor Issue
DaemonSet requires `hostNetwork=true` and `privileged=true` for network scanning, but networking namespace had baseline PodSecurity policy blocking pod creation.

**Fix**: Create namespace.yaml with privileged PodSecurity labels (consistent with other privileged namespaces like adguard-home)

🤖 Generated with [Claude Code](https://claude.com/claude-code)