### PR TITLE
feat(tools): activate Renovate bot in dev cluster

### DIFF
--- a/argocd/overlays/dev/kustomization.yaml
+++ b/argocd/overlays/dev/kustomization.yaml
@@ -76,7 +76,7 @@ resources:
   # - apps/netbox.yaml
   # - apps/loki.yaml
   # - apps/promtail.yaml
-  # - apps/renovate.yaml
+  - apps/renovate.yaml
   # - apps/stirling-pdf.yaml
   # - apps/stirling-pdf-ingress.yaml
   # - apps/it-tools.yaml


### PR DESCRIPTION
## Summary
Enable Renovate application in dev cluster to start automated dependency updates.

This completes the Renovate Discord workflow implementation deployed in PR #428.

## Changes
- Uncommented `apps/renovate.yaml` in `argocd/overlays/dev/kustomization.yaml`

## Next Steps
After merge and ArgoCD sync:
1. Verify Renovate CronJob is running: `kubectl get cronjob -n tools renovate`
2. Trigger manual run: `kubectl create job --from=cronjob/renovate renovate-test -n tools`
3. Monitor Discord for notification when first PR is created

## Test Plan
- [ ] ArgoCD syncs Renovate application
- [ ] CronJob is created in tools namespace
- [ ] Manual job execution succeeds
- [ ] Discord notification received on PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)