### PR TITLE
fix(netbird): final cleanup and auth issuer

### DIFF
--- a/apps/40-network/netbird/overlays/dev/kustomization.yaml
+++ b/apps/40-network/netbird/overlays/dev/kustomization.yaml
@@ -4,13 +4,6 @@ kind: Kustomization
 
 namespace: networking
 
-nameSuffix: -dev
-
-labels:
-  - pairs:
-      vixens.lab/environment: dev
-    includeSelectors: true
-
 resources:
   - ../../base
 
@@ -29,7 +22,14 @@ patches:
           {
             "HttpConfig": {
               "Address": ":80",
-              "AuthIssuer": "https://authentik.dev.truxonline.com/application/o/netbird/",
+              "AuthIssuer": "https://authentik.truxonline.com/application/o/netbird/",
               "AuthAudience": "netbird"
             }
           }
+  - target:
+      kind: Deployment
+      name: netbird-dashboard
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/env/4/value
+        value: https://authentik.truxonline.com/application/o/netbird/


### PR DESCRIPTION
Restored original resource names and switched to production Authentik authority for Dev Netbird.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed development environment-specific naming conventions and labels from configuration
  * Updated authentication endpoints to production domains for management services and dashboard components

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->