### PR TITLE
fix(netbird): fix storage class name

### DIFF
--- a/apps/40-network/netbird/base/pvc.yaml
+++ b/apps/40-network/netbird/base/pvc.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: synology-iscsi-retain
+  storageClassName: synelia-iscsi-retain
   resources:
     requests:
       storage: 5Gi


### PR DESCRIPTION
Corrects invalid storageClassName causing PVC provisioning failure.