### PR TITLE
revert: map PostgreSQL credentials keys (incompatible operator)

### DIFF
--- a/apps/04-databases/postgresql-shared/base/credentials/authentik-secret.yaml
+++ b/apps/04-databases/postgresql-shared/base/credentials/authentik-secret.yaml
@@ -22,11 +22,3 @@ spec:
     secretName: authentik-postgresql-credentials
     creationPolicy: Owner
     secretNamespace: databases
-  template:
-    data:
-      username: "{{ .POSTGRES_USER }}"
-      password: "{{ .POSTGRES_PASSWORD }}"
-      POSTGRES_USER: "{{ .POSTGRES_USER }}"
-      POSTGRES_PASSWORD: "{{ .POSTGRES_PASSWORD }}"
-      REDIS_PASSWORD: "{{ .REDIS_PASSWORD }}"
-      SECRET_KEY: "{{ .SECRET_KEY }}"


### PR DESCRIPTION
Reverting previous fix as the current Infisical operator version does not support 'spec.template'.