### PR TITLE
fix(authentik): blueprint in default path

### DIFF
--- a/apps/03-security/authentik/base/deployment-server.yaml
+++ b/apps/03-security/authentik/base/deployment-server.yaml
@@ -69,15 +69,13 @@ spec:
                   key: SECRET_KEY
             - name: AUTHENTIK_HTTP__CORS_ORIGINS
               value: "https://netbird.dev.truxonline.com,https://netbird.truxonline.com"
-            - name: AUTHENTIK_BLUEPRINTS__BOOTSTRAP_AND_OVERWRITE
-              value: "true"
                   # Add other environment variables from Authentik documentation
                   # if needed
           volumeMounts:
             - name: authentik-data
               mountPath: /var/lib/authentik
             - name: blueprints
-              mountPath: /blueprints/vixens-netbird.yaml
+              mountPath: /blueprints/default/vixens-netbird.yaml
               subPath: vixens-netbird.yaml
           resources:
             requests:

--- a/apps/03-security/authentik/base/deployment-worker.yaml
+++ b/apps/03-security/authentik/base/deployment-worker.yaml
@@ -71,7 +71,7 @@ spec:
             - name: authentik-data
               mountPath: /var/lib/authentik
             - name: blueprints
-              mountPath: /blueprints/vixens-netbird.yaml
+              mountPath: /blueprints/default/vixens-netbird.yaml
               subPath: vixens-netbird.yaml
       volumes:
         - name: authentik-data


### PR DESCRIPTION
Mount blueprint in the 'default' subdirectory which is known to be scanned by Authentik bootstrap.