### PR TITLE
chore(ci): fix kubeval failures

### DIFF
--- a/.kubevalignore
+++ b/.kubevalignore
@@ -4,3 +4,4 @@ apps/02-monitoring/alertmanager/base/charts/*
 **/values/*.yaml
 apps/40-network/netbird/overlays/prod/api-cors-middleware.yaml
 **/api-cors-middleware.yaml
+apps/40-network/netbird/base/infisical-postgresql-secret.yaml


### PR DESCRIPTION
Ignores InfisicalSecret CRD in Kubeval checks.