### PR TITLE
fix(netbox): use wildcard ALLOWED_HOSTS to fix 400 errors via Traefik

### DIFF
--- a/apps/70-tools/netbox/overlays/prod/deployment-patch.yaml
+++ b/apps/70-tools/netbox/overlays/prod/deployment-patch.yaml
@@ -9,7 +9,7 @@ spec:
         - name: netbox
           env:
             - name: ALLOWED_HOSTS
-              value: "netbox.truxonline.com,127.0.0.1,localhost"
+              value: "*"
           livenessProbe:
             httpGet:
               httpHeaders:


### PR DESCRIPTION
## Summary
Fix netbox HTTP 400 errors in prod by using wildcard ALLOWED_HOSTS

## Problem
- Netbox in prod returns 400 Bad Request when accessed via Traefik
- ALLOWED_HOSTS was set to specific hostnames but Traefik request headers don't match exactly

## Solution
- Use `ALLOWED_HOSTS="*"` (same as dev overlay)
- Ingress already filters by hostname, so wildcard is safe
- Traefik handles TLS termination and routing

## Testing
- ✅ Validated in dev: works perfectly with ALLOWED_HOSTS="*"
- ✅ Both HTTP redirect and HTTPS access functional
- ✅ Playwright browser tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)