### PR TITLE
fix(authentik): correct Netbird redirect URIs

### DIFF
--- a/apps/03-security/authentik/base/configmap.yaml
+++ b/apps/03-security/authentik/base/configmap.yaml
@@ -18,8 +18,12 @@ data:
           client_id: netbird
           client_type: public
           redirect_uris:
+            - https://netbird.dev.truxonline.com
             - https://netbird.dev.truxonline.com/
+            - https://netbird.dev.truxonline.com/silent-auth
+            - https://netbird.truxonline.com
             - https://netbird.truxonline.com/
+            - https://netbird.truxonline.com/silent-auth
       - model: authentik_core.application
         id: netbird-app
         identifiers:


### PR DESCRIPTION
Adds missing redirect URIs (without trailing slash and silent-auth path) to Netbird blueprint to fix login error.