### PR TITLE
fix(authentik): delegate role creation to job

### DIFF
--- a/apps/04-databases/postgresql-shared/base/cluster.yaml
+++ b/apps/04-databases/postgresql-shared/base/cluster.yaml
@@ -29,11 +29,11 @@ spec:
         login: true
         passwordSecret:
           name: netbox-postgresql-credentials
-      - name: authentik
-        ensure: present
-        login: true
-        passwordSecret:
-          name: authentik-postgresql-credentials
+#      - name: authentik
+#        ensure: present
+#        login: true
+#        passwordSecret:
+#          name: authentik-postgresql-credentials
       - name: scanopy
         ensure: present
         login: true


### PR DESCRIPTION
Retire Authentik from CNPG managed roles to avoid secret key mismatch. The PostSync job will handle creation using correct Infisical keys.