### PR TITLE
fix(netbird): add init container to cleanup corrupted geo files

### DIFF
--- a/apps/40-network/netbird/base/deployment-management.yaml
+++ b/apps/40-network/netbird/base/deployment-management.yaml
@@ -25,6 +25,18 @@ spec:
       serviceAccountName: netbird-management
       priorityClassName: vixens-medium
       initContainers:
+        - name: cleanup-corrupted-geo
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              echo "Cleaning up potentially corrupted geolocation files..."
+              rm -f /var/lib/netbird/GeoLite2-City*.mmdb /var/lib/netbird/geonames*.db 2>/dev/null || true
+              echo "Cleanup done"
+          volumeMounts:
+            - name: netbird-data
+              mountPath: /var/lib/netbird
         - name: init-config
           image: busybox:1.37
           command:


### PR DESCRIPTION
## Summary
- Add init container `cleanup-corrupted-geo` to remove corrupted geolocation files before management pod startup
- Fixes FATAL error: `invalid MaxMind DB file` caused by corrupted GeoLite2-City.mmdb on PVC

## Root Cause
The management pod was failing with:
```
FATL: could not initialize geolocation service: /var/lib/netbird/GeoLite2-City_20251230.mmdb could not be opened: error opening database: invalid MaxMind DB file
```

Previous interrupted download left a corrupted `.mmdb` file on the persistent volume. NetBird doesn't handle this gracefully.

## Solution
Add an init container that cleans up potentially corrupted geo files before the main container starts:
- Removes `GeoLite2-City*.mmdb` 
- Removes `geonames*.db`

This allows NetBird to re-download fresh copies on startup.

## Test plan
- [ ] Verify init container runs successfully
- [ ] Verify management pod starts (1/1 Running)
- [ ] Verify NetBird dashboard accessible via Authentik login

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment initialization process with automatic cleanup of potentially corrupted geolocation database files. This improvement ensures cleaner and more reliable service startups by proactively removing stale or corrupted cached data before each deployment, effectively preventing potential data inconsistencies while improving overall system stability, reliability, and operational performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->