### PR TITLE
fix(authentik): map PostgreSQL credentials keys for CNPG compatibility

### DIFF
--- a/apps/04-databases/postgresql-shared/base/credentials/authentik-secret.yaml
+++ b/apps/04-databases/postgresql-shared/base/credentials/authentik-secret.yaml
@@ -22,3 +22,11 @@ spec:
     secretName: authentik-postgresql-credentials
     creationPolicy: Owner
     secretNamespace: databases
+  template:
+    data:
+      username: "{{ .POSTGRES_USER }}"
+      password: "{{ .POSTGRES_PASSWORD }}"
+      POSTGRES_USER: "{{ .POSTGRES_USER }}"
+      POSTGRES_PASSWORD: "{{ .POSTGRES_PASSWORD }}"
+      REDIS_PASSWORD: "{{ .REDIS_PASSWORD }}"
+      SECRET_KEY: "{{ .SECRET_KEY }}"


### PR DESCRIPTION
Map POSTGRES_USER/PASSWORD to username/password in InfisicalSecret for CloudNativePG managed roles compatibility.