### PR TITLE
fix(kubernetes-dashboard): update prod config

### DIFF
--- a/apps/00-infra/kubernetes-dashboard/overlays/prod/ingress.yaml
+++ b/apps/00-infra/kubernetes-dashboard/overlays/prod/ingress.yaml
@@ -20,7 +20,7 @@ spec:
               service:
                 name: kubernetes-dashboard-kong-proxy
                 port:
-                  number: 443
+                  number: 80
   tls:
     - hosts:
         - dashboard.truxonline.com


### PR DESCRIPTION
Updating prod ingress to match the new HTTP-only Kong gateway configuration.