### PR TITLE
fix(kubernetes-dashboard): correct subchart values structure for v7

### DIFF
--- a/apps/00-infra/kubernetes-dashboard/values/common.yaml
+++ b/apps/00-infra/kubernetes-dashboard/values/common.yaml
@@ -2,7 +2,7 @@
 # apps/00-infra/kubernetes-dashboard/values/common.yaml
 # Official Chart: https://github.com/kubernetes/dashboard
 
-# Global tolerations for all components
+# Global tolerations for all components (if supported)
 tolerations:
   - key: node-role.kubernetes.io/control-plane
     operator: Exists
@@ -15,33 +15,46 @@ kong:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists
       effect: NoSchedule
-# We handle ingress via our standard traefik Ingress resource in overlays
+
+# API component
 api:
+  app:
+    scheduling:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
   ingress:
     enabled: false
   extraArgs:
     - --enable-skip-login
     - --enable-insecure-login
     - --token-ttl=43200
-  tolerations:
-    - key: node-role.kubernetes.io/control-plane
-      operator: Exists
-      effect: NoSchedule
-# Metrics scraper integration
-metrics-scraper:
-  enabled: true
-  tolerations:
-    - key: node-role.kubernetes.io/control-plane
-      operator: Exists
-      effect: NoSchedule
-# Auth and Web components
+
+# Auth component
 auth:
-  tolerations:
-    - key: node-role.kubernetes.io/control-plane
-      operator: Exists
-      effect: NoSchedule
+  app:
+    scheduling:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+
+# Web component
 web:
-  tolerations:
-    - key: node-role.kubernetes.io/control-plane
-      operator: Exists
-      effect: NoSchedule
+  app:
+    scheduling:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+
+# Metrics scraper component
+metrics-scraper:
+  app:
+    scheduling:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+  enabled: true


### PR DESCRIPTION
This PR fixes the tolerations for all dashboard components by using the correct nesting structure required by the v7 umbrella chart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized Kubernetes dashboard configuration structure by consolidating toleration settings under a unified scheduling block for improved maintainability and consistency across components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->