### PR TITLE
fix(netbird): force SSL_CERT_FILE for Go app

### DIFF
--- a/apps/40-network/netbird/base/management.yaml
+++ b/apps/40-network/netbird/base/management.yaml
@@ -27,6 +27,18 @@ spec:
               value: "https://authentik.dev.truxonline.com/application/o/netbird/"
             - name: AUTH_KEYS_LOCATION
               value: "http://authentik.auth.svc.cluster.local:9000/application/o/netbird/jwks/"
+            - name: AUTH_CLIENT_ID
+              value: "netbird"
+            - name: AUTH_AUDIENCE
+              value: "netbird"
+            - name: AUTH_AUTHORIZATION_ENDPOINT
+              value: "https://authentik.dev.truxonline.com/application/o/authorize/"
+            - name: AUTH_DEVICE_AUTH_ENDPOINT
+              value: "https://authentik.dev.truxonline.com/application/o/device/"
+            - name: AUTH_TOKEN_ENDPOINT
+              value: "https://authentik.dev.truxonline.com/application/o/token/"
+            - name: AUTH_OIDC_CONFIG_ENDPOINT
+              value: "https://authentik.dev.truxonline.com/application/o/netbird/.well-known/openid-configuration"
           command:
             - sh
             - -c
@@ -36,9 +48,33 @@ spec:
                 "HttpConfig": {
                   "Address": ":80",
                   "AuthIssuer": "$AUTH_ISSUER",
-                  "AuthAudience": "netbird",
+                  "AuthAudience": "$AUTH_AUDIENCE",
                   "AuthKeysLocation": "$AUTH_KEYS_LOCATION",
+                  "OIDCConfigEndpoint": "$AUTH_OIDC_CONFIG_ENDPOINT",
                   "IdpSignKeyRefreshEnabled": true
+                },
+                "DeviceAuthorizationFlow": {
+                  "Provider": "hosted",
+                  "ProviderConfig": {
+                    "ClientID": "$AUTH_CLIENT_ID",
+                    "AuthorizationEndpoint": "$AUTH_AUTHORIZATION_ENDPOINT",
+                    "DeviceAuthEndpoint": "$AUTH_DEVICE_AUTH_ENDPOINT",
+                    "TokenEndpoint": "$AUTH_TOKEN_ENDPOINT",
+                    "Scope": "openid profile email offline_access",
+                    "Audience": "$AUTH_AUDIENCE",
+                    "UseIDToken": true
+                  }
+                },
+                "PKCEAuthorizationFlow": {
+                  "Provider": "hosted",
+                  "ProviderConfig": {
+                    "ClientID": "$AUTH_CLIENT_ID",
+                    "AuthorizationEndpoint": "$AUTH_AUTHORIZATION_ENDPOINT",
+                    "TokenEndpoint": "$AUTH_TOKEN_ENDPOINT",
+                    "Scope": "openid profile email offline_access",
+                    "Audience": "$AUTH_AUDIENCE",
+                    "UseIDToken": true
+                  }
                 },
                 "DatastoreConfig": {
                   "Engine": "postgres"
@@ -62,6 +98,8 @@ spec:
                   key: POSTGRES_PASSWORD
             - name: NETBIRD_STORE_ENGINE_POSTGRES_DSN
               value: "host=postgresql-shared-rw.databases.svc.cluster.local user=netbird password=$(NB_POSTGRES_PASSWORD) dbname=netbird port=5432 sslmode=disable"
+            - name: SSL_CERT_FILE
+              value: "/etc/ssl/certs/ca-certificates.crt"
           ports:
             - containerPort: 80
               name: http


### PR DESCRIPTION
Added SSL_CERT_FILE env var to point to the mounted CA bundle containing the Staging Root CA. This forces the Go application to use the custom trust store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OpenID Connect (OIDC) authentication with multiple authorization flows including Device Authorization and PKCE
  * Improved SSL/TLS certificate handling with dynamic CA certificate configuration support

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->