### PR TITLE
fix(kubernetes-dashboard): remove duplicate args

### DIFF
--- a/apps/00-infra/kubernetes-dashboard/values/common.yaml
+++ b/apps/00-infra/kubernetes-dashboard/values/common.yaml
@@ -22,8 +22,6 @@ api:
     enabled: false
   containers:
     args:
-      - --namespace=kubernetes-dashboard
-      - --metrics-scraper-service-name=kubernetes-dashboard-metrics-scraper
       - --token-ttl=43200
 
 auth:


### PR DESCRIPTION
Removing duplicate --namespace and --metrics-scraper-service-name flags which are already provided by the Helm chart and caused the API pod to crash.