### PR TITLE
fix(media): increase PVC sizes

### DIFF
--- a/apps/00-infra/cert-manager-webhook-gandi/base/gandi-infisical-secret.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/base/gandi-infisical-secret.yaml
@@ -1,22 +1,22 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: gandi-credentials-sync
   namespace: cert-manager
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/00-infra/cert-manager-webhook-gandi
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/00-infra/cert-manager-webhook-gandi"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: gandi-credentials
-    secretNamespace: cert-manager
-    secretType: Opaque
-  resyncInterval: 60
+    creationPolicy: "Owner"
+    secretType: "Opaque"

--- a/apps/00-infra/cert-manager-webhook-gandi/overlays/prod/gandi-infisical-secret-patch.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/overlays/prod/gandi-infisical-secret-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,6 +8,4 @@ spec:
   authentication:
     universalAuth:
       secretsScope:
-        envSlug: prod
-  managedSecretReference:
-    secretNamespace: cert-manager
+        envSlug: prod  # Changed from 'dev' to 'prod'

--- a/apps/00-infra/cert-manager-webhook-gandi/overlays/staging/gandi-infisical-secret-patch.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/overlays/staging/gandi-infisical-secret-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,6 +8,4 @@ spec:
   authentication:
     universalAuth:
       secretsScope:
-        envSlug: staging
-  managedSecretReference:
-    secretNamespace: cert-manager
+        envSlug: staging  # Changed from 'dev' to 'staging'

--- a/apps/00-infra/cert-manager-webhook-gandi/overlays/test/gandi-infisical-secret-patch.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/overlays/test/gandi-infisical-secret-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,6 +8,4 @@ spec:
   authentication:
     universalAuth:
       secretsScope:
-        envSlug: test
-  managedSecretReference:
-    secretNamespace: cert-manager
+        envSlug: test  # Changed from 'dev' to 'test'

--- a/apps/01-storage/synology-csi/infisical/base/synology-infisical-secret.yaml
+++ b/apps/01-storage/synology-csi/infisical/base/synology-infisical-secret.yaml
@@ -1,22 +1,22 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: synology-csi-credentials-sync
   namespace: synology-csi
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/01-storage/synology-csi
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/01-storage/synology-csi"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: client-info-secret
-    secretNamespace: synology-csi
-    secretType: Opaque
-  resyncInterval: 60
+    creationPolicy: "Owner"
+    secretType: "Opaque"

--- a/apps/01-storage/synology-csi/infisical/overlays/prod/synology-infisical-secret-patch.yaml
+++ b/apps/01-storage/synology-csi/infisical/overlays/prod/synology-infisical-secret-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,6 +8,4 @@ spec:
   authentication:
     universalAuth:
       secretsScope:
-        envSlug: prod
-  managedSecretReference:
-    secretNamespace: synology-csi
+        envSlug: prod  # Changed from 'dev' to 'prod'

--- a/apps/01-storage/synology-csi/infisical/overlays/staging/synology-infisical-secret-patch.yaml
+++ b/apps/01-storage/synology-csi/infisical/overlays/staging/synology-infisical-secret-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,6 +8,4 @@ spec:
   authentication:
     universalAuth:
       secretsScope:
-        envSlug: staging
-  managedSecretReference:
-    secretNamespace: synology-csi
+        envSlug: staging  # Changed from 'dev' to 'staging'

--- a/apps/01-storage/synology-csi/infisical/overlays/test/synology-infisical-secret-patch.yaml
+++ b/apps/01-storage/synology-csi/infisical/overlays/test/synology-infisical-secret-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,6 +8,5 @@ spec:
   authentication:
     universalAuth:
       secretsScope:
-        envSlug: test
-  managedSecretReference:
-    secretNamespace: synology-csi
+        envSlug: test  # Changed from 'dev' to 'test'
+        # projectSlug inherited from base: "vixens"

--- a/apps/01-storage/synology-csi/overlays/prod/infisical-patch.yaml
+++ b/apps/01-storage/synology-csi/overlays/prod/infisical-patch.yaml
@@ -8,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: synology-csi

--- a/apps/02-monitoring/alertmanager/base/infisical-secret.yaml
+++ b/apps/02-monitoring/alertmanager/base/infisical-secret.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: alertmanager-secrets
   namespace: monitoring
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/02-monitoring/alertmanager
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev # Patched in overlays
+        secretsPath: "/apps/02-monitoring/alertmanager"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: alertmanager-secrets
-    secretNamespace: monitoring
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/02-monitoring/alertmanager/overlays/dev/patch-infisical-env.yaml
+++ b/apps/02-monitoring/alertmanager/overlays/dev/patch-infisical-env.yaml
@@ -8,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: dev
-  managedSecretReference:
-    secretNamespace: monitoring

--- a/apps/02-monitoring/alertmanager/overlays/prod/patch-infisical-env.yaml
+++ b/apps/02-monitoring/alertmanager/overlays/prod/patch-infisical-env.yaml
@@ -8,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: monitoring

--- a/apps/02-monitoring/goldilocks/base/infisical-secret.yaml
+++ b/apps/02-monitoring/goldilocks/base/infisical-secret.yaml
@@ -9,13 +9,12 @@ spec:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
+        envSlug: dev
         secretsPath: /apps/02-monitoring/goldilocks
   hostAPI: http://192.168.111.69:8085
   managedSecretReference:
     creationPolicy: Owner
     secretName: goldilocks-secrets
-    secretNamespace: monitoring
     secretType: Opaque
   resyncInterval: 60

--- a/apps/02-monitoring/grafana/base/infisical-secret.yaml
+++ b/apps/02-monitoring/grafana/base/infisical-secret.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: grafana-admin-sync
   namespace: monitoring
 spec:
+  hostAPI: http://192.168.111.69:8085
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
+        envSlug: dev
         secretsPath: /apps/02-monitoring/grafana
-  hostAPI: http://192.168.111.69:8085
   managedSecretReference:
-    creationPolicy: Owner
     secretName: grafana-admin
-    secretNamespace: monitoring
     secretType: Opaque
+    creationPolicy: Owner

--- a/apps/02-monitoring/grafana/overlays/dev/patch-infisical-env.yaml
+++ b/apps/02-monitoring/grafana/overlays/dev/patch-infisical-env.yaml
@@ -8,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: dev
-  managedSecretReference:
-    secretNamespace: monitoring

--- a/apps/02-monitoring/grafana/overlays/prod/patch-infisical-env.yaml
+++ b/apps/02-monitoring/grafana/overlays/prod/patch-infisical-env.yaml
@@ -8,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: monitoring

--- a/apps/02-monitoring/grafana/overlays/staging/patch-infisical-env.yaml
+++ b/apps/02-monitoring/grafana/overlays/staging/patch-infisical-env.yaml
@@ -8,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: staging
-  managedSecretReference:
-    secretNamespace: monitoring

--- a/apps/02-monitoring/grafana/overlays/test/patch-infisical-env.yaml
+++ b/apps/02-monitoring/grafana/overlays/test/patch-infisical-env.yaml
@@ -8,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: test
-  managedSecretReference:
-    secretNamespace: monitoring

