### PR TITLE
fix(authentik): fetch Redis password from correct path

### DIFF
--- a/apps/03-security/authentik/base/deployment-server.yaml
+++ b/apps/03-security/authentik/base/deployment-server.yaml
@@ -46,8 +46,8 @@ spec:
             - name: AUTHENTIK_REDIS__PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: authentik-secrets
-                  key: REDIS_PASSWORD
+                  name: authentik-redis-credentials
+                  key: password
             - name: AUTHENTIK_POSTGRESQL__HOST
               value: postgresql-shared-rw.databases.svc.cluster.local
             - name: AUTHENTIK_POSTGRESQL__NAME

--- a/apps/03-security/authentik/base/deployment-worker.yaml
+++ b/apps/03-security/authentik/base/deployment-worker.yaml
@@ -42,8 +42,8 @@ spec:
             - name: AUTHENTIK_REDIS__PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: authentik-secrets
-                  key: REDIS_PASSWORD
+                  name: authentik-redis-credentials
+                  key: password
             - name: AUTHENTIK_POSTGRESQL__HOST
               value: postgresql-shared-rw.databases.svc.cluster.local
             - name: AUTHENTIK_POSTGRESQL__NAME

--- a/apps/03-security/authentik/base/infisical-redis-secret.yaml
+++ b/apps/03-security/authentik/base/infisical-redis-secret.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: authentik-redis-secret-sync
+  namespace: auth
+spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
+  authentication:
+    universalAuth:
+      credentialsRef:
+        secretName: infisical-universal-auth
+        secretNamespace: argocd
+      secretsScope:
+        projectSlug: vixens
+        envSlug: dev
+        secretsPath: /apps/04-databases/redis-shared
+  managedSecretReference:
+    secretName: authentik-redis-credentials
+    creationPolicy: Owner
+    secretNamespace: auth

--- a/apps/03-security/authentik/base/kustomization.yaml
+++ b/apps/03-security/authentik/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - deployment-worker.yaml
   - service.yaml
   - infisical-secret.yaml
+  - infisical-redis-secret.yaml
   - litestream-secret.yaml
   - configmap.yaml
   - pvc.yaml


### PR DESCRIPTION
Fetch Redis password from /apps/04-databases/redis-shared instead of /apps/03-security/authentik where it was missing.