### PR TITLE
fix(netvisor): configure daemon connectivity (DNS + secrets) - retry

### DIFF
--- a/apps/40-network/netvisor/base/daemon-daemonset.yaml
+++ b/apps/40-network/netvisor/base/daemon-daemonset.yaml
@@ -14,7 +14,7 @@ spec:
       labels:
         app: netvisor-daemon
     spec:
-      hostNetwork: true
+      hostNetwork: false
       tolerations:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
@@ -26,10 +26,20 @@ spec:
             privileged: true
           env:
             - name: SCANOPY_SERVER_TARGET
-              value: "netvisor-server.networking.svc.cluster.local"
+              value: "http://netvisor-server.networking.svc.cluster.local"
             - name: SCANOPY_SERVER_PORT
               value: "60072"
             - name: SCANOPY_DAEMON_PORT
               value: "60073"
-            - name: SCANOPY_CONCURRENT_SCANS
-              value: "10"
+            - name: SCANOPY_NETWORK_ID
+              valueFrom:
+                secretKeyRef:
+                  name: netvisor-secrets
+                  key: SCANOPY_NETWORK_ID
+            - name: SCANOPY_DAEMON_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: netvisor-secrets
+                  key: SCANOPY_DAEMON_API_KEY
+            - name: SCANOPY_MODE
+              value: "Pull"


### PR DESCRIPTION
## Summary
Retry promotion of netvisor daemon fixes to production (previous PR #356 was merged too early).

Configure netvisor daemon for proper connectivity with server:

- Add SCANOPY_NETWORK_ID and SCANOPY_DAEMON_API_KEY from Infisical
- Use http:// scheme for SCANOPY_SERVER_TARGET
- Disable hostNetwork to allow Kubernetes DNS resolution
- Add SCANOPY_MODE=Pull configuration

## Technical Details
- Daemon now uses `netvisor-server.networking.svc.cluster.local` (internal service)
- Secrets synced from Infisical `/apps/40-network/netvisor` path
- Fixed DNS resolution error by disabling hostNetwork

## Validation
- ✅ Changes validated in dev, test, staging
- ✅ Daemon pods running and attempting server registration
- 🔄 Awaiting onboarding completion for full functionality

## Related
- Commits: 8d1c420, 6d01cc6, a62bf56, 7595937, 668c739
- Previous PR: #356 (merged too early)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security configuration by incorporating credential management
  * Updated server connectivity parameters
  * Adjusted network and operational settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->