### PR TITLE
fix(netbird): restore hostAPI

### DIFF
--- a/apps/04-databases/postgresql-shared/base/credentials/netbird-postgresql-credentials.yaml
+++ b/apps/04-databases/postgresql-shared/base/credentials/netbird-postgresql-credentials.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "1"
 spec:
+  hostAPI: http://192.168.111.69:8085
   resyncInterval: 60
   authentication:
     universalAuth:


### PR DESCRIPTION
Restore explicit hostAPI to avoid connecting to Infisical Cloud.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated database configuration to include API host endpoint reference for enhanced service connectivity management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->