### PR TITLE
fix(netbird): use external HTTPS for Dashboard OIDC

### DIFF
--- a/apps/40-network/netbird/overlays/dev/patches.yaml
+++ b/apps/40-network/netbird/overlays/dev/patches.yaml
@@ -19,7 +19,7 @@ spec:
             - name: NETBIRD_STORE_ENGINE_POSTGRES_DSN
               value: "host=postgresql-shared-rw.databases.svc.cluster.local user=netbird password=$(NB_POSTGRES_PASSWORD) dbname=netbird port=5432 sslmode=disable"
             - name: NETBIRD_AUTH_OIDC_CONFIGURATION_ENDPOINT
-              value: "http://authentik.auth.svc.cluster.local:9000/application/o/netbird/.well-known/openid-configuration"
+              value: "https://authentik.dev.truxonline.com/application/o/netbird/.well-known/openid-configuration"
             - name: NETBIRD_AUTH_AUDIENCE
               value: "netbird"
             - name: NETBIRD_AUTH_CLIENT_ID
@@ -72,9 +72,9 @@ spec:
             - name: AUTH_CLIENT_ID
               value: "netbird"
             - name: AUTH_AUTHORITY
-              value: "http://authentik.auth.svc.cluster.local:9000/application/o/netbird/"
+              value: "https://authentik.dev.truxonline.com/application/o/netbird/"
             - name: NETBIRD_AUTH_OIDC_CONFIGURATION_ENDPOINT
-              value: "http://authentik.auth.svc.cluster.local:9000/application/o/netbird/.well-known/openid-configuration"
+              value: "https://authentik.dev.truxonline.com/application/o/netbird/.well-known/openid-configuration"
             - name: AUTH_SUPPORTED_SCOPES
               value: "openid profile email offline_access"
             - name: NETBIRD_MGMT_API_ENDPOINT


### PR DESCRIPTION
Changed Dashboard OIDC authority to external HTTPS URL to allow browser-side authentication.