### PR TITLE
fix(authentik): force CORS headers via Traefik

### DIFF
--- a/apps/03-security/authentik/overlays/dev/cors-middleware.yaml
+++ b/apps/03-security/authentik/overlays/dev/cors-middleware.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: authentik-cors
+  namespace: auth
+spec:
+  headers:
+    accessControlAllowMethods:
+      - GET
+      - OPTIONS
+      - POST
+    accessControlAllowHeaders:
+      - "*"
+    accessControlAllowOriginList:
+      - "https://netbird.dev.truxonline.com"
+      - "https://netbird.truxonline.com"
+    accessControlMaxAge: 100
+    accessControlAllowCredentials: true

--- a/apps/03-security/authentik/overlays/dev/ingress.yaml
+++ b/apps/03-security/authentik/overlays/dev/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-staging
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
-    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd, auth-authentik-cors@kubernetescrd
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/03-security/authentik/overlays/dev/kustomization.yaml
+++ b/apps/03-security/authentik/overlays/dev/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+  - cors-middleware.yaml
 patches:
   - path: deployment-patch.yaml
     target:


### PR DESCRIPTION
Add Traefik CORS middleware to Authentik ingress to allow Netbird dashboard to access OIDC configuration.