### PR TITLE
chore(adguard): re-hibernate after testing

### DIFF
--- a/argocd/overlays/dev/kustomization.yaml
+++ b/argocd/overlays/dev/kustomization.yaml
@@ -70,7 +70,7 @@ resources:
   # - apps/docspell.yaml # OLD Helm-based (deprecated, use docspell-native)
   # - apps/docspell-native.yaml
   # - apps/changedetection.yaml
-  - apps/adguard-home.yaml
+  # - apps/adguard-home.yaml
   # - apps/netvisor.yaml
   - apps/authentik.yaml
   # - apps/netbox.yaml


### PR DESCRIPTION
Cleanup: re-hibernating adguard-home after Litestream metrics verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * AdGuard Home has been disabled in the development environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->