### PR TITLE
fix(netbird): CORS CRD version

### DIFF
--- a/apps/40-network/netbird/base/middleware-cors.yaml
+++ b/apps/40-network/netbird/base/middleware-cors.yaml
@@ -1,12 +1,11 @@
 ---
-apiVersion: traefik.io/v1alpha1
+apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   name: netbird-cors
 spec:
   headers:
-    cors:
-      accessControlAllowMethods:
+    accessControlAllowMethods:
       - GET
       - OPTIONS
       - POST


### PR DESCRIPTION
Uses traefik.containo.us/v1alpha1 for CORS middleware.