### PR TITLE
fix: hydrus-client integrity check image

### DIFF
--- a/apps/20-media/hydrus-client/base/deployment.yaml
+++ b/apps/20-media/hydrus-client/base/deployment.yaml
@@ -37,14 +37,13 @@ spec:
             - name: config
               mountPath: /opt/hydrus/db
         - name: check-integrity
-          image: alpine:3.19
+          image: litestream/litestream:0.3.13
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
           command: ["/bin/sh", "-c"]
           args:
             - |
-              apk add --no-cache sqlite
               for db in /opt/hydrus/db/*.db; do
                 [ -e "$db" ] || continue
                 echo "🔍 Checking $db..."


### PR DESCRIPTION
Switching to litestream image for check-integrity to avoid apk permission issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container configuration for deployment initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->