### PR TITLE
feat(kubernetes-dashboard): enable skip-login

### DIFF
--- a/apps/00-infra/kubernetes-dashboard/values/common.yaml
+++ b/apps/00-infra/kubernetes-dashboard/values/common.yaml
@@ -20,10 +20,11 @@ api:
       tolerations: *tol
   ingress:
     enabled: false
-  extraArgs:
-    - --enable-skip-login
-    - --enable-insecure-login
-    - --token-ttl=43200
+  containers:
+    args:
+      - --enable-skip-login
+      - --enable-insecure-login
+      - --token-ttl=43200
 
 auth:
   tolerations: *tol


### PR DESCRIPTION
Moving skip-login arguments to the correct structure api.containers.args for v7 chart.