### PR TITLE
fix(netbird): correct infisical paths

### DIFF
--- a/apps/40-network/netbird/overlays/dev/infisical-secret-patch.yaml
+++ b/apps/40-network/netbird/overlays/dev/infisical-secret-patch.yaml
@@ -8,4 +8,4 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: dev
-        secretsPath: /apps/40-network/netbird
+        secretsPath: /netbird

--- a/apps/40-network/netbird/overlays/prod/infisical-secret-patch.yaml
+++ b/apps/40-network/netbird/overlays/prod/infisical-secret-patch.yaml
@@ -8,4 +8,4 @@ spec:
     universalAuth:
       secretsScope:
         envSlug: prod
-        secretsPath: /apps/40-network/netbird
+        secretsPath: /netbird


### PR DESCRIPTION
The infisical secrets paths were incorrect in overlays, leading to empty secrets and OIDC failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Infisical secret configuration paths for both development and production environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->