### PR TITLE
fix(authentik): remove invalid spec field

### DIFF
--- a/apps/03-security/authentik/overlays/prod/kustomization.yaml
+++ b/apps/03-security/authentik/overlays/prod/kustomization.yaml
@@ -36,6 +36,3 @@ patches:
 resources:
   - ../../base
   - ingress.yaml
-spec:
-  managedSecretReference:
-    secretNamespace: auth


### PR DESCRIPTION
Fixes Manifest generation error for Authentik in production.