### PR TITLE
fix(litestream): hydrus-client port 9091 and reloader

### DIFF
--- a/apps/20-media/hydrus-client/base/deployment.yaml
+++ b/apps/20-media/hydrus-client/base/deployment.yaml
@@ -16,10 +16,10 @@ spec:
     metadata:
       labels:
         app: hydrus-client
-        test-label: "true"
       annotations:
+        reloader.stakater.com/auto: "true"
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        prometheus.io/port: "9091"
         prometheus.io/path: "/metrics"
     spec:
       priorityClassName: vixens-medium
@@ -205,7 +205,7 @@ spec:
             - -config
             - /etc/litestream.yml
           ports:
-            - containerPort: 9090
+            - containerPort: 9091
               name: metrics
           envFrom:
             - secretRef:

--- a/apps/20-media/hydrus-client/base/litestream-config.yaml
+++ b/apps/20-media/hydrus-client/base/litestream-config.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   litestream.yml: |
     metrics:
-      addr: ":9090"
+      addr: ":9091"
     dbs:
       - path: /opt/hydrus/db/client.db
         replicas:


### PR DESCRIPTION
Fixes for hydrus-client: use port 9091 and add missing reloader annotation.