--- a/apps/02-monitoring/hubble-ui/base/infisical-secret.yaml
+++ b/apps/02-monitoring/hubble-ui/base/infisical-secret.yaml
@@ -4,18 +4,17 @@ metadata:
   name: hubble-ui-secrets-sync
   namespace: monitoring
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/02-monitoring/hubble-ui
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/02-monitoring/hubble-ui"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: hubble-ui-secrets
-    secretNamespace: monitoring
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/02-monitoring/loki/base/infisical-secret.yaml
+++ b/apps/02-monitoring/loki/base/infisical-secret.yaml
@@ -3,18 +3,17 @@ kind: InfisicalSecret
 metadata:
   name: loki-secrets-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/02-monitoring/loki
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/02-monitoring/loki"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: loki-secrets
-    secretNamespace: monitoring
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/02-monitoring/loki/overlays/prod/infisical-patch.yaml
+++ b/apps/02-monitoring/loki/overlays/prod/infisical-patch.yaml
@@ -7,5 +7,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: monitoring

--- a/apps/02-monitoring/loki/overlays/staging/infisical-patch.yaml
+++ b/apps/02-monitoring/loki/overlays/staging/infisical-patch.yaml
@@ -7,5 +7,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: staging
-  managedSecretReference:
-    secretNamespace: monitoring

--- a/apps/02-monitoring/loki/overlays/test/infisical-patch.yaml
+++ b/apps/02-monitoring/loki/overlays/test/infisical-patch.yaml
@@ -7,5 +7,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: test
-  managedSecretReference:
-    secretNamespace: monitoring

--- a/apps/02-monitoring/prometheus/base/infisical-secret.yaml
+++ b/apps/02-monitoring/prometheus/base/infisical-secret.yaml
@@ -3,18 +3,17 @@ kind: InfisicalSecret
 metadata:
   name: prometheus-secrets-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/02-monitoring/prometheus
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/02-monitoring/prometheus"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: prometheus-secrets
-    secretNamespace: monitoring
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/02-monitoring/prometheus/overlays/prod/patch-infisical-env.yaml
+++ b/apps/02-monitoring/prometheus/overlays/prod/patch-infisical-env.yaml
@@ -8,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: monitoring

--- a/apps/02-monitoring/promtail/base/infisical-secret.yaml
+++ b/apps/02-monitoring/promtail/base/infisical-secret.yaml
@@ -3,18 +3,17 @@ kind: InfisicalSecret
 metadata:
   name: promtail-secrets-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/02-monitoring/promtail
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/02-monitoring/promtail"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: promtail-secrets
-    secretNamespace: monitoring
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/03-security/authentik/base/infisical-secret.yaml
+++ b/apps/03-security/authentik/base/infisical-secret.yaml
@@ -3,18 +3,17 @@ kind: InfisicalSecret
 metadata:
   name: authentik-secrets-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/03-security/authentik
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev # Patched in overlays
+        secretsPath: "/apps/03-security/authentik"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: authentik-secrets
-    secretNamespace: auth
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/03-security/authentik/base/litestream-secret.yaml
+++ b/apps/03-security/authentik/base/litestream-secret.yaml
@@ -3,18 +3,17 @@ kind: InfisicalSecret
 metadata:
   name: authentik-litestream-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/_shared/litestream
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev # Patched in overlays
+        secretsPath: "/apps/_shared/litestream"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: authentik-litestream-secret
-    secretNamespace: auth
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/03-security/authentik/overlays/prod/infisical-patch.yaml
+++ b/apps/03-security/authentik/overlays/prod/infisical-patch.yaml
@@ -7,5 +7,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: auth

--- a/apps/03-security/authentik/overlays/staging/infisical-patch.yaml
+++ b/apps/03-security/authentik/overlays/staging/infisical-patch.yaml
@@ -7,5 +7,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: staging
-  managedSecretReference:
-    secretNamespace: auth

--- a/apps/03-security/authentik/overlays/test/infisical-patch.yaml
+++ b/apps/03-security/authentik/overlays/test/infisical-patch.yaml
@@ -7,5 +7,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: test
-  managedSecretReference:
-    secretNamespace: auth

--- a/apps/04-databases/mariadb-shared/base/infisical-secret.yaml
+++ b/apps/04-databases/mariadb-shared/base/infisical-secret.yaml
@@ -4,17 +4,16 @@ metadata:
   name: mariadb-shared-credentials
   namespace: databases
 spec:
+  hostAPI: http://192.168.111.69:8085
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/04-databases/mariadb-shared
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/04-databases/mariadb-shared"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: mariadb-shared-credentials
-    secretNamespace: databases
+    creationPolicy: Owner

--- a/apps/04-databases/mariadb-shared/overlays/prod/patch-infisical-env.yaml
+++ b/apps/04-databases/mariadb-shared/overlays/prod/patch-infisical-env.yaml
@@ -8,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: databases

--- a/apps/04-databases/postgresql-shared/base/credentials/admin-secret.yaml
+++ b/apps/04-databases/postgresql-shared/base/credentials/admin-secret.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: postgresql-admin-credentials
   namespace: databases
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/04-databases/postgresql-shared/admin
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/04-databases/postgresql-shared/admin"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: postgresql-admin-credentials
-    secretNamespace: databases
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/04-databases/postgresql-shared/base/credentials/authentik-secret.yaml
+++ b/apps/04-databases/postgresql-shared/base/credentials/authentik-secret.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: authentik-postgresql-credentials
   namespace: databases
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/03-security/authentik
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/03-security/authentik"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: authentik-postgresql-credentials
-    secretNamespace: databases
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/04-databases/postgresql-shared/base/credentials/backup-s3-secret.yaml
+++ b/apps/04-databases/postgresql-shared/base/credentials/backup-s3-secret.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: postgresql-backup-s3
   namespace: databases
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/04-databases/postgresql-shared
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/04-databases/postgresql-shared"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: postgresql-backup-s3
-    secretNamespace: databases
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/04-databases/postgresql-shared/base/credentials/docspell-secret.yaml
+++ b/apps/04-databases/postgresql-shared/base/credentials/docspell-secret.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: docspell-postgresql-credentials
   namespace: databases
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/60-services/docspell
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/60-services/docspell"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: docspell-postgresql-credentials
-    secretNamespace: databases
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/04-databases/postgresql-shared/base/credentials/linkwarden-secret.yaml
+++ b/apps/04-databases/postgresql-shared/base/credentials/linkwarden-secret.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: linkwarden-postgresql-credentials
   namespace: databases
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/70-tools/linkwarden
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/70-tools/linkwarden"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: linkwarden-postgresql-credentials
-    secretNamespace: databases
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/04-databases/postgresql-shared/base/credentials/netbox-postgresql-credentials.yaml
+++ b/apps/04-databases/postgresql-shared/base/credentials/netbox-postgresql-credentials.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: netbox-postgresql-credentials
-  namespace: databases
+  namespace: databases # This secret will be in the 'databases' namespace
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/70-tools/netbox
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/70-tools/netbox" # New path for Netbox PostgreSQL credentials in Infisical
   managedSecretReference:
-    creationPolicy: Owner
     secretName: netbox-postgresql-credentials
