### PR TITLE
fix(netbox): add Host header to liveness/readiness probes

### DIFF
--- a/apps/70-tools/netbox/overlays/prod/deployment-patch.yaml
+++ b/apps/70-tools/netbox/overlays/prod/deployment-patch.yaml
@@ -10,3 +10,13 @@ spec:
           env:
             - name: ALLOWED_HOSTS
               value: "netbox.truxonline.com,127.0.0.1,localhost"
+          livenessProbe:
+            httpGet:
+              httpHeaders:
+                - name: Host
+                  value: localhost
+          readinessProbe:
+            httpGet:
+              httpHeaders:
+                - name: Host
+                  value: localhost


### PR DESCRIPTION
## Summary
Fix netbox liveness/readiness probe failures by adding Host header

## Problem
Django requires a Host header in HTTP requests to match against ALLOWED_HOSTS.
Kubernetes probes don't send Host headers by default, causing HTTP 400 responses
even with ALLOWED_HOSTS configured to include localhost and 127.0.0.1.

## Solution
Add `httpHeaders` to both liveness and readiness probes with `Host: localhost`

## Testing
- Verified with curl inside pod that requests with Host header return 200 OK
- Verified without Host header returns 400 Bad Request

🤖 Generated with [Claude Code](https://claude.com/claude-code)