### PR TITLE
fix(authentik): support Netbird fragment callback

### DIFF
--- a/apps/03-security/authentik/base/configmap.yaml
+++ b/apps/03-security/authentik/base/configmap.yaml
@@ -20,9 +20,11 @@ data:
           redirect_uris:
             - https://netbird.dev.truxonline.com
             - https://netbird.dev.truxonline.com/
+            - https://netbird.dev.truxonline.com/#callback
             - https://netbird.dev.truxonline.com/silent-auth
             - https://netbird.truxonline.com
             - https://netbird.truxonline.com/
+            - https://netbird.truxonline.com/#callback
             - https://netbird.truxonline.com/silent-auth
       - model: authentik_core.application
         id: netbird-app


### PR DESCRIPTION
Adds https://netbird.truxonline.com/#callback to authorized redirect URIs.