### PR TITLE
fix(netbird): remove dashboard redirect env vars

### DIFF
--- a/apps/40-network/netbird/overlays/prod/dashboard-env-patch.yaml
+++ b/apps/40-network/netbird/overlays/prod/dashboard-env-patch.yaml
@@ -7,9 +7,7 @@
 - op: replace
   path: /spec/template/spec/containers/0/env/4/value
   value: https://authentik.truxonline.com/application/o/netbird/
-- op: replace
-  path: /spec/template/spec/containers/0/env/7/value
-  value: https://netbird.truxonline.com
-- op: replace
-  path: /spec/template/spec/containers/0/env/8/value
-  value: https://netbird.truxonline.com/silent-auth
+- op: remove
+  path: /spec/template/spec/containers/0/env/8
+- op: remove
+  path: /spec/template/spec/containers/0/env/7


### PR DESCRIPTION
Removes AUTH_REDIRECT_URI and AUTH_SILENT_REDIRECT_URI to prevent duplication caused by the dashboard's internal logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production dashboard configuration by removing obsolete environment variable entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->