### PR TITLE
fix(media-stack): remove invalid spec field

### DIFF
--- a/apps/20-media/amule/overlays/prod/kustomization.yaml
+++ b/apps/20-media/amule/overlays/prod/kustomization.yaml
@@ -13,6 +13,3 @@ patches:
 resources:
   - ../../base
   - ingress.yaml
-spec:
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/booklore/overlays/prod/kustomization.yaml
+++ b/apps/20-media/booklore/overlays/prod/kustomization.yaml
@@ -14,6 +14,3 @@ patchesStrategicMerge:
 resources:
   - ../../base
   - ingress.yaml
-spec:
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/frigate/overlays/prod/kustomization.yaml
+++ b/apps/20-media/frigate/overlays/prod/kustomization.yaml
@@ -28,6 +28,3 @@ patches:
 resources:
   - ../../base
   - ingress.yaml
-spec:
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/lidarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/lidarr/overlays/prod/kustomization.yaml
@@ -18,6 +18,3 @@ patchesStrategicMerge:
 resources:
   - ../../base
   - ingress.yaml
-spec:
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/mylar/overlays/prod/kustomization.yaml
+++ b/apps/20-media/mylar/overlays/prod/kustomization.yaml
@@ -18,6 +18,3 @@ patchesStrategicMerge:
 resources:
   - ../../base
   - ingress.yaml
-spec:
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/prowlarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/prowlarr/overlays/prod/kustomization.yaml
@@ -18,6 +18,3 @@ patchesStrategicMerge:
 resources:
   - ../../base
   - ingress.yaml
-spec:
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/pyload/overlays/prod/kustomization.yaml
+++ b/apps/20-media/pyload/overlays/prod/kustomization.yaml
@@ -13,6 +13,3 @@ patches:
 resources:
   - ../../base
   - ingress.yaml
-spec:
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/qbittorrent/overlays/prod/kustomization.yaml
+++ b/apps/20-media/qbittorrent/overlays/prod/kustomization.yaml
@@ -13,6 +13,3 @@ patches:
 resources:
   - ../../base
   - ingress.yaml
-spec:
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/radarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/radarr/overlays/prod/kustomization.yaml
@@ -18,6 +18,3 @@ patchesStrategicMerge:
 resources:
   - ../../base
   - ingress.yaml
-spec:
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/sonarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/sonarr/overlays/prod/kustomization.yaml
@@ -18,6 +18,3 @@ patches:
       name: sonarr-litestream-secret
     path: litestream-secret-patch.yaml
 patchesStrategicMerge:
-spec:
-  managedSecretReference:
-    secretNamespace: media

--- a/apps/20-media/whisparr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/whisparr/overlays/prod/kustomization.yaml
@@ -18,6 +18,3 @@ patchesStrategicMerge:
 resources:
   - ../../base
   - ingress.yaml
-spec:
-  managedSecretReference:
-    secretNamespace: media


### PR DESCRIPTION
Fixes manifest generation errors for multiple media apps in production by removing the invalid 'spec' field from kustomization files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production configuration across media applications (Amule, Booklore, Frigate, Lidarr, Mylar, Prowlarr, Pyload, qBittorrent, Radarr, Sonarr, Whisparr) to streamline secret namespace references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->