### PR TITLE
fix(kubernetes-dashboard): remove all custom args

### DIFF
--- a/apps/00-infra/kubernetes-dashboard/values/common.yaml
+++ b/apps/00-infra/kubernetes-dashboard/values/common.yaml
@@ -21,8 +21,7 @@ api:
   ingress:
     enabled: false
   containers:
-    args:
-      - --token-ttl=43200
+    args: []
 
 auth:
   tolerations: *tol


### PR DESCRIPTION
The --token-ttl flag is not supported and causes the API to crash. Removing all custom args to let Helm use its defaults.