### PR TITLE
fix(netbird): trailing slashes for OIDC URLs

### DIFF
--- a/apps/40-network/netbird/overlays/prod/patches.yaml
+++ b/apps/40-network/netbird/overlays/prod/patches.yaml
@@ -149,6 +149,6 @@ spec:
             - name: AUTH_AUTHORITY
               value: https://authentik.truxonline.com/application/o/netbird/
             - name: AUTH_REDIRECT_URI
-              value: https://netbird.truxonline.com
+              value: https://netbird.truxonline.com/
             - name: AUTH_SILENT_REDIRECT_URI
-              value: https://netbird.truxonline.com/silent-auth
+              value: https://netbird.truxonline.com/silent-auth/


### PR DESCRIPTION
Fixes duplicated redirect_uri by adding trailing slashes to AUTH_REDIRECT_URI and AUTH_SILENT_REDIRECT_URI in production.