### PR TITLE
fix: hydrus-client 40Gi and cleanup

### DIFF
--- a/apps/20-media/hydrus-client/base/deployment.yaml
+++ b/apps/20-media/hydrus-client/base/deployment.yaml
@@ -43,17 +43,7 @@ spec:
             runAsGroup: 1000
           command: ["/bin/sh", "-c"]
           args:
-            - |
-              for db in /opt/hydrus/db/*.db; do
-                [ -e "$db" ] || continue
-                echo "🔍 Checking $db..."
-                if ! sqlite3 "$db" "PRAGMA integrity_check;" | grep -q "ok"; then
-                  echo "❌ Corruption detected in $db! Deleting for fresh restore."
-                  rm "$db"
-                else
-                  echo "✅ $db is healthy."
-                fi
-              done
+            - "for db in /opt/hydrus/db/*.db; do\n  [ -e \"$db\" ] || continue\n  echo \"\U0001F50D Checking $db...\"\n  if ! sqlite3 \"$db\" \"PRAGMA integrity_check;\" | grep -q \"ok\"; then\n    echo \"❌ Corruption detected in $db! Deleting for fresh restore.\"\n    rm \"$db\"\n  else\n    echo \"✅ $db is healthy.\"\n  fi\ndone\n"
           volumeMounts:
             - name: config
               mountPath: /opt/hydrus/db
@@ -65,6 +55,7 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
+              rm -f /opt/hydrus/db/*.tmp* /opt/hydrus/db/*-wal;
               DB_PATH=/opt/hydrus/db/client.db
               if [ -f "$DB_PATH" ]; then
                 echo "✅ Local healthy DB found. Skipping restore."
@@ -89,6 +80,7 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
+              rm -f /opt/hydrus/db/*.tmp* /opt/hydrus/db/*-wal;
               DB_PATH=/opt/hydrus/db/client.mappings.db
               if [ -f "$DB_PATH" ]; then
                 echo "✅ Local healthy DB found. Skipping restore."
@@ -113,6 +105,7 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
+              rm -f /opt/hydrus/db/*.tmp* /opt/hydrus/db/*-wal;
               DB_PATH=/opt/hydrus/db/client.master.db
               if [ -f "$DB_PATH" ]; then
                 echo "✅ Local healthy DB found. Skipping restore."
@@ -137,6 +130,7 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
+              rm -f /opt/hydrus/db/*.tmp* /opt/hydrus/db/*-wal;
               DB_PATH=/opt/hydrus/db/client.caches.db
               if [ -f "$DB_PATH" ]; then
                 echo "✅ Local healthy DB found. Skipping restore."

--- a/apps/20-media/hydrus-client/base/pvc.yaml
+++ b/apps/20-media/hydrus-client/base/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   storageClassName: synelia-iscsi-retain
   resources:
     requests:
-      storage: 20Gi
+      storage: 40Gi


### PR DESCRIPTION
Bumping storage to 40Gi and cleaning up tmp files to resolve restore failures in prod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database integrity verification and temporary file cleanup procedures in deployment configuration
  * Increased persistent storage capacity from 20Gi to 40Gi

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->