### PR TITLE
chore(it-tools): migrate to centralized redirect-https middleware

### DIFF
--- a/apps/70-tools/it-tools/overlays/dev/ingress.yaml
+++ b/apps/70-tools/it-tools/overlays/dev/ingress.yaml
@@ -2,38 +2,16 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: it-tools-http-redirect
-  namespace: tools
-  annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web
-    traefik.ingress.kubernetes.io/router.middlewares: traefik-global-redirect-https@kubernetescrd
-spec:
-  ingressClassName: traefik
-  rules:
-    - host: it-tools.dev.truxonline.com
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: it-tools
-                port:
-                  number: 8080
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
   name: it-tools-ingress
   namespace: tools
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-staging
-    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-global-redirect-https@kubernetescrd
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: IT Tools
     gethomepage.dev/icon: it-tools.png
     gethomepage.dev/group: Tools
-    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/70-tools/it-tools/overlays/prod/ingress.yaml
+++ b/apps/70-tools/it-tools/overlays/prod/ingress.yaml
@@ -2,38 +2,16 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: it-tools-http-redirect
-  namespace: tools
-  annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web
-    traefik.ingress.kubernetes.io/router.middlewares: traefik-global-redirect-https@kubernetescrd
-spec:
-  ingressClassName: traefik
-  rules:
-    - host: it-tools.truxonline.com
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: it-tools
-                port:
-                  number: 8080
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
   name: it-tools-ingress
   namespace: tools
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-global-redirect-https@kubernetescrd
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: IT Tools
     gethomepage.dev/icon: it-tools.png
     gethomepage.dev/group: Tools
-    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
   ingressClassName: traefik
   rules:

--- a/argocd/overlays/dev/kustomization.yaml
+++ b/argocd/overlays/dev/kustomization.yaml
@@ -79,8 +79,8 @@ resources:
   - apps/renovate.yaml
   # - apps/stirling-pdf.yaml
   # - apps/stirling-pdf-ingress.yaml
-  # - apps/it-tools.yaml
-  # - apps/it-tools-ingress.yaml
+  - apps/it-tools.yaml
+  - apps/it-tools-ingress.yaml
   # - apps/contacts.yaml
   - apps/external-dns-unifi.yaml
   - apps/external-dns-unifi-secrets.yaml


### PR DESCRIPTION
Migration of it-tools to the centralized Traefik redirect-https middleware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured HTTPS/TLS support for the it-tools service across development and production environments.
  * Integrated Let's Encrypt for automatic certificate management in both environments.
  * Updated routing rules to support encrypted (websecure) and standard web connections.
  * Enabled proper ingress handling for service access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->