### PR TITLE
fix(kyverno): stabilization and audit-only mode

### DIFF
--- a/apps/00-infra/kyverno/base/policies/add-default-labels.yaml
+++ b/apps/00-infra/kyverno/base/policies/add-default-labels.yaml
@@ -12,6 +12,7 @@ metadata:
       Mutates resources to add default labels for consistency.
       Adds 'managed-by: kyverno' label if not present.
 spec:
+  validationFailureAction: Audit
   background: true
   rules:
     - name: add-managed-by-label
@@ -28,8 +29,9 @@ spec:
               namespaces:
                 - kube-system
                 - kyverno
-      mutate:
-        patchStrategicMerge:
+      validate:
+        message: "Resource should have app.kubernetes.io/managed-by label."
+        pattern:
           metadata:
             labels:
-              +(app.kubernetes.io/managed-by): argocd
+              app.kubernetes.io/managed-by: "*?"

--- a/apps/00-infra/kyverno/base/policies/require-storage-strategy.yaml
+++ b/apps/00-infra/kyverno/base/policies/require-storage-strategy.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/description: >-
       Ensures that Dev uses disposable storage (delete) and Prod uses persistent storage (retain).
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: check-dev-storage

--- a/argocd/overlays/dev/apps/kyverno.yaml
+++ b/argocd/overlays/dev/apps/kyverno.yaml
@@ -113,7 +113,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
-      selfHeal: true
+      selfHeal: false
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/argocd/overlays/prod/apps/kyverno.yaml
+++ b/argocd/overlays/prod/apps/kyverno.yaml
@@ -113,7 +113,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
-      selfHeal: true
+      selfHeal: false
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true


### PR DESCRIPTION
Converted all Kyverno policies to strict Audit mode, disabled label mutation, and turned off selfHeal on Kyverno ArgoCD apps to prevent sync loops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kyverno policy now validates that cluster resources include required managed-by labels in audit mode.

* **Bug Fixes**
  * Corrected Kyverno policy configuration format.

* **Chores**
  * Disabled ArgoCD self-healing for Kyverno deployments in dev and prod environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->