### PR TITLE
feat(netbird): isolate dev from prod

### DIFF
--- a/apps/40-network/netbird/base/kustomization.yaml
+++ b/apps/40-network/netbird/base/kustomization.yaml
@@ -11,7 +11,6 @@ labels:
     includeSelectors: false
 
 resources:
-  - namespace.yaml
   - configmap.yaml
   - infisical-secret.yaml
   - infisical-postgresql-secret.yaml

--- a/apps/40-network/netbird/overlays/dev/kustomization.yaml
+++ b/apps/40-network/netbird/overlays/dev/kustomization.yaml
@@ -4,6 +4,13 @@ kind: Kustomization
 
 namespace: networking
 
+nameSuffix: -dev
+
+labels:
+  - pairs:
+      vixens.lab/environment: dev
+    includeSelectors: true
+
 resources:
   - ../../base
 

--- a/apps/40-network/netbird/overlays/prod/kustomization.yaml
+++ b/apps/40-network/netbird/overlays/prod/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: networking
+
 resources:
   - ../../base
   - api-cors-middleware.yaml


### PR DESCRIPTION
This PR isolates the Netbird development resources from production using nameSuffix: -dev.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated netbird deployment configuration for development and production environments with environment-specific namespace and labeling settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->