### PR TITLE
fix(netbird): use relative redirect paths

### DIFF
--- a/apps/40-network/netbird/overlays/prod/patches.yaml
+++ b/apps/40-network/netbird/overlays/prod/patches.yaml
@@ -148,6 +148,6 @@ spec:
             - name: AUTH_AUTHORITY
               value: https://authentik.truxonline.com/application/o/netbird/
             - name: AUTH_REDIRECT_URI
-              value: https://netbird.truxonline.com/
+              value: /
             - name: AUTH_SILENT_REDIRECT_URI
-              value: https://netbird.truxonline.com/silent-auth/
+              value: /silent-auth/


### PR DESCRIPTION
Use relative paths for OIDC redirects to avoid URL doubling.