### PR TITLE
fix(kubernetes-dashboard): remove obsolete flags

### DIFF
--- a/apps/00-infra/kubernetes-dashboard/values/common.yaml
+++ b/apps/00-infra/kubernetes-dashboard/values/common.yaml
@@ -22,8 +22,8 @@ api:
     enabled: false
   containers:
     args:
-      - --enable-skip-login
-      - --enable-insecure-login
+      - --namespace=kubernetes-dashboard
+      - --metrics-scraper-service-name=kubernetes-dashboard-metrics-scraper
       - --token-ttl=43200
 
 auth:


### PR DESCRIPTION
The --enable-skip-login flag is not supported in v7.14.0 and causes the API pod to fail with an error, leading to 502 Bad Gateway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Kubernetes Dashboard API container arguments to remove login bypass functionality and enforce authentication requirements
  * Added explicit namespace assignment and metrics scraper service name configuration for proper resource isolation
  * Applied minor formatting adjustments to improve configuration structure

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->