### PR TITLE
fix(kubernetes-dashboard): skip tls verification for kong backend

### DIFF
--- a/apps/00-infra/kubernetes-dashboard/overlays/dev/ingress.yaml
+++ b/apps/00-infra/kubernetes-dashboard/overlays/dev/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
     traefik.ingress.kubernetes.io/service.serversscheme: https
+    traefik.ingress.kubernetes.io/service.serverstransport: kubernetes-dashboard-dashboard-skip-verify@kubernetescrd
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/00-infra/kubernetes-dashboard/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/kubernetes-dashboard/overlays/dev/kustomization.yaml
@@ -5,3 +5,4 @@ namespace: kubernetes-dashboard
 resources:
   - ../../base
   - ingress.yaml
+  - transport.yaml

--- a/apps/00-infra/kubernetes-dashboard/overlays/dev/transport.yaml
+++ b/apps/00-infra/kubernetes-dashboard/overlays/dev/transport.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: dashboard-skip-verify
+  namespace: kubernetes-dashboard
+spec:
+  insecureSkipVerify: true


### PR DESCRIPTION
Traefik fails to talk to Kong because of certificate verification errors. This PR adds a ServersTransport to skip verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes Dashboard infrastructure configuration in the development environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->