### PR TITLE
fix(netbird): OIDC URLs without slashes

### DIFF
--- a/apps/40-network/netbird/overlays/prod/dashboard-env-patch.yaml
+++ b/apps/40-network/netbird/overlays/prod/dashboard-env-patch.yaml
@@ -9,7 +9,7 @@
   value: https://authentik.truxonline.com/application/o/netbird/
 - op: replace
   path: /spec/template/spec/containers/0/env/7/value
-  value: /
+  value: https://netbird.truxonline.com
 - op: replace
   path: /spec/template/spec/containers/0/env/8/value
-  value: /silent-auth/
+  value: https://netbird.truxonline.com/silent-auth


### PR DESCRIPTION
Removes trailing slashes from OIDC redirect URIs to fix duplication bug.