### PR TITLE
fix(netbird): target correct Infisical environment in prod

### DIFF
--- a/apps/40-network/netbird/overlays/prod/infisical-env-patch.yaml
+++ b/apps/40-network/netbird/overlays/prod/infisical-env-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/authentication/universalAuth/secretsScope/envSlug
+  value: prod

--- a/apps/40-network/netbird/overlays/prod/kustomization.yaml
+++ b/apps/40-network/netbird/overlays/prod/kustomization.yaml
@@ -9,6 +9,14 @@ patches:
   - path: patches.yaml
   - path: infisical-secret-patch.yaml
   - target:
+      kind: InfisicalSecret
+      name: netbird-postgresql-credentials-sync
+    path: infisical-env-patch.yaml
+  - target:
+      kind: InfisicalSecret
+      name: netbird-secrets-sync
+    path: infisical-env-patch.yaml
+  - target:
       group: networking.k8s.io
       version: v1
       kind: Ingress


### PR DESCRIPTION
Updates InfisicalSecret resources in production overlay to use envSlug: prod instead of dev.