### PR TITLE
fix(prod): Authentik CORS for Netbird

### DIFF
--- a/apps/03-security/authentik/overlays/prod/cors-middleware.yaml
+++ b/apps/03-security/authentik/overlays/prod/cors-middleware.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: authentik-cors
+  namespace: auth
+spec:
+  headers:
+    accessControlAllowMethods:
+      - GET
+      - OPTIONS
+      - POST
+    accessControlAllowHeaders:
+      - "*"
+    accessControlAllowOriginList:
+      - "https://netbird.truxonline.com"
+      - "https://netbird.dev.truxonline.com"
+    accessControlMaxAge: 100
+    accessControlAllowCredentials: true

--- a/apps/03-security/authentik/overlays/prod/ingress.yaml
+++ b/apps/03-security/authentik/overlays/prod/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
-    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd, auth-authentik-cors@kubernetescrd
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/03-security/authentik/overlays/prod/kustomization.yaml
+++ b/apps/03-security/authentik/overlays/prod/kustomization.yaml
@@ -47,3 +47,4 @@ patches:
 resources:
   - ../../base
   - ingress.yaml
+  - cors-middleware.yaml


### PR DESCRIPTION
Add Traefik CORS middleware to Authentik production ingress to allow Netbird dashboard authentication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CORS configuration for the authentication service, enabling cross-origin requests with support for specified HTTP methods, headers, allowed origins, and credential handling.

* **Configuration**
  * Updated ingress routing to apply the new CORS middleware.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->