### PR TITLE
fix(netbird): use relative paths for AUTH_REDIRECT_URI

### DIFF
--- a/apps/40-network/netbird/overlays/prod/dashboard-env-patch.yaml
+++ b/apps/40-network/netbird/overlays/prod/dashboard-env-patch.yaml
@@ -10,7 +10,7 @@
   value: https://authentik.truxonline.com/application/o/netbird/
 - op: replace
   path: /spec/template/spec/containers/0/env/7/value
-  value: https://netbird.truxonline.com/
+  value: /
 - op: replace
   path: /spec/template/spec/containers/0/env/8/value
-  value: https://netbird.truxonline.com/silent-auth/
+  value: /silent-auth


### PR DESCRIPTION
## Summary
- Fixed "Redirect URI Error" on Netbird dashboard
- AUTH_REDIRECT_URI was using full URLs but the dashboard concatenates them with the domain
- Changed from `https://netbird.truxonline.com/` to `/` (relative path)

## Root cause
The dashboard builds redirect URIs as: `${domain}${AUTH_REDIRECT_URI}`
So with full URLs it became: `https://netbird.truxonline.comhttps://netbird.truxonline.com/`

## Test plan
- [ ] Navigate to https://netbird.truxonline.com
- [ ] Should redirect to Authentik login
- [ ] After login, should return to dashboard (no redirect URI error)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production environment configuration for the dashboard service routing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->