### PR TITLE
fix(litestream): move metrics to top of config

### DIFF
--- a/apps/20-media/hydrus-client/base/litestream-config.yaml
+++ b/apps/20-media/hydrus-client/base/litestream-config.yaml
@@ -5,6 +5,8 @@ metadata:
   name: hydrus-client-litestream-config
 data:
   litestream.yml: |
+    metrics:
+      addr: ":9090"
     dbs:
       - path: /opt/hydrus/db/client.db
         replicas:
@@ -22,5 +24,3 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/hydrus-client/client.caches.db
             endpoint: $LITESTREAM_ENDPOINT
-    metrics:
-      addr: ":9090"


### PR DESCRIPTION
Testing if moving metrics key to the top of litestream.yml fixes the Prometheus endpoint in v0.3.13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized metrics configuration structure within litestream settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->