### PR TITLE
fix(litestream): upgrade all apps to v0.5.5 for metrics support

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - name: config
               mountPath: /config
         - name: restore-db
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -172,7 +172,7 @@ spec:
               memory: 512Mi
               cpu: 500m
         - name: litestream
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/20-media/frigate/base/deployment.yaml
+++ b/apps/20-media/frigate/base/deployment.yaml
@@ -50,7 +50,7 @@ spec:
             - name: db
               mountPath: /config
         - name: restore-db
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           args:
             - restore
             - -config
@@ -126,7 +126,7 @@ spec:
               cpu: 2000m
               memory: 4Gi
         - name: litestream
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           args:
             - replicate
             - -config

--- a/apps/20-media/lidarr/base/deployment.yaml
+++ b/apps/20-media/lidarr/base/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: config
               mountPath: /config
         - name: restore-db
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -118,7 +118,7 @@ spec:
             - name: music
               mountPath: /music
         - name: litestream
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/20-media/mylar/base/deployment.yaml
+++ b/apps/20-media/mylar/base/deployment.yaml
@@ -53,7 +53,7 @@ spec:
             - name: config
               mountPath: /config
         - name: restore-db
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -121,7 +121,7 @@ spec:
               mountPath: /comics
               subPath: comics
         - name: litestream
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/20-media/prowlarr/base/deployment.yaml
+++ b/apps/20-media/prowlarr/base/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: config
               mountPath: /config
         - name: restore-db
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -114,7 +114,7 @@ spec:
             - name: config
               mountPath: /config
         - name: litestream
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/20-media/radarr/base/deployment.yaml
+++ b/apps/20-media/radarr/base/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: config
               mountPath: /config
         - name: restore-db
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -119,7 +119,7 @@ spec:
               mountPath: /movies
               subPath: movies
         - name: litestream
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - name: config
               mountPath: /config
         - name: restore-db
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -132,7 +132,7 @@ spec:
             - name: downloads
               mountPath: /downloads
         - name: litestream
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/20-media/sonarr/base/deployment.yaml
+++ b/apps/20-media/sonarr/base/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: restore-db
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -97,7 +97,7 @@ spec:
               mountPath: /tv
               subPath: TV Show # Mounts /volume3/Content/TVShow
         - name: litestream
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/20-media/whisparr/base/deployment.yaml
+++ b/apps/20-media/whisparr/base/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: config
               mountPath: /config
         - name: restore-db
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -119,7 +119,7 @@ spec:
               mountPath: /media
               subPath: xxx
         - name: litestream
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/40-network/adguard-home/base/deployment.yaml
+++ b/apps/40-network/adguard-home/base/deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - name: adguard-conf
               mountPath: /opt/adguardhome/conf
         - name: restore-db
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           args:
             - restore
             - -config
@@ -105,7 +105,7 @@ spec:
               memory: 1024Mi
               cpu: 1000m
         - name: litestream
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           args:
             - replicate
             - -config

--- a/apps/60-services/vaultwarden/base/deployment.yaml
+++ b/apps/60-services/vaultwarden/base/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: restore-db
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           args:
             - restore
             - -config
@@ -86,7 +86,7 @@ spec:
             - name: data
               mountPath: /data
         - name: litestream
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           args:
             - replicate
             - -config

--- a/apps/template-app/base/deployment.yaml
+++ b/apps/template-app/base/deployment.yaml
@@ -50,7 +50,7 @@ spec:
               mountPath: /config
         # 2. Optionnel: Restauration SQLite (Litestream)
         - name: restore-db
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           args:
             - restore
             - -config
@@ -93,7 +93,7 @@ spec:
               mountPath: /config
         # 3. Optionnel: Sidecar Litestream
         - name: litestream
-          image: litestream/litestream:0.3.13
+          image: litestream/litestream:0.5.5
           args:
             - replicate
             - -config


### PR DESCRIPTION
Upgrades remaining apps to Litestream v0.5.5 to support Prometheus metrics. Verified with hydrus-client.