### PR TITLE
fix(netbird): use correct Traefik API version

### DIFF
--- a/apps/40-network/netbird/overlays/prod/api-cors-middleware.yaml
+++ b/apps/40-network/netbird/overlays/prod/api-cors-middleware.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: netbird-api-cors


### PR DESCRIPTION
Updates CORS middleware to use traefik.io/v1alpha1 group instead of deprecated traefik.containo.us.