### PR TITLE
fix(hydrus-client): upgrade litestream to v0.5.5 for metrics support

### DIFF
--- a/apps/20-media/hydrus-client/base/deployment.yaml
+++ b/apps/20-media/hydrus-client/base/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       annotations:
         reloader.stakater.com/auto: "true"
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9091"
+        prometheus.io/port: "9090"
         prometheus.io/path: "/metrics"
     spec:
       priorityClassName: vixens-medium
@@ -62,7 +62,7 @@ spec:
             - name: config
               mountPath: /opt/hydrus/db
         - name: restore-db
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -87,7 +87,7 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: restore-mappings
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -112,7 +112,7 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: restore-master
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -137,7 +137,7 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: restore-caches
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -196,7 +196,7 @@ spec:
             - name: client-files
               mountPath: /opt/hydrus/db/client_files
         - name: litestream
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -205,7 +205,7 @@ spec:
             - -config
             - /etc/litestream.yml
           ports:
-            - containerPort: 9091
+            - containerPort: 9090
               name: metrics
           envFrom:
             - secretRef:

--- a/apps/20-media/hydrus-client/base/litestream-config.yaml
+++ b/apps/20-media/hydrus-client/base/litestream-config.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   litestream.yml: |
     metrics:
-      addr: ":9091"
+      addr: ":9090"
     dbs:
       - path: /opt/hydrus/db/client.db
         replicas:


### PR DESCRIPTION
Upgrades Litestream to v0.5.5 to support Prometheus metrics configuration via config file. Reverts port to standard 9090.