-    secretNamespace: databases
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/04-databases/postgresql-shared/base/credentials/nocodb-secret.yaml
+++ b/apps/04-databases/postgresql-shared/base/credentials/nocodb-secret.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: nocodb-postgresql-credentials
   namespace: databases
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/70-tools/nocodb
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/70-tools/nocodb"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: nocodb-postgresql-credentials
-    secretNamespace: databases
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/04-databases/postgresql-shared/base/credentials/scanopy-secret.yaml
+++ b/apps/04-databases/postgresql-shared/base/credentials/scanopy-secret.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: scanopy-postgresql-credentials
   namespace: databases
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/40-network/netvisor
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/40-network/netvisor"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: scanopy-postgresql-credentials
-    secretNamespace: databases
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/04-databases/postgresql-shared/base/credentials/vaultwarden-secret.yaml
+++ b/apps/04-databases/postgresql-shared/base/credentials/vaultwarden-secret.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: vaultwarden-postgresql-credentials
   namespace: databases
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/60-services/vaultwarden
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/60-services/vaultwarden"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: vaultwarden-postgresql-credentials
-    secretNamespace: databases
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/04-databases/postgresql-shared/overlays/prod/patch-credentials-env.yaml
+++ b/apps/04-databases/postgresql-shared/overlays/prod/patch-credentials-env.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -8,8 +9,6 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: databases
 ---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
@@ -21,8 +20,6 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: databases
 ---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
@@ -34,8 +31,6 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: databases
 ---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
@@ -47,8 +42,6 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: databases
 ---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
@@ -60,8 +53,6 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: databases
 ---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
@@ -73,8 +64,6 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: databases
 ---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
@@ -86,5 +75,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: databases

--- a/apps/04-databases/postgresql-shared/overlays/staging/patch-credentials-env.yaml
+++ b/apps/04-databases/postgresql-shared/overlays/staging/patch-credentials-env.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -8,8 +9,6 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: staging
-  managedSecretReference:
-    secretNamespace: databases
 ---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
@@ -21,8 +20,6 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: staging
-  managedSecretReference:
-    secretNamespace: databases
 ---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
@@ -34,8 +31,6 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: staging
-  managedSecretReference:
-    secretNamespace: databases
 ---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
@@ -47,8 +42,6 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: staging
-  managedSecretReference:
-    secretNamespace: databases
 ---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
@@ -60,8 +53,6 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: staging
-  managedSecretReference:
-    secretNamespace: databases
 ---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
@@ -73,5 +64,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: staging
-  managedSecretReference:
-    secretNamespace: databases

--- a/apps/04-databases/postgresql-shared/overlays/test/patch-credentials-env.yaml
+++ b/apps/04-databases/postgresql-shared/overlays/test/patch-credentials-env.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -8,8 +9,6 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: test
-  managedSecretReference:
-    secretNamespace: databases
 ---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
@@ -21,8 +20,6 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: test
-  managedSecretReference:
-    secretNamespace: databases
 ---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
@@ -34,8 +31,6 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: test
-  managedSecretReference:
-    secretNamespace: databases
 ---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
@@ -47,8 +42,6 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: test
-  managedSecretReference:
-    secretNamespace: databases
 ---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
@@ -60,8 +53,6 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: test
-  managedSecretReference:
-    secretNamespace: databases
 ---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
@@ -73,5 +64,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: test
-  managedSecretReference:
-    secretNamespace: databases

--- a/apps/04-databases/redis-shared/base/redis-credentials.yaml
+++ b/apps/04-databases/redis-shared/base/redis-credentials.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: redis-shared-credentials
-  namespace: databases
+  namespace: databases # Assuming the shared Redis will be in the 'databases' namespace
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/04-databases/redis-shared
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/04-databases/redis-shared"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: redis-shared-credentials
-    secretNamespace: databases
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/04-databases/redis-shared/overlays/prod/kustomization.yaml
+++ b/apps/04-databases/redis-shared/overlays/prod/kustomization.yaml
@@ -8,11 +8,6 @@ resources:
 
 patches:
   - path: patch-infisical-env.yaml
-    target:
-      group: secrets.infisical.com
-      version: v1alpha1
-      kind: InfisicalSecret
-      name: redis-shared-credentials
 
 labels:
   - pairs:

--- a/apps/04-databases/redis-shared/overlays/prod/patch-infisical-env.yaml
+++ b/apps/04-databases/redis-shared/overlays/prod/patch-infisical-env.yaml
@@ -2,10 +2,9 @@ apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: redis-shared-credentials
+  namespace: databases
 spec:
   authentication:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: databases

--- a/apps/10-home/homeassistant/base/infisical-config.yaml
+++ b/apps/10-home/homeassistant/base/infisical-config.yaml
@@ -1,22 +1,22 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: homeassistant-config-sync
   namespace: homeassistant
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
+        envSlug: dev
         secretsPath: /apps/10-home/homeassistant
-  hostAPI: http://192.168.111.69:8085
   managedSecretReference:
-    creationPolicy: Owner
     secretName: homeassistant-config
-    secretNamespace: homeassistant
+    creationPolicy: Owner
     secretType: Opaque
-  resyncInterval: 60

--- a/apps/10-home/homeassistant/base/litestream-secret.yaml
+++ b/apps/10-home/homeassistant/base/litestream-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: homeassistant-litestream-secret
 spec:
+  hostAPI: http://192.168.111.69:8085
+  managedSecretReference:
+    secretName: homeassistant-litestream-secret
+    creationPolicy: "Owner"
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /shared/litestream
-  hostAPI: http://192.168.111.69:8085
-  managedSecretReference:
-    creationPolicy: Owner
-    secretName: homeassistant-litestream-secret
-    secretNamespace: homeassistant
+        envSlug: dev
+        secretsPath: "/shared/litestream"
   resyncInterval: 60

--- a/apps/10-home/homeassistant/overlays/dev/infisical-filebrowser-auth.yaml
+++ b/apps/10-home/homeassistant/overlays/dev/infisical-filebrowser-auth.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -10,13 +11,12 @@ spec:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
+        envSlug: dev
         secretsPath: /apps/10-home/homeassistant
   hostAPI: http://192.168.111.69:8085
   managedSecretReference:
-    creationPolicy: Owner
     secretName: filebrowser-auth
-    secretNamespace: homeassistant
+    creationPolicy: Owner
     secretType: Opaque
   resyncInterval: 60

--- a/apps/10-home/homeassistant/overlays/prod/infisical-config-patch.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/infisical-config-patch.yaml
@@ -8,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: homeassistant

--- a/apps/10-home/homeassistant/overlays/prod/infisical-filebrowser-auth.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/infisical-filebrowser-auth.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: filebrowser-auth
   namespace: homeassistant
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: prod
         projectSlug: vixens
+        envSlug: prod
         secretsPath: /apps/10-home/homeassistant
-  hostAPI: http://192.168.111.69:8085
   managedSecretReference:
-    creationPolicy: Owner
     secretName: filebrowser-auth
-    secretNamespace: homeassistant
-  resyncInterval: 60
+    creationPolicy: Owner

--- a/apps/10-home/homeassistant/overlays/prod/litestream-secret-patch.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/litestream-secret-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: homeassistant

--- a/apps/10-home/homeassistant/overlays/staging/infisical-filebrowser-auth.yaml
+++ b/apps/10-home/homeassistant/overlays/staging/infisical-filebrowser-auth.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: filebrowser-auth
   namespace: homeassistant
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: staging
         projectSlug: vixens
+        envSlug: staging
         secretsPath: /apps/10-home/homeassistant
-  hostAPI: http://192.168.111.69:8085
   managedSecretReference:
-    creationPolicy: Owner
     secretName: filebrowser-auth
-    secretNamespace: homeassistant
-  resyncInterval: 60
+    creationPolicy: Owner

--- a/apps/10-home/homeassistant/overlays/test/infisical-filebrowser-auth.yaml
+++ b/apps/10-home/homeassistant/overlays/test/infisical-filebrowser-auth.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -10,13 +11,12 @@ spec:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
+        envSlug: dev
         secretsPath: /apps/10-home/homeassistant
   hostAPI: http://192.168.111.69:8085
   managedSecretReference:
-    creationPolicy: Owner
     secretName: filebrowser-auth
-    secretNamespace: homeassistant
+    creationPolicy: Owner
     secretType: Opaque
   resyncInterval: 60

--- a/apps/10-home/mealie/base/infisical-secret.yaml
+++ b/apps/10-home/mealie/base/infisical-secret.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: mealie-secrets-sync
   namespace: mealie
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
+  managedSecretReference:
+    secretName: mealie-secrets
+    creationPolicy: "Owner"
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/10-home/mealie
-  hostAPI: http://192.168.111.69:8085
-  managedSecretReference:
-    creationPolicy: Owner
-    secretName: mealie-secrets
-    secretNamespace: mealie
-  resyncInterval: 60
+        envSlug: dev
+        secretsPath: "/apps/10-home/mealie"

--- a/apps/10-home/mosquitto/overlays/dev/infisical-mosquitto-auth.yaml
+++ b/apps/10-home/mosquitto/overlays/dev/infisical-mosquitto-auth.yaml
@@ -10,13 +10,12 @@ spec:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
+        envSlug: dev
         secretsPath: /apps/10-home/mosquitto
-  hostAPI: http://192.168.111.69:8085
+  hostAPI: http://192.168.111.69:8085 # Assuming dev uses the same Infisical server endpoint
   managedSecretReference:
-    creationPolicy: Owner
     secretName: mosquitto-password-file
-    secretNamespace: mosquitto
+    creationPolicy: Owner
     secretType: Opaque
   resyncInterval: 60

--- a/apps/10-home/mosquitto/overlays/prod/infisical-mosquitto-auth.yaml
+++ b/apps/10-home/mosquitto/overlays/prod/infisical-mosquitto-auth.yaml
@@ -1,22 +1,22 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: mosquitto-password-sync
   namespace: mosquitto
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: prod
         projectSlug: vixens
+        envSlug: prod
         secretsPath: /apps/10-home/mosquitto
-  hostAPI: http://192.168.111.69:8085
   managedSecretReference:
-    creationPolicy: Owner
     secretName: mosquitto-password-file
-    secretNamespace: mosquitto
+    creationPolicy: Owner
     secretType: Opaque
-  resyncInterval: 60

--- a/apps/10-home/mosquitto/overlays/staging/infisical-mosquitto-auth.yaml
+++ b/apps/10-home/mosquitto/overlays/staging/infisical-mosquitto-auth.yaml
@@ -1,22 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: mosquitto-password-sync
   namespace: mosquitto
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
-    creationPolicy: Owner
-    secretName: mosquitto-password-file
-    secretType: Opaque
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: staging
         projectSlug: vixens
+        envSlug: staging
         secretsPath: /apps/10-home/mosquitto
-  hostAPI: http://192.168.111.69:8085
-  managedSecretReference:
-    secretNamespace: mosquitto
-  resyncInterval: 60
+    secretName: mosquitto-password-file
+    creationPolicy: Owner
+    secretType: Opaque

--- a/apps/10-home/mosquitto/overlays/test/infisical-mosquitto-auth.yaml
+++ b/apps/10-home/mosquitto/overlays/test/infisical-mosquitto-auth.yaml
@@ -1,22 +1,22 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: mosquitto-password-sync
   namespace: mosquitto
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: test
         projectSlug: vixens
+        envSlug: test
         secretsPath: /apps/10-home/mosquitto
-  hostAPI: http://192.168.111.69:8085
   managedSecretReference:
-    creationPolicy: Owner
     secretName: mosquitto-password-file
-    secretNamespace: mosquitto
+    creationPolicy: Owner
     secretType: Opaque
-  resyncInterval: 60

--- a/apps/20-media/amule/base/infisical-secret.yaml
+++ b/apps/20-media/amule/base/infisical-secret.yaml
@@ -18,5 +18,4 @@ spec:
         secretsPath: "/apps/20-media/amule"
   managedSecretReference:
     secretName: amule-secrets
-    secretNamespace: downloads
     creationPolicy: "Owner"

--- a/apps/20-media/amule/overlays/dev/patch-infisical-env.yaml
+++ b/apps/20-media/amule/overlays/dev/patch-infisical-env.yaml
@@ -7,5 +7,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: dev
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/amule/overlays/prod/patch-infisical-env.yaml
+++ b/apps/20-media/amule/overlays/prod/patch-infisical-env.yaml
@@ -7,6 +7,4 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-        secretsPath: /apps/20-media/amule
-  managedSecretReference:
-    secretNamespace: media
+        secretsPath: "/apps/20-media/amule"

--- a/apps/20-media/booklore/base/infisical-secret.yaml
+++ b/apps/20-media/booklore/base/infisical-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: booklore-secrets-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/20-media/booklore
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/20-media/booklore"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: booklore-secrets
-    secretNamespace: media
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/20-media/frigate/base/infisical-config.yaml
+++ b/apps/20-media/frigate/base/infisical-config.yaml
@@ -4,18 +4,17 @@ metadata:
   name: frigate-config-sync
   namespace: media
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/20-media/frigate/config
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/20-media/frigate/config"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: frigate-config-secret
-    secretNamespace: media
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/20-media/frigate/base/infisical-secret.yaml
+++ b/apps/20-media/frigate/base/infisical-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: frigate-secrets-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/20-media/frigate
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/20-media/frigate"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: frigate-secrets
-    secretNamespace: media
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/20-media/frigate/base/litestream-secret.yaml
+++ b/apps/20-media/frigate/base/litestream-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: frigate-litestream-secret
 spec:
+  hostAPI: http://192.168.111.69:8085
+  managedSecretReference:
+    secretName: frigate-litestream-secret
+    creationPolicy: "Owner"
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /shared/litestream
-  hostAPI: http://192.168.111.69:8085
-  managedSecretReference:
-    creationPolicy: Owner
-    secretName: frigate-litestream-secret
-    secretNamespace: media
+        envSlug: dev
+        secretsPath: "/shared/litestream"
   resyncInterval: 60

--- a/apps/20-media/frigate/base/pvc.yaml
+++ b/apps/20-media/frigate/base/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   storageClassName: synelia-iscsi-retain
   resources:
     requests:
-      storage: 5Gi
+      storage: 2Gi

--- a/apps/20-media/frigate/overlays/prod/infisical-config-patch.yaml
+++ b/apps/20-media/frigate/overlays/prod/infisical-config-patch.yaml
@@ -7,5 +7,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/frigate/overlays/prod/litestream-secret-patch.yaml
+++ b/apps/20-media/frigate/overlays/prod/litestream-secret-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/frigate/overlays/staging/infisical-config-patch.yaml
+++ b/apps/20-media/frigate/overlays/staging/infisical-config-patch.yaml
@@ -7,5 +7,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: staging
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/frigate/overlays/test/infisical-config-patch.yaml
+++ b/apps/20-media/frigate/overlays/test/infisical-config-patch.yaml
@@ -7,5 +7,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: test
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/hydrus-client/base/infisical-secret.yaml
+++ b/apps/20-media/hydrus-client/base/infisical-secret.yaml
@@ -1,19 +1,19 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: hydrus-client-secrets-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  managedSecretReference:
+    secretName: hydrus-client-secrets
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/20-media/hydrus-client
-  hostAPI: http://192.168.111.69:8085
-  managedSecretReference:
-    secretName: hydrus-client-secrets
-    secretNamespace: media
+        envSlug: dev
+        secretsPath: "/apps/20-media/hydrus-client"
   resyncInterval: 60

--- a/apps/20-media/hydrus-client/base/litestream-secret.yaml
+++ b/apps/20-media/hydrus-client/base/litestream-secret.yaml
@@ -1,19 +1,19 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: litestream-shared-secrets
 spec:
+  hostAPI: http://192.168.111.69:8085
+  managedSecretReference:
+    secretName: litestream-shared-secrets
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /shared/litestream
-  hostAPI: http://192.168.111.69:8085
-  managedSecretReference:
-    secretName: litestream-shared-secrets
-    secretNamespace: media
+        envSlug: dev  # Patched in overlays
+        secretsPath: "/shared/litestream"
   resyncInterval: 60

--- a/apps/20-media/hydrus-client/base/pvc.yaml
+++ b/apps/20-media/hydrus-client/base/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   storageClassName: synelia-iscsi-retain
   resources:
     requests:
-      storage: 20Gi
+      storage: 5Gi

--- a/apps/20-media/hydrus-client/overlays/prod/infisical-shared-patch.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/infisical-shared-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/lazylibrarian/base/infisical-secret.yaml
+++ b/apps/20-media/lazylibrarian/base/infisical-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: lazylibrarian-secrets-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/20-media/lazylibrarian
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/20-media/lazylibrarian"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: lazylibrarian-secrets
-    secretNamespace: media
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/20-media/lidarr/base/deployment.yaml
+++ b/apps/20-media/lidarr/base/deployment.yaml
@@ -20,8 +20,6 @@ spec:
         reloader.stakater.com/auto: "true"
     spec:
       priorityClassName: vixens-medium
-      securityContext:
-        fsGroup: 1000
       tolerations:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"

--- a/apps/20-media/lidarr/base/infisical-secret.yaml
+++ b/apps/20-media/lidarr/base/infisical-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: lidarr-secrets-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/20-media/lidarr
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/20-media/lidarr"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: lidarr-secrets
-    secretNamespace: media
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/20-media/lidarr/base/litestream-secret.yaml
+++ b/apps/20-media/lidarr/base/litestream-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: lidarr-litestream-secret
 spec:
+  hostAPI: http://192.168.111.69:8085
+  managedSecretReference:
+    secretName: lidarr-litestream-secret
+    creationPolicy: "Owner"
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /shared/litestream
-  hostAPI: http://192.168.111.69:8085
-  managedSecretReference:
-    creationPolicy: Owner
-    secretName: lidarr-litestream-secret
-    secretNamespace: media
+        envSlug: dev
+        secretsPath: "/shared/litestream"
   resyncInterval: 60

--- a/apps/20-media/lidarr/overlays/prod/litestream-secret-patch.yaml
+++ b/apps/20-media/lidarr/overlays/prod/litestream-secret-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/mylar/base/deployment.yaml
+++ b/apps/20-media/mylar/base/deployment.yaml
@@ -21,9 +21,11 @@ spec:
     spec:
       priorityClassName: vixens-medium
       securityContext:
-        fsGroup: 1000
+        fsGroup: 0
       tolerations:
         - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
       initContainers:
         - name: restore-config
           image: rclone/rclone:1.65

--- a/apps/20-media/mylar/base/infisical-secret.yaml
+++ b/apps/20-media/mylar/base/infisical-secret.yaml
@@ -1,19 +1,19 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: mylar-secrets-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  managedSecretReference:
+    secretName: mylar-secrets
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/20-media/mylar
-  hostAPI: http://192.168.111.69:8085
-  managedSecretReference:
-    secretName: mylar-secrets
-    secretNamespace: media
+        envSlug: dev
+        secretsPath: "/apps/20-media/mylar"
   resyncInterval: 60

--- a/apps/20-media/mylar/base/litestream-secret.yaml
+++ b/apps/20-media/mylar/base/litestream-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: mylar-litestream-secret
 spec:
+  hostAPI: http://192.168.111.69:8085
+  managedSecretReference:
+    secretName: mylar-litestream-secret
+    creationPolicy: "Owner"
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /shared/litestream
-  hostAPI: http://192.168.111.69:8085
-  managedSecretReference:
-    creationPolicy: Owner
-    secretName: mylar-litestream-secret
-    secretNamespace: media
+        envSlug: dev
+        secretsPath: "/shared/litestream"
   resyncInterval: 60

--- a/apps/20-media/mylar/overlays/prod/litestream-secret-patch.yaml
+++ b/apps/20-media/mylar/overlays/prod/litestream-secret-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/prowlarr/base/deployment.yaml
+++ b/apps/20-media/prowlarr/base/deployment.yaml
@@ -20,8 +20,6 @@ spec:
         reloader.stakater.com/auto: "true"
     spec:
       priorityClassName: vixens-medium
-      securityContext:
-        fsGroup: 1000
       tolerations:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"

--- a/apps/20-media/prowlarr/base/infisical-secret.yaml
+++ b/apps/20-media/prowlarr/base/infisical-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: prowlarr-secrets-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/20-media/prowlarr
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/20-media/prowlarr"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: prowlarr-secrets
-    secretNamespace: media
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/20-media/prowlarr/base/litestream-secret.yaml
+++ b/apps/20-media/prowlarr/base/litestream-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: prowlarr-litestream-secret
 spec:
+  hostAPI: http://192.168.111.69:8085
+  managedSecretReference:
+    secretName: prowlarr-litestream-secret
+    creationPolicy: "Owner"
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /shared/litestream
-  hostAPI: http://192.168.111.69:8085
-  managedSecretReference:
-    creationPolicy: Owner
-    secretName: prowlarr-litestream-secret
-    secretNamespace: media
+        envSlug: dev
+        secretsPath: "/shared/litestream"
   resyncInterval: 60

--- a/apps/20-media/prowlarr/overlays/prod/litestream-secret-patch.yaml
+++ b/apps/20-media/prowlarr/overlays/prod/litestream-secret-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/pyload/base/infisical-secret.yaml
+++ b/apps/20-media/pyload/base/infisical-secret.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: pyload-secrets
   namespace: downloads
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/20-media/pyload
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev # Patched in overlays
+        secretsPath: "/apps/20-media/pyload"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: pyload-secrets
-    secretNamespace: downloads
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/20-media/pyload/overlays/dev/patch-infisical-env.yaml
+++ b/apps/20-media/pyload/overlays/dev/patch-infisical-env.yaml
@@ -7,5 +7,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: dev
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/pyload/overlays/prod/patch-infisical-env.yaml
+++ b/apps/20-media/pyload/overlays/prod/patch-infisical-env.yaml
@@ -7,6 +7,4 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-        secretsPath: /apps/20-media/pyload
-  managedSecretReference:
-    secretNamespace: media
+        secretsPath: "/apps/20-media/pyload"

--- a/apps/20-media/qbittorrent/base/infisical-secret.yaml
+++ b/apps/20-media/qbittorrent/base/infisical-secret.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: qbittorrent-secrets
   namespace: downloads
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/20-media/qbittorrent
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev # Patched in overlays
+        secretsPath: "/apps/20-media/qbittorrent"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: qbittorrent-secrets
-    secretNamespace: downloads
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/20-media/qbittorrent/overlays/dev/patch-infisical-env.yaml
+++ b/apps/20-media/qbittorrent/overlays/dev/patch-infisical-env.yaml
@@ -7,5 +7,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: dev
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/qbittorrent/overlays/prod/patch-infisical-env.yaml
+++ b/apps/20-media/qbittorrent/overlays/prod/patch-infisical-env.yaml
@@ -7,6 +7,4 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-        secretsPath: /apps/20-media/qbittorrent
-  managedSecretReference:
-    secretNamespace: media
+        secretsPath: "/apps/20-media/qbittorrent"

--- a/apps/20-media/radarr/base/deployment.yaml
+++ b/apps/20-media/radarr/base/deployment.yaml
@@ -20,8 +20,6 @@ spec:
         reloader.stakater.com/auto: "true"
     spec:
       priorityClassName: vixens-medium
-      securityContext:
-        fsGroup: 1000
       tolerations:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"

--- a/apps/20-media/radarr/base/infisical-secret.yaml
+++ b/apps/20-media/radarr/base/infisical-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: radarr-secrets-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/20-media/radarr
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/20-media/radarr"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: radarr-secrets
-    secretNamespace: media
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/20-media/radarr/base/litestream-secret.yaml
+++ b/apps/20-media/radarr/base/litestream-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: radarr-litestream-secret
 spec:
+  hostAPI: http://192.168.111.69:8085
+  managedSecretReference:
+    secretName: radarr-litestream-secret
+    creationPolicy: "Owner"
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /shared/litestream
-  hostAPI: http://192.168.111.69:8085
-  managedSecretReference:
-    creationPolicy: Owner
-    secretName: radarr-litestream-secret
-    secretNamespace: media
+        envSlug: dev
+        secretsPath: "/shared/litestream"
   resyncInterval: 60

--- a/apps/20-media/radarr/overlays/prod/litestream-secret-patch.yaml
+++ b/apps/20-media/radarr/overlays/prod/litestream-secret-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -17,11 +17,11 @@ spec:
       labels:
         app: sabnzbd
     spec:
-      priorityClassName: vixens-medium
-      securityContext:
-        fsGroup: 1000
+      priorityClassName: vixens-low
       tolerations:
         - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
       initContainers:
         - name: restore-config
           image: rclone/rclone:1.65

--- a/apps/20-media/sabnzbd/base/infisical-secret.yaml
+++ b/apps/20-media/sabnzbd/base/infisical-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: sabnzbd-secrets-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/20-media/sabnzbd
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev # Patched in overlays
+        secretsPath: "/apps/20-media/sabnzbd"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: sabnzbd-secrets
-    secretNamespace: media
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/20-media/sabnzbd/base/litestream-secret.yaml
+++ b/apps/20-media/sabnzbd/base/litestream-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: sabnzbd-litestream-secret
 spec:
+  hostAPI: http://192.168.111.69:8085
+  managedSecretReference:
+    secretName: sabnzbd-litestream-secret
+    creationPolicy: "Owner"
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /shared/litestream
-  hostAPI: http://192.168.111.69:8085
-  managedSecretReference:
-    creationPolicy: Owner
-    secretName: sabnzbd-litestream-secret
-    secretNamespace: media
+        envSlug: dev # Patched in overlays
+        secretsPath: "/shared/litestream"
   resyncInterval: 60

--- a/apps/20-media/sabnzbd/overlays/prod/infisical-patch.yaml
+++ b/apps/20-media/sabnzbd/overlays/prod/infisical-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/sabnzbd/overlays/prod/litestream-secret-patch.yaml
+++ b/apps/20-media/sabnzbd/overlays/prod/litestream-secret-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/sabnzbd/overlays/staging/infisical-patch.yaml
+++ b/apps/20-media/sabnzbd/overlays/staging/infisical-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: staging
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/sabnzbd/overlays/test/infisical-patch.yaml
+++ b/apps/20-media/sabnzbd/overlays/test/infisical-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: test
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/sonarr/base/infisical-secret.yaml
+++ b/apps/20-media/sonarr/base/infisical-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: sonarr-secrets-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/20-media/sonarr
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/20-media/sonarr"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: sonarr-secrets
-    secretNamespace: media
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/20-media/sonarr/base/litestream-secret.yaml
+++ b/apps/20-media/sonarr/base/litestream-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: sonarr-litestream-secret
 spec:
+  hostAPI: http://192.168.111.69:8085
+  managedSecretReference:
+    secretName: sonarr-litestream-secret
+    creationPolicy: "Owner"
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /shared/litestream
-  hostAPI: http://192.168.111.69:8085
-  managedSecretReference:
-    creationPolicy: Owner
-    secretName: sonarr-litestream-secret
-    secretNamespace: media
+        envSlug: dev
+        secretsPath: "/shared/litestream"
   resyncInterval: 60

--- a/apps/20-media/sonarr/overlays/prod/litestream-secret-patch.yaml
+++ b/apps/20-media/sonarr/overlays/prod/litestream-secret-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/whisparr/base/deployment.yaml
+++ b/apps/20-media/whisparr/base/deployment.yaml
@@ -20,8 +20,6 @@ spec:
         reloader.stakater.com/auto: "true"
     spec:
       priorityClassName: vixens-medium
-      securityContext:
-        fsGroup: 1000
       tolerations:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"

--- a/apps/20-media/whisparr/base/infisical-secret.yaml
+++ b/apps/20-media/whisparr/base/infisical-secret.yaml
@@ -1,19 +1,19 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: whisparr-secrets-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  managedSecretReference:
+    secretName: whisparr-secrets
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/20-media/whisparr
-  hostAPI: http://192.168.111.69:8085
-  managedSecretReference:
-    secretName: whisparr-secrets
-    secretNamespace: media
+        envSlug: dev
+        secretsPath: "/apps/20-media/whisparr"
   resyncInterval: 60

--- a/apps/20-media/whisparr/base/litestream-secret.yaml
+++ b/apps/20-media/whisparr/base/litestream-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: whisparr-litestream-secret
 spec:
+  hostAPI: http://192.168.111.69:8085
+  managedSecretReference:
+    secretName: whisparr-litestream-secret
+    creationPolicy: "Owner"
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /shared/litestream
-  hostAPI: http://192.168.111.69:8085
-  managedSecretReference:
-    creationPolicy: Owner
-    secretName: whisparr-litestream-secret
-    secretNamespace: media
+        envSlug: dev
+        secretsPath: "/shared/litestream"
   resyncInterval: 60

--- a/apps/20-media/whisparr/overlays/prod/litestream-secret-patch.yaml
+++ b/apps/20-media/whisparr/overlays/prod/litestream-secret-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/40-network/adguard-home/base/infisical-secret.yaml
+++ b/apps/40-network/adguard-home/base/infisical-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: adguard-home-secrets-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/40-network/adguard-home
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/40-network/adguard-home"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: adguard-home-secrets
-    secretNamespace: networking
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/40-network/adguard-home/base/litestream-secret.yaml
+++ b/apps/40-network/adguard-home/base/litestream-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: adguard-litestream-secret
 spec:
+  hostAPI: http://192.168.111.69:8085
+  managedSecretReference:
+    secretName: adguard-litestream-secret
+    creationPolicy: "Owner"
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /shared/litestream
-  hostAPI: http://192.168.111.69:8085
-  managedSecretReference:
-    creationPolicy: Owner
-    secretName: adguard-litestream-secret
-    secretNamespace: networking
+        envSlug: dev
+        secretsPath: "/shared/litestream"
   resyncInterval: 60

--- a/apps/40-network/adguard-home/overlays/prod/litestream-secret-patch.yaml
+++ b/apps/40-network/adguard-home/overlays/prod/litestream-secret-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: networking

--- a/apps/40-network/external-dns-gandi/base/infisical-secret.yaml
+++ b/apps/40-network/external-dns-gandi/base/infisical-secret.yaml
@@ -4,17 +4,16 @@ metadata:
   name: external-dns-gandi-sync
   namespace: networking
 spec:
+  hostAPI: http://192.168.111.69:8085
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: prod
         projectSlug: vixens
+        envSlug: prod
         secretsPath: /apps/40-network/external-dns/gandi
-  hostAPI: http://192.168.111.69:8085
   managedSecretReference:
-    creationPolicy: Owner
     secretName: external-dns-gandi-secret
-    secretNamespace: networking
+    creationPolicy: Owner

--- a/apps/40-network/external-dns-unifi/base/infisical-secret.yaml
+++ b/apps/40-network/external-dns-unifi/base/infisical-secret.yaml
@@ -4,17 +4,16 @@ metadata:
   name: external-dns-unifi-sync
   namespace: networking
 spec:
+  hostAPI: http://192.168.111.69:8085
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: prod
         projectSlug: vixens
+        envSlug: prod
         secretsPath: /apps/40-network/external-dns/unifi
-  hostAPI: http://192.168.111.69:8085
   managedSecretReference:
-    creationPolicy: Owner
     secretName: external-dns-unifi-secret
-    secretNamespace: networking
+    creationPolicy: Owner

--- a/apps/40-network/netvisor/base/infisical-secret.yaml
+++ b/apps/40-network/netvisor/base/infisical-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: netvisor-secrets-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/40-network/netvisor
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/40-network/netvisor"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: netvisor-secrets
-    secretNamespace: networking
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/60-services/docspell-native/base/infisical-secrets.yaml
+++ b/apps/60-services/docspell-native/base/infisical-secrets.yaml
@@ -1,45 +1,44 @@
-apiVersion: secrets.infisical.com/v1alpha1
-kind: InfisicalSecret
-metadata:
-  labels:
-    app: docspell
-  name: docspell-db-credentials-sync
-spec:
-  authentication:
-    universalAuth:
-      credentialsRef:
-        secretName: infisical-universal-auth
-        secretNamespace: argocd
-      secretsScope:
-        envSlug: dev
-        projectSlug: vixens
-        secretsPath: /apps/60-services/docspell
-  hostAPI: http://192.168.111.69:8085
-  managedSecretReference:
-    creationPolicy: Owner
-    secretName: docspell-db-credentials
-    secretNamespace: services
-  resyncInterval: 60
 ---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
+  name: docspell-db-credentials-sync
   labels:
     app: docspell
-  name: docspell-secrets-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/60-services/docspell
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/60-services/docspell"
   managedSecretReference:
-    creationPolicy: Owner
-    secretName: docspell-secrets
-    secretNamespace: services
+    secretName: docspell-db-credentials
+    creationPolicy: "Owner"
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: docspell-secrets-sync
+  labels:
+    app: docspell
+spec:
+  hostAPI: http://192.168.111.69:8085
   resyncInterval: 60
+  authentication:
+    universalAuth:
+      credentialsRef:
+        secretName: infisical-universal-auth
+        secretNamespace: argocd
+      secretsScope:
+        projectSlug: vixens
+        envSlug: dev
+        secretsPath: "/apps/60-services/docspell"
+  managedSecretReference:
+    secretName: docspell-secrets
+    creationPolicy: "Owner"

--- a/apps/60-services/docspell-native/overlays/prod/patch-infisical-secrets.yaml
+++ b/apps/60-services/docspell-native/overlays/prod/patch-infisical-secrets.yaml
@@ -1,27 +1,24 @@
-apiVersion: secrets.infisical.com/v1alpha1
-kind: InfisicalSecret
-metadata:
-  labels:
-    app: docspell
-  name: docspell-db-credentials-sync
-spec:
-  authentication:
-    universalAuth:
-      secretsScope:
-        envSlug: prod
-  managedSecretReference:
-    secretNamespace: services
 ---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
+  name: docspell-db-credentials-sync
   labels:
     app: docspell
-  name: docspell-secrets-sync
 spec:
   authentication:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: services
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: docspell-secrets-sync
+  labels:
+    app: docspell
+spec:
+  authentication:
+    universalAuth:
+      secretsScope:
+        envSlug: prod

--- a/apps/60-services/docspell/base/db-credentials-secret.yaml
+++ b/apps/60-services/docspell/base/db-credentials-secret.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: docspell-db-credentials-sync
   namespace: services
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/60-services/docspell
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/60-services/docspell"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: docspell-db-credentials
-    secretNamespace: services
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/60-services/docspell/base/infisical-secret.yaml
+++ b/apps/60-services/docspell/base/infisical-secret.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: docspell-secrets
   namespace: services
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/60-services/docspell
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/60-services/docspell"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: docspell-secrets
-    secretNamespace: services
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/60-services/gluetun/base/infisical-secret.yaml
+++ b/apps/60-services/gluetun/base/infisical-secret.yaml
@@ -1,22 +1,22 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
+  name: gluetun-wireguard-secrets-sync
   labels:
     app: gluetun
-  name: gluetun-wireguard-secrets-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/60-services/gluetun
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/60-services/gluetun"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: gluetun-wireguard-secrets
-    secretNamespace: services
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/60-services/gluetun/overlays/prod/patch-infisical-env.yaml
+++ b/apps/60-services/gluetun/overlays/prod/patch-infisical-env.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: services

--- a/apps/60-services/gluetun/overlays/staging/patch-infisical-env.yaml
+++ b/apps/60-services/gluetun/overlays/staging/patch-infisical-env.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: staging
-  managedSecretReference:
-    secretNamespace: services

--- a/apps/60-services/gluetun/overlays/test/patch-infisical-env.yaml
+++ b/apps/60-services/gluetun/overlays/test/patch-infisical-env.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: test
-  managedSecretReference:
-    secretNamespace: services

--- a/apps/60-services/vaultwarden/base/infisical-secret.yaml
+++ b/apps/60-services/vaultwarden/base/infisical-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: vaultwarden-secrets
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/60-services/vaultwarden
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/60-services/vaultwarden"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: vaultwarden-secrets
-    secretNamespace: services
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/60-services/vaultwarden/base/litestream-secret.yaml
+++ b/apps/60-services/vaultwarden/base/litestream-secret.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: litestream-shared-secrets
 spec:
+  hostAPI: http://192.168.111.69:8085
+  managedSecretReference:
+    secretName: litestream-shared-secrets
+    creationPolicy: "Owner"
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /shared/litestream
-  hostAPI: http://192.168.111.69:8085
-  managedSecretReference:
-    creationPolicy: Owner
-    secretName: litestream-shared-secrets
-    secretNamespace: services
+        envSlug: dev # Will be patched by overlays
+        secretsPath: "/shared/litestream"
   resyncInterval: 60

--- a/apps/60-services/vaultwarden/overlays/prod/infisical-patch.yaml
+++ b/apps/60-services/vaultwarden/overlays/prod/infisical-patch.yaml
@@ -7,5 +7,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: services

--- a/apps/60-services/vaultwarden/overlays/prod/litestream-secret-patch.yaml
+++ b/apps/60-services/vaultwarden/overlays/prod/litestream-secret-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -7,5 +8,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: services

--- a/apps/70-tools/changedetection/base/infisical-secret.yaml
+++ b/apps/70-tools/changedetection/base/infisical-secret.yaml
@@ -3,18 +3,17 @@ kind: InfisicalSecret
 metadata:
   name: changedetection-secrets-sync
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/70-tools/changedetection
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/70-tools/changedetection"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: changedetection-secrets
-    secretNamespace: tools
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/70-tools/gitops-revision-controller/base/revisions-homeassistant.yaml
+++ b/apps/70-tools/gitops-revision-controller/base/revisions-homeassistant.yaml
@@ -4,19 +4,18 @@ metadata:
   name: homeassistant-revision
   namespace: tools
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/70-tools/gitops-revision-controller
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/70-tools/gitops-revision-controller"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: homeassistant-revision
-    secretNamespace: tools
+    creationPolicy: Owner
     secretType: Opaque
-  resyncInterval: 60

--- a/apps/70-tools/headlamp/base/infisical-secret.yaml
+++ b/apps/70-tools/headlamp/base/infisical-secret.yaml
@@ -4,18 +4,17 @@ metadata:
   name: headlamp-secrets-sync
   namespace: tools
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/70-tools/headlamp
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/70-tools/headlamp"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: headlamp-secrets
-    secretNamespace: tools
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/70-tools/homepage/base/infisical-config.yaml
+++ b/apps/70-tools/homepage/base/infisical-config.yaml
@@ -4,18 +4,17 @@ metadata:
   name: homepage-config-sync
   namespace: tools
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/70-tools/homepage/config
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev # Will be patched in overlays
+        secretsPath: "/apps/70-tools/homepage/config"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: homepage-config-secret
-    secretNamespace: tools
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/70-tools/homepage/overlays/dev/infisical-secret.yaml
+++ b/apps/70-tools/homepage/overlays/dev/infisical-secret.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: homepage-secrets-sync
   namespace: tools
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/70-tools/homepage
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/70-tools/homepage"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: homepage-secrets
-    secretNamespace: tools
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/70-tools/homepage/overlays/prod/infisical-config-patch.yaml
+++ b/apps/70-tools/homepage/overlays/prod/infisical-config-patch.yaml
@@ -7,5 +7,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: tools

--- a/apps/70-tools/homepage/overlays/prod/infisical-secret.yaml
+++ b/apps/70-tools/homepage/overlays/prod/infisical-secret.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: homepage-secrets-sync
   namespace: tools
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: prod
         projectSlug: vixens
-        secretsPath: /apps/70-tools/homepage
-  hostAPI: http://192.168.111.69:8085
+        envSlug: prod
+        secretsPath: "/apps/70-tools/homepage"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: homepage-secrets
-    secretNamespace: tools
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/70-tools/linkwarden/overlays/dev/infisical-secret.yaml
+++ b/apps/70-tools/linkwarden/overlays/dev/infisical-secret.yaml
@@ -1,23 +1,23 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
-  labels:
-    app: linkwarden
   name: linkwarden-secrets-sync
   namespace: tools
+  labels:
+    app: linkwarden
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/70-tools/linkwarden
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/70-tools/linkwarden"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: linkwarden-secrets
-    secretNamespace: tools
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/70-tools/linkwarden/overlays/prod/infisical-secret.yaml
+++ b/apps/70-tools/linkwarden/overlays/prod/infisical-secret.yaml
@@ -1,23 +1,23 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
-  labels:
-    app: linkwarden
   name: linkwarden-secrets-sync
   namespace: tools
+  labels:
+    app: linkwarden
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: prod
         projectSlug: vixens
-        secretsPath: /apps/70-tools/linkwarden
-  hostAPI: http://192.168.111.69:8085
+        envSlug: prod
+        secretsPath: "/apps/70-tools/linkwarden"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: linkwarden-secrets
-    secretNamespace: tools
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/70-tools/netbox/base/infisical-secret.yaml
+++ b/apps/70-tools/netbox/base/infisical-secret.yaml
@@ -4,18 +4,17 @@ metadata:
   name: netbox-secrets-sync
   namespace: tools
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/70-tools/netbox
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/70-tools/netbox"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: netbox-secrets
-    secretNamespace: tools
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/70-tools/netbox/base/netbox-db-secrets.yaml
+++ b/apps/70-tools/netbox/base/netbox-db-secrets.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: netbox-db-secrets-sync
   namespace: tools
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/70-tools/netbox
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/70-tools/netbox"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: netbox-db-secrets
-    secretNamespace: tools
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/70-tools/nocodb/base/infisical-secret.yaml
+++ b/apps/70-tools/nocodb/base/infisical-secret.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: nocodb-secrets-sync
   namespace: tools
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
-        secretsPath: /apps/70-tools/nocodb
-  hostAPI: http://192.168.111.69:8085
+        envSlug: dev
+        secretsPath: "/apps/70-tools/nocodb"
   managedSecretReference:
-    creationPolicy: Owner
     secretName: nocodb-secrets
-    secretNamespace: tools
-  resyncInterval: 60
+    creationPolicy: "Owner"

--- a/apps/70-tools/renovate/base/infisical-secret.yaml
+++ b/apps/70-tools/renovate/base/infisical-secret.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
   name: renovate-secret-sync
   namespace: tools
 spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
   authentication:
     universalAuth:
       credentialsRef:
         secretName: infisical-universal-auth
         secretNamespace: argocd
       secretsScope:
-        envSlug: dev
         projectSlug: vixens
+        envSlug: dev  # Default, patched by overlay
         secretsPath: /apps/70-tools/renovate
-  hostAPI: http://192.168.111.69:8085
   managedSecretReference:
-    creationPolicy: Owner
     secretName: renovate-secret
-    secretNamespace: tools
-  resyncInterval: 60
+    creationPolicy: Owner

--- a/apps/70-tools/renovate/overlays/dev/patch-infisical-env.yaml
+++ b/apps/70-tools/renovate/overlays/dev/patch-infisical-env.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -8,5 +9,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: dev
-  managedSecretReference:
-    secretNamespace: tools

--- a/apps/70-tools/renovate/overlays/prod/patch-infisical-env.yaml
+++ b/apps/70-tools/renovate/overlays/prod/patch-infisical-env.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
@@ -8,5 +9,3 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-  managedSecretReference:
-    secretNamespace: tools


### PR DESCRIPTION
Increase PVC sizes to prevent 'no space left on device' errors during Litestream restoration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased storage allocation for Frigate service from 2Gi to 5Gi
  * Increased storage allocation for Hydrus-client service from 5Gi to 20Gi

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->