### PR TITLE
fix(netbird): increase management liveness probe timeout

### DIFF
--- a/apps/40-network/netbird/base/deployment-management.yaml
+++ b/apps/40-network/netbird/base/deployment-management.yaml
@@ -109,14 +109,14 @@ spec:
               protocol: TCP
           livenessProbe:
             failureThreshold: 5
-            initialDelaySeconds: 60
+            initialDelaySeconds: 180
             periodSeconds: 10
             tcpSocket:
               port: http
             timeoutSeconds: 3
           readinessProbe:
             failureThreshold: 5
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             periodSeconds: 10
             tcpSocket:
               port: http


### PR DESCRIPTION
## Summary
- Increased liveness probe `initialDelaySeconds` from 60s to 180s
- Increased readiness probe `initialDelaySeconds` from 30s to 60s

## Root Cause
The NetBird management server downloads a geolocation database (`geonames_*.db`) on first startup. This download takes longer than the default 60s timeout, causing the liveness probe to kill the pod before it can become ready.

## Test plan
- [ ] Management pod starts successfully without being killed by liveness probe
- [ ] Geolocation database downloads completely
- [ ] Management becomes ready (1/1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved service startup stability with adjusted health check timing to allow additional initialization time.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->