### PR TITLE
fix(litestream): use top-level addr for v0.5.5 and enable prometheus

### DIFF
--- a/apps/10-home/homeassistant/base/litestream-config.yaml
+++ b/apps/10-home/homeassistant/base/litestream-config.yaml
@@ -10,5 +10,4 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/homeassistant/home-assistant_v2.db
             endpoint: $LITESTREAM_ENDPOINT
-    metrics:
-      addr: ":9090"
+    addr: ":9090"

--- a/apps/20-media/frigate/base/litestream-config.yaml
+++ b/apps/20-media/frigate/base/litestream-config.yaml
@@ -10,5 +10,4 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/frigate/frigate.db
             endpoint: $LITESTREAM_ENDPOINT
-    metrics:
-      addr: ":9090"
+    addr: ":9090"

--- a/apps/20-media/hydrus-client/base/litestream-config.yaml
+++ b/apps/20-media/hydrus-client/base/litestream-config.yaml
@@ -5,8 +5,7 @@ metadata:
   name: hydrus-client-litestream-config
 data:
   litestream.yml: |
-    metrics:
-      addr: ":9090"
+    addr: ":9090"
     dbs:
       - path: /opt/hydrus/db/client.db
         replicas:

--- a/apps/20-media/lidarr/base/litestream-config.yaml
+++ b/apps/20-media/lidarr/base/litestream-config.yaml
@@ -10,5 +10,4 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/lidarr/lidarr.db
             endpoint: $LITESTREAM_ENDPOINT
-    metrics:
-      addr: ":9090"
+    addr: ":9090"

--- a/apps/20-media/mylar/base/litestream-config.yaml
+++ b/apps/20-media/mylar/base/litestream-config.yaml
@@ -10,5 +10,4 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/mylar/mylar.db
             endpoint: $LITESTREAM_ENDPOINT
-    metrics:
-      addr: ":9090"
+    addr: ":9090"

--- a/apps/20-media/prowlarr/base/litestream-config.yaml
+++ b/apps/20-media/prowlarr/base/litestream-config.yaml
@@ -10,5 +10,4 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/prowlarr/prowlarr.db
             endpoint: $LITESTREAM_ENDPOINT
-    metrics:
-      addr: ":9090"
+    addr: ":9090"

--- a/apps/20-media/radarr/base/litestream-config.yaml
+++ b/apps/20-media/radarr/base/litestream-config.yaml
@@ -10,5 +10,4 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/radarr/radarr.db
             endpoint: $LITESTREAM_ENDPOINT
-    metrics:
-      addr: ":9090"
+    addr: ":9090"

--- a/apps/20-media/sabnzbd/base/litestream-config.yaml
+++ b/apps/20-media/sabnzbd/base/litestream-config.yaml
@@ -10,5 +10,4 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/sabnzbd/history1.db
             endpoint: $LITESTREAM_ENDPOINT
-    metrics:
-      addr: ":9090"
+    addr: ":9090"

--- a/apps/20-media/sonarr/base/litestream-config.yaml
+++ b/apps/20-media/sonarr/base/litestream-config.yaml
@@ -10,5 +10,4 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/sonarr/sonarr.db
             endpoint: $LITESTREAM_ENDPOINT
-    metrics:
-      addr: ":9090"
+    addr: ":9090"

--- a/apps/20-media/whisparr/base/litestream-config.yaml
+++ b/apps/20-media/whisparr/base/litestream-config.yaml
@@ -10,5 +10,4 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/whisparr/whisparr.db
             endpoint: $LITESTREAM_ENDPOINT
-    metrics:
-      addr: ":9090"
+    addr: ":9090"

--- a/apps/40-network/adguard-home/base/litestream-config.yaml
+++ b/apps/40-network/adguard-home/base/litestream-config.yaml
@@ -14,5 +14,4 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/adguard-home/stats.db
             endpoint: $LITESTREAM_ENDPOINT
-    metrics:
-      addr: ":9090"
+    addr: ":9090"

--- a/apps/60-services/vaultwarden/base/litestream-config.yaml
+++ b/apps/60-services/vaultwarden/base/litestream-config.yaml
@@ -10,5 +10,4 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/vaultwarden/db.sqlite3
             endpoint: $LITESTREAM_ENDPOINT
-    metrics:
-      addr: ":9090"
+    addr: ":9090"

--- a/apps/template-app/base/litestream-config.yaml
+++ b/apps/template-app/base/litestream-config.yaml
@@ -10,5 +10,4 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/template-app/app.db
             endpoint: $LITESTREAM_ENDPOINT
-    metrics:
-      addr: ":9090"
+    addr: ":9090"

--- a/argocd/overlays/dev/kustomization.yaml
+++ b/argocd/overlays/dev/kustomization.yaml
@@ -37,10 +37,10 @@ resources:
   # - apps/homeassistant.yaml
   # - apps/mosquitto.yaml
   # - apps/birdnet-go.yaml
-  # - apps/prometheus.yaml # Prometheus standalone monitoring
-  # - apps/prometheus-ingress.yaml             # Prometheus IngressRoutes
-  # - apps/grafana.yaml                        # Grafana standalone monitoring
-  # - apps/grafana-ingress.yaml # Grafana IngressRoutes with HTTP→HTTPS redirect
+  - apps/prometheus.yaml # Prometheus standalone monitoring
+  - apps/prometheus-ingress.yaml             # Prometheus IngressRoutes
+  - apps/grafana.yaml                        # Grafana standalone monitoring
+  - apps/grafana-ingress.yaml # Grafana IngressRoutes with HTTP→HTTPS redirect
   # - apps/homepage.yaml
   # - apps/linkwarden.yaml
   # - apps/gluetun.yaml


### PR DESCRIPTION
Fixes Litestream v0.5.5 metrics configuration by using top-level addr field. Also enables Prometheus and Grafana in dev for verification.