### PR TITLE
fix(kubernetes-dashboard): move args to correct path

### DIFF
--- a/apps/00-infra/kubernetes-dashboard/values/common.yaml
+++ b/apps/00-infra/kubernetes-dashboard/values/common.yaml
@@ -20,10 +20,11 @@ api:
       tolerations: *tol
   ingress:
     enabled: false
-  extraArgs:
-    - --enable-skip-login
-    - --enable-insecure-login
-    - --token-ttl=43200
+  containers:
+    args:
+      - --enable-skip-login
+      - --enable-insecure-login
+      - --token-ttl=43200
 
 auth:
   tolerations: *tol


### PR DESCRIPTION
My previous PR didn't use the correct path for container arguments. This one uses api.containers.args as defined in the v7 chart.