### PR TITLE
fix(netbird): use absolute URLs for AUTH_REDIRECT_URI in prod

### DIFF
--- a/apps/40-network/netbird/overlays/prod/dashboard-env-patch.yaml
+++ b/apps/40-network/netbird/overlays/prod/dashboard-env-patch.yaml
@@ -10,7 +10,7 @@
   value: https://authentik.truxonline.com/application/o/netbird/
 - op: replace
   path: /spec/template/spec/containers/0/env/7/value
-  value: /
+  value: https://netbird.truxonline.com/
 - op: replace
   path: /spec/template/spec/containers/0/env/8/value
-  value: /silent-auth
+  value: https://netbird.truxonline.com/silent-auth/


### PR DESCRIPTION
## Summary
- Fix OAuth authentication failure in NetBird dashboard on production
- The relative paths (`/` and `/silent-auth`) were causing OIDC library to fail

## Changes
- `AUTH_REDIRECT_URI`: `/` → `https://netbird.truxonline.com/`
- `AUTH_SILENT_REDIRECT_URI`: `/silent-auth` → `https://netbird.truxonline.com/silent-auth/`

## Root Cause
The OIDC library in NetBird dashboard requires absolute URLs for redirect URIs. Using relative paths caused the token exchange to fail with `code: undefined`.

## Test plan
- [ ] Verify dashboard loads without authentication errors
- [ ] Verify login flow redirects to Authentik correctly
- [ ] Verify successful authentication returns to dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production dashboard endpoint URLs to use explicit NetBird domain addresses for improved routing configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->