### PR TITLE
fix(authentik): use internal service URL for forwardAuth

### DIFF
--- a/DEADJOE
+++ b/DEADJOE
@@ -1,0 +1,44 @@
+
+*** These modified files were found in JOE when it aborted on Tue Jan 13 19:46:57 2026
+*** JOE was aborted by UNIX signal 15
+
+*** Fichier '(Sans nom)'
+$KUBECONFIG
+null_resource.wait_install_ip
+3.17
+3.1.7
+quay.io/argoproj/argocd:v3.1.7
+tmux send-keys
+environments
+daphne
+diva
+dulce
+
+*** Fichier '(Sans nom)'
+serena
+commit+push
+Ignorez cette
+ignorez cet
+Ignorer cet
+_command
+bash
+execute
+Continuer quand
+worker
+
+*** Fichier '(Sans nom)'
+/root/vixens/.git/MERGE_MSG
+/root/vixens/.git/MERGE_MSG
+/root/vixens/.git/MERGE_MSG
+/root/vixens/.git/MERGE_MSG
+/root/vixens/.git/MERGE_MSG
+../.gemini/settings.json
+../.gemini/settings.json
+GEMINI.md
+GEMINI.md.old
+/root/vixens/.git/MERGE_MSG
+/root/vixens/.git/MERGE_MSG
+
+*** Fichier '* Startup Log *'
+Traitement de '/etc/joe/editorrc'...Traitement de '/etc/joe/ftyperc'...Finished processing /etc/joe/ftyperc
+Finished processing /etc/joe/editorrc

--- a/apps/03-security/authentik/base/middleware-forward-auth.yaml
+++ b/apps/03-security/authentik/base/middleware-forward-auth.yaml
@@ -4,7 +4,7 @@ metadata:
   name: authentik-forward-auth
 spec:
   forwardAuth:
-    address: https://authentik.truxonline.com/outpost.goauthentik.io/auth/traefik
+    address: http://authentik.auth.svc.cluster.local:9000/outpost.goauthentik.io/auth/traefik
     trustForwardHeader: true
     authResponseHeaders:
       - X-authentik-username


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Updates**
  * Updated internal authentication service routing to use Kubernetes cluster-local endpoints for improved security posture and reduced external dependency exposure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->