### PR TITLE
fix(netbird): add cleanup init container to prod overlay

### DIFF
--- a/apps/40-network/netbird/overlays/prod/patches.yaml
+++ b/apps/40-network/netbird/overlays/prod/patches.yaml
@@ -64,6 +64,18 @@ spec:
   template:
     spec:
       initContainers:
+        - name: cleanup-corrupted-geo
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              echo "Cleaning up potentially corrupted geolocation files..."
+              rm -f /var/lib/netbird/GeoLite2-City*.mmdb /var/lib/netbird/geonames*.db 2>/dev/null || true
+              echo "Cleanup done"
+          volumeMounts:
+            - name: netbird-data
+              mountPath: /var/lib/netbird
         - name: init-config
           command:
             - sh


### PR DESCRIPTION
## Summary
- Add cleanup-corrupted-geo init container to prod overlay patches.yaml

## Root Cause
The prod overlay `patches.yaml` was replacing the entire initContainers list with only the `init-config` container, losing the `cleanup-corrupted-geo` container that was added in base.

This was causing the management pod to fail on startup because corrupted geolocation files were not being cleaned up.

## Test plan
- [ ] Verify kustomize build includes both init containers
- [ ] Verify management pod starts successfully
- [ ] Verify NetBird dashboard accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of corrupted geolocation data in production environments. The service now includes automatic cleanup procedures during startup to maintain data integrity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->