### PR TITLE
fix(kubernetes-dashboard): use containo.us api group for ServersTransport

### DIFF
--- a/apps/00-infra/kubernetes-dashboard/overlays/dev/transport.yaml
+++ b/apps/00-infra/kubernetes-dashboard/overlays/dev/transport.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: traefik.io/v1alpha1
+apiVersion: traefik.containo.us/v1alpha1
 kind: ServersTransport
 metadata:
   name: dashboard-skip-verify


### PR DESCRIPTION
Traefik in this cluster seems to prefer the containo.us API group for CRDs. This PR updates the ServersTransport.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Kubernetes API version reference for improved compatibility and correct resource configuration in the development environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->