### PR TITLE
fix(loki): kustomization syntax error

### DIFF
--- a/apps/02-monitoring/loki/overlays/dev/kustomization.yaml
+++ b/apps/02-monitoring/loki/overlays/dev/kustomization.yaml
@@ -12,8 +12,8 @@ patches:
       kind: Namespace
       metadata:
         name: monitoring
-      labels:
-        environment: dev
+        labels:
+          environment: dev
   - patch: |-
       apiVersion: apps/v1
       kind: StatefulSet

--- a/apps/02-monitoring/loki/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/loki/overlays/prod/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
       kind: Namespace
       metadata:
         name: monitoring
-      labels:
-        environment: prod
+        labels:
+          environment: prod


### PR DESCRIPTION
Fixed malformed namespace labels in kustomization.yaml that was causing sync issues.