### PR TITLE
fix(kubernetes-dashboard): force traefik to use https scheme for kong backend

### DIFF
--- a/apps/00-infra/kubernetes-dashboard/overlays/dev/ingress.yaml
+++ b/apps/00-infra/kubernetes-dashboard/overlays/dev/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-staging
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    traefik.ingress.kubernetes.io/service.serversscheme: https
 spec:
   ingressClassName: traefik
   rules:


### PR DESCRIPTION
Traefik returns 500 because it likely tries to reach the Kong backend over HTTP while it expects HTTPS. This PR adds the serversscheme annotation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration to enhance security for backend service connections in the development environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->