### PR TITLE
chore(monitoring): re-hibernate prometheus and grafana in dev

### DIFF
--- a/argocd/overlays/dev/kustomization.yaml
+++ b/argocd/overlays/dev/kustomization.yaml
@@ -37,10 +37,10 @@ resources:
   # - apps/homeassistant.yaml
   # - apps/mosquitto.yaml
   # - apps/birdnet-go.yaml
-  - apps/prometheus.yaml # Prometheus standalone monitoring
-  - apps/prometheus-ingress.yaml             # Prometheus IngressRoutes
-  - apps/grafana.yaml                        # Grafana standalone monitoring
-  - apps/grafana-ingress.yaml # Grafana IngressRoutes with HTTP→HTTPS redirect
+  # - apps/prometheus.yaml # Prometheus standalone monitoring
+  # - apps/prometheus-ingress.yaml             # Prometheus IngressRoutes
+  # - apps/grafana.yaml                        # Grafana standalone monitoring
+  # - apps/grafana-ingress.yaml # Grafana IngressRoutes with HTTP→HTTPS redirect
   # - apps/homepage.yaml
   # - apps/linkwarden.yaml
   # - apps/gluetun.yaml


### PR DESCRIPTION
Re-hibernating monitoring stack in dev after metrics verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled Prometheus and Grafana monitoring services in the development environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->