### PR TITLE
fix(netbird): relative redirect URIs

### DIFF
--- a/apps/40-network/netbird/overlays/prod/patches.yaml
+++ b/apps/40-network/netbird/overlays/prod/patches.yaml
@@ -19,6 +19,7 @@ metadata:
   name: netbird-api
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.middlewares: networking-netbird-api-cors@kubernetescrd
 spec:
   rules:
     - host: netbird-api.truxonline.com


### PR DESCRIPTION
Uses relative paths for OIDC redirect URIs to prevent the dashboard from doubling the origin URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication redirect URI configuration to use relative paths.
  * Enhanced API cross-origin resource sharing handling through middleware improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->