### PR TITLE
test: validate trunk-based workflow with whoami custom header

### DIFF
--- a/apps/99-test/whoami/overlays/dev/kustomization.yaml
+++ b/apps/99-test/whoami/overlays/dev/kustomization.yaml
@@ -3,3 +3,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - middleware.yaml
+
+patches:
+  - target:
+      kind: Ingress
+      name: whoami
+    patch: |-
+      - op: add
+        path: /metadata/annotations/traefik.ingress.kubernetes.io~1router.middlewares
+        value: whoami-whoami-custom-header@kubernetescrd

--- a/apps/99-test/whoami/overlays/dev/middleware.yaml
+++ b/apps/99-test/whoami/overlays/dev/middleware.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: whoami-custom-header
+  namespace: whoami
+spec:
+  headers:
+    customResponseHeaders:
+      X-Vixens-Version: "trunk-based-test"


### PR DESCRIPTION
## Objectif

Valider le workflow trunk-based complet avec une modification simple de l'application whoami.

## Changements

- ✅ Ajout d'un Middleware Traefik pour injecter l'en-tête HTTP personnalisé `X-Vixens-Version: trunk-based-test`
- ✅ Mise à jour du kustomization dev pour inclure le middleware
- ✅ Patch de l'Ingress pour référencer le middleware

## Workflow à Tester

1. ✅ Feature branch créée
2. ✅ Commit effectué
3. ✅ PR créée vers `dev`
4. ⏳ Merge PR → dev
5. ⏳ GitHub Action auto-tag `dev-vX.Y.Z`
6. ⏳ Validation déploiement dev
7. ⏳ Promotion prod: `gh workflow run promote-prod.yaml -f version=vX.Y.Z`
8. ⏳ Validation tags `prod-vX.Y.Z` et `prod-stable`
9. ⏳ Validation déploiement prod

## Vérification

Une fois déployé en dev:
```bash
curl -I https://whoami.dev.truxonline.com
# Doit inclure: X-Vixens-Version: trunk-based-test
```

Relates to task: Tester le workflow trunk-based avec whoami