### PR TITLE
fix(whoami): resolve namespace sync conflict

### DIFF
--- a/apps/99-test/whoami/base/namespace.yaml
+++ b/apps/99-test/whoami/base/namespace.yaml
@@ -4,6 +4,5 @@ kind: Namespace
 metadata:
   name: whoami
   labels:
-    environment: dev
     goldilocks.fairwinds.com/enabled: "true"
     pod-security.kubernetes.io/enforce: baseline

--- a/apps/99-test/whoami/overlays/dev/kustomization.yaml
+++ b/apps/99-test/whoami/overlays/dev/kustomization.yaml
@@ -8,13 +8,7 @@ resources:
 
 
 patches:
-  - patch: |
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: whoami
-      labels:
-        environment: dev
+
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/99-test/whoami/overlays/prod/kustomization.yaml
+++ b/apps/99-test/whoami/overlays/prod/kustomization.yaml
@@ -5,11 +5,4 @@ resources:
   - ../../base
   - ingress.yaml
 
-patches:
-  - patch: |
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: whoami
-      labels:
-        environment: prod
+

--- a/argocd/overlays/dev/apps/whoami.yaml
+++ b/argocd/overlays/dev/apps/whoami.yaml
@@ -22,4 +22,4 @@ spec:
       prune: true
       selfHeal: true
     syncOptions:
-      - CreateNamespace=true
+      - CreateNamespace=false


### PR DESCRIPTION
Disabled CreateNamespace in ArgoCD to allow explicit Namespace resource management without OutOfSync errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic namespace creation in the development environment configuration.
  * Removed environment-specific labels from namespace metadata configurations across development and production overlays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->