### PR TITLE
fix(netbird): relay env prefixes

### DIFF
--- a/apps/40-network/netbird/base/signal-relay.yaml
+++ b/apps/40-network/netbird/base/signal-relay.yaml
@@ -59,6 +59,10 @@ spec:
         - name: relay
           image: netbirdio/relay:0.62.2
           env:
+            - name: NB_RELAY_PORT
+              value: "33080"
+            - name: NB_RELAY_EXPOSED_ADDRESS
+              value: "netbird-relay.truxonline.com:443"
             - name: NETBIRD_RELAY_PORT
               value: "33080"
             - name: NETBIRD_RELAY_EXPOSED_ADDRESS

--- a/apps/40-network/netbird/overlays/dev/patches.yaml
+++ b/apps/40-network/netbird/overlays/dev/patches.yaml
@@ -52,6 +52,8 @@ spec:
       containers:
         - name: relay
           env:
+            - name: NB_RELAY_EXPOSED_ADDRESS
+              value: "netbird-relay.dev.truxonline.com:443"
             - name: NETBIRD_RELAY_EXPOSED_ADDRESS
               value: "netbird-relay.dev.truxonline.com:443"
 ---

--- a/apps/40-network/netbird/overlays/prod/patches.yaml
+++ b/apps/40-network/netbird/overlays/prod/patches.yaml
@@ -51,6 +51,8 @@ spec:
       containers:
         - name: relay
           env:
+            - name: NB_RELAY_EXPOSED_ADDRESS
+              value: "netbird-relay.truxonline.com:443"
             - name: NETBIRD_RELAY_EXPOSED_ADDRESS
               value: "netbird-relay.truxonline.com:443"
 ---


### PR DESCRIPTION
Supports both NB_ and NETBIRD_ environment prefixes for the Relay service to ensure compatibility.