### PR TITLE
feat(litestream): enable Prometheus metrics for SQLite apps

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -20,6 +20,9 @@ spec:
         app: homeassistant
       annotations:
         reloader.stakater.com/auto: "true"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
     spec:
       securityContext:
         fsGroup: 1000
@@ -177,6 +180,9 @@ spec:
             - replicate
             - -config
             - /etc/litestream.yml
+          ports:
+            - containerPort: 9090
+              name: metrics
           envFrom:
             - secretRef:
                 name: homeassistant-litestream-secret

--- a/apps/10-home/homeassistant/base/litestream-config.yaml
+++ b/apps/10-home/homeassistant/base/litestream-config.yaml
@@ -10,3 +10,5 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/homeassistant/home-assistant_v2.db
             endpoint: $LITESTREAM_ENDPOINT
+    metrics:
+      addr: ":9090"

--- a/apps/20-media/frigate/base/deployment.yaml
+++ b/apps/20-media/frigate/base/deployment.yaml
@@ -20,6 +20,9 @@ spec:
         app: frigate
       annotations:
         reloader.stakater.com/auto: "true"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
     spec:
       priorityClassName: vixens-high
       tolerations:
@@ -128,6 +131,9 @@ spec:
             - replicate
             - -config
             - /etc/litestream.yml
+          ports:
+            - containerPort: 9090
+              name: metrics
           resources:
             requests:
               cpu: 10m

--- a/apps/20-media/frigate/base/litestream-config.yaml
+++ b/apps/20-media/frigate/base/litestream-config.yaml
@@ -10,3 +10,5 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/frigate/frigate.db
             endpoint: $LITESTREAM_ENDPOINT
+    metrics:
+      addr: ":9090"

--- a/apps/20-media/hydrus-client/base/deployment.yaml
+++ b/apps/20-media/hydrus-client/base/deployment.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         app: hydrus-client
         test-label: "true"
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
     spec:
       priorityClassName: vixens-medium
       tolerations:
@@ -200,6 +204,9 @@ spec:
             - replicate
             - -config
             - /etc/litestream.yml
+          ports:
+            - containerPort: 9090
+              name: metrics
           envFrom:
             - secretRef:
                 name: litestream-shared-secrets

--- a/apps/20-media/hydrus-client/base/litestream-config.yaml
+++ b/apps/20-media/hydrus-client/base/litestream-config.yaml
@@ -22,3 +22,5 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/hydrus-client/client.caches.db
             endpoint: $LITESTREAM_ENDPOINT
+    metrics:
+      addr: ":9090"

--- a/apps/20-media/lidarr/base/deployment.yaml
+++ b/apps/20-media/lidarr/base/deployment.yaml
@@ -18,6 +18,9 @@ spec:
         app: lidarr
       annotations:
         reloader.stakater.com/auto: "true"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
     spec:
       priorityClassName: vixens-medium
       tolerations:
@@ -123,6 +126,9 @@ spec:
             - replicate
             - -config
             - /etc/litestream.yml
+          ports:
+            - containerPort: 9090
+              name: metrics
           resources:
             requests:
               cpu: 10m

--- a/apps/20-media/lidarr/base/litestream-config.yaml
+++ b/apps/20-media/lidarr/base/litestream-config.yaml
@@ -10,3 +10,5 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/lidarr/lidarr.db
             endpoint: $LITESTREAM_ENDPOINT
+    metrics:
+      addr: ":9090"

--- a/apps/20-media/mylar/base/deployment.yaml
+++ b/apps/20-media/mylar/base/deployment.yaml
@@ -18,6 +18,9 @@ spec:
         app: mylar
       annotations:
         reloader.stakater.com/auto: "true"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
     spec:
       priorityClassName: vixens-medium
       securityContext:
@@ -126,6 +129,9 @@ spec:
             - replicate
             - -config
             - /etc/litestream.yml
+          ports:
+            - containerPort: 9090
+              name: metrics
           resources:
             requests:
               cpu: 10m

--- a/apps/20-media/mylar/base/litestream-config.yaml
+++ b/apps/20-media/mylar/base/litestream-config.yaml
@@ -10,3 +10,5 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/mylar/mylar.db
             endpoint: $LITESTREAM_ENDPOINT
+    metrics:
+      addr: ":9090"

--- a/apps/20-media/prowlarr/base/deployment.yaml
+++ b/apps/20-media/prowlarr/base/deployment.yaml
@@ -18,6 +18,9 @@ spec:
         app: prowlarr
       annotations:
         reloader.stakater.com/auto: "true"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
     spec:
       priorityClassName: vixens-medium
       tolerations:
@@ -119,6 +122,9 @@ spec:
             - replicate
             - -config
             - /etc/litestream.yml
+          ports:
+            - containerPort: 9090
+              name: metrics
           resources:
             requests:
               cpu: 10m

--- a/apps/20-media/prowlarr/base/litestream-config.yaml
+++ b/apps/20-media/prowlarr/base/litestream-config.yaml
@@ -10,3 +10,5 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/prowlarr/prowlarr.db
             endpoint: $LITESTREAM_ENDPOINT
+    metrics:
+      addr: ":9090"

--- a/apps/20-media/radarr/base/deployment.yaml
+++ b/apps/20-media/radarr/base/deployment.yaml
@@ -18,6 +18,9 @@ spec:
         app: radarr
       annotations:
         reloader.stakater.com/auto: "true"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
     spec:
       priorityClassName: vixens-medium
       tolerations:
@@ -124,6 +127,9 @@ spec:
             - replicate
             - -config
             - /etc/litestream.yml
+          ports:
+            - containerPort: 9090
+              name: metrics
           resources:
             requests:
               cpu: 10m

--- a/apps/20-media/radarr/base/litestream-config.yaml
+++ b/apps/20-media/radarr/base/litestream-config.yaml
@@ -10,3 +10,5 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/radarr/radarr.db
             endpoint: $LITESTREAM_ENDPOINT
+    metrics:
+      addr: ":9090"

--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -16,6 +16,10 @@ spec:
     metadata:
       labels:
         app: sabnzbd
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
     spec:
       priorityClassName: vixens-low
       tolerations:
@@ -136,6 +140,9 @@ spec:
             - replicate
             - -config
             - /etc/litestream.yml
+          ports:
+            - containerPort: 9090
+              name: metrics
           resources:
             requests:
               cpu: 10m

--- a/apps/20-media/sabnzbd/base/litestream-config.yaml
+++ b/apps/20-media/sabnzbd/base/litestream-config.yaml
@@ -10,3 +10,5 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/sabnzbd/history1.db
             endpoint: $LITESTREAM_ENDPOINT
+    metrics:
+      addr: ":9090"

--- a/apps/20-media/sonarr/base/deployment.yaml
+++ b/apps/20-media/sonarr/base/deployment.yaml
@@ -18,6 +18,9 @@ spec:
         app: sonarr
       annotations:
         reloader.stakater.com/auto: "true"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
     spec:
       priorityClassName: vixens-medium
       tolerations:
@@ -102,6 +105,9 @@ spec:
             - replicate
             - -config
             - /etc/litestream.yml
+          ports:
+            - containerPort: 9090
+              name: metrics
           resources:
             requests:
               cpu: 10m

--- a/apps/20-media/sonarr/base/litestream-config.yaml
+++ b/apps/20-media/sonarr/base/litestream-config.yaml
@@ -10,3 +10,5 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/sonarr/sonarr.db
             endpoint: $LITESTREAM_ENDPOINT
+    metrics:
+      addr: ":9090"

--- a/apps/20-media/whisparr/base/deployment.yaml
+++ b/apps/20-media/whisparr/base/deployment.yaml
@@ -18,6 +18,9 @@ spec:
         app: whisparr
       annotations:
         reloader.stakater.com/auto: "true"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
     spec:
       priorityClassName: vixens-medium
       tolerations:
@@ -124,6 +127,9 @@ spec:
             - replicate
             - -config
             - /etc/litestream.yml
+          ports:
+            - containerPort: 9090
+              name: metrics
           resources:
             requests:
               cpu: 10m

--- a/apps/20-media/whisparr/base/litestream-config.yaml
+++ b/apps/20-media/whisparr/base/litestream-config.yaml
@@ -10,3 +10,5 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/whisparr/whisparr.db
             endpoint: $LITESTREAM_ENDPOINT
+    metrics:
+      addr: ":9090"

--- a/apps/40-network/adguard-home/base/deployment.yaml
+++ b/apps/40-network/adguard-home/base/deployment.yaml
@@ -18,6 +18,10 @@ spec:
     metadata:
       labels:
         app: adguard-home
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
     spec:
       priorityClassName: vixens-critical
       tolerations:
@@ -106,6 +110,9 @@ spec:
             - replicate
             - -config
             - /etc/litestream.yml
+          ports:
+            - containerPort: 9090
+              name: metrics
           resources:
             requests:
               cpu: 10m

--- a/apps/40-network/adguard-home/base/litestream-config.yaml
+++ b/apps/40-network/adguard-home/base/litestream-config.yaml
@@ -14,3 +14,5 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/adguard-home/stats.db
             endpoint: $LITESTREAM_ENDPOINT
+    metrics:
+      addr: ":9090"

--- a/apps/60-services/vaultwarden/base/deployment.yaml
+++ b/apps/60-services/vaultwarden/base/deployment.yaml
@@ -16,6 +16,10 @@ spec:
     metadata:
       labels:
         app: vaultwarden
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
     spec:
       priorityClassName: vixens-high
       securityContext:
@@ -87,6 +91,9 @@ spec:
             - replicate
             - -config
             - /etc/litestream.yml
+          ports:
+            - containerPort: 9090
+              name: metrics
           resources:
             requests:
               cpu: 10m

--- a/apps/60-services/vaultwarden/base/litestream-config.yaml
+++ b/apps/60-services/vaultwarden/base/litestream-config.yaml
@@ -10,3 +10,5 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/vaultwarden/db.sqlite3
             endpoint: $LITESTREAM_ENDPOINT
+    metrics:
+      addr: ":9090"

--- a/apps/template-app/base/deployment.yaml
+++ b/apps/template-app/base/deployment.yaml
@@ -18,6 +18,9 @@ spec:
         app: template-app
       annotations:
         reloader.stakater.com/auto: "true"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
     spec:
       priorityClassName: vixens-medium # Choose: vixens-critical, high, medium, low
       tolerations:
@@ -95,6 +98,9 @@ spec:
             - replicate
             - -config
             - /etc/litestream.yml
+          ports:
+            - containerPort: 9090
+              name: metrics
           envFrom:
             - secretRef:
                 name: template-app-litestream-secret

--- a/apps/template-app/base/litestream-config.yaml
+++ b/apps/template-app/base/litestream-config.yaml
@@ -10,3 +10,5 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/template-app/app.db
             endpoint: $LITESTREAM_ENDPOINT
+    metrics:
+      addr: ":9090"


### PR DESCRIPTION
Enables Prometheus metrics endpoint in Litestream configurations and adds annotations/ports to deployments for automated discovery. Covers 13 apps using SQLite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Prometheus metrics collection across all applications with metrics exposed on port 9090 at the `/metrics` endpoint.
  * Configured metrics scraping for improved observability and monitoring of application performance across the infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->