### PR TITLE
fix(netbird): add missing AUTH_REDIRECT_URI for prod OAuth flow

### DIFF
--- a/apps/40-network/netbird/overlays/prod/dashboard-env-patch.yaml
+++ b/apps/40-network/netbird/overlays/prod/dashboard-env-patch.yaml
@@ -8,7 +8,9 @@
 - op: replace
   path: /spec/template/spec/containers/0/env/4/value
   value: https://authentik.truxonline.com/application/o/netbird/
-- op: remove
-  path: /spec/template/spec/containers/0/env/8
-- op: remove
-  path: /spec/template/spec/containers/0/env/7
+- op: replace
+  path: /spec/template/spec/containers/0/env/7/value
+  value: https://netbird.truxonline.com/
+- op: replace
+  path: /spec/template/spec/containers/0/env/8/value
+  value: https://netbird.truxonline.com/silent-auth/


### PR DESCRIPTION
## Summary
- Fixed OAuth authentication error "Token request failed" on Netbird dashboard in prod
- Added missing `AUTH_REDIRECT_URI` and `AUTH_SILENT_REDIRECT_URI` environment variables
- The patch was incorrectly removing these variables instead of replacing them with prod values

## Test plan
- [ ] ArgoCD syncs the change
- [ ] Navigate to https://netbird.truxonline.com
- [ ] Login via Authentik should redirect back to the dashboard successfully

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dashboard configuration settings with new endpoint URLs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->