### PR TITLE
fix(kubernetes-dashboard): switch kong to http

### DIFF
--- a/apps/00-infra/kubernetes-dashboard/overlays/dev/ingress.yaml
+++ b/apps/00-infra/kubernetes-dashboard/overlays/dev/ingress.yaml
@@ -8,8 +8,6 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-staging
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
-    traefik.ingress.kubernetes.io/service.serversscheme: https
-    traefik.ingress.kubernetes.io/service.serverstransport: kubernetes-dashboard-dashboard-skip-verify@kubernetescrd
 spec:
   ingressClassName: traefik
   rules:
@@ -22,7 +20,7 @@ spec:
               service:
                 name: kubernetes-dashboard-kong-proxy
                 port:
-                  number: 443
+                  number: 80
   tls:
     - hosts:
         - dashboard.dev.truxonline.com

--- a/apps/00-infra/kubernetes-dashboard/values/common.yaml
+++ b/apps/00-infra/kubernetes-dashboard/values/common.yaml
@@ -18,6 +18,12 @@ api:
   app:
     scheduling:
       tolerations: *tol
+  ingress:
+    enabled: false
+  extraArgs:
+    - --enable-skip-login
+    - --enable-insecure-login
+    - --token-ttl=43200
 
 auth:
   tolerations: *tol
@@ -36,6 +42,13 @@ metrics-scraper:
   app:
     scheduling:
       tolerations: *tol
+  enabled: true
 
 kong:
+  enabled: true
+  proxy:
+    http:
+      enabled: true
+    tls:
+      enabled: false
   tolerations: *tol


### PR DESCRIPTION
Switching Kong gateway to HTTP mode to avoid complex TLS verification issues with Traefik.