### PR TITLE
fix(argocd): alertmanager + hubble-ui final fixes

### DIFF
--- a/argocd/overlays/prod/apps/alertmanager.yaml
+++ b/argocd/overlays/prod/apps/alertmanager.yaml
@@ -21,9 +21,6 @@ spec:
     - repoURL: https://github.com/charchess/vixens.git
       targetRevision: main
       ref: values
-    - repoURL: https://github.com/charchess/vixens.git
-      targetRevision: main
-      path: apps/02-monitoring/alertmanager/overlays/prod
   destination:
     server: https://kubernetes.default.svc
     namespace: monitoring


### PR DESCRIPTION
Complete fixes for Unknown ArgoCD applications:

- **alertmanager**: Remove empty prod overlay source
- **hubble-ui**: Convert ingress-patch to actual patch (avoid ID conflict)

Part of fixing 4 Unknown apps in prod.