### PR TITLE
fix(workflow): run auto-tag-dev on main branch

### DIFF
--- a/.github/workflows/auto-tag-dev.yaml
+++ b/.github/workflows/auto-tag-dev.yaml
@@ -3,7 +3,7 @@ name: Auto-tag Dev
 
 on:
   push:
-    branches: [dev]
+    branches: [main]
 
 jobs:
   auto-tag:


### PR DESCRIPTION
Updates auto-tag-dev workflow to run on main branch instead of dev, completing migration to pure trunk-based development.