### PR TITLE
fix(shared): complete namespace centralization

### DIFF
--- a/apps/02-monitoring/loki/overlays/dev/kustomization.yaml
+++ b/apps/02-monitoring/loki/overlays/dev/kustomization.yaml
@@ -4,20 +4,11 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
-
-
 patches:
-  - patch: |
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: monitoring
-        labels:
-          environment: dev
-  - patch: |-
-      apiVersion: apps/v1
-      kind: StatefulSet
-      metadata:
-        name: loki
-      spec:
-        replicas: 0
+  - target:
+      kind: Deployment
+      name: loki
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 0

--- a/apps/02-monitoring/loki/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/loki/overlays/prod/kustomization.yaml
@@ -9,13 +9,3 @@ patches:
     target:
       kind: InfisicalSecret
       name: loki-secrets-sync
-  - patch: |
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: monitoring
-        labels:
-          environment: prod
-resources:
-  - ../../base
-  - ingress.yaml

--- a/apps/02-monitoring/prometheus/overlays/dev/kustomization.yaml
+++ b/apps/02-monitoring/prometheus/overlays/dev/kustomization.yaml
@@ -7,13 +7,6 @@ commonLabels:
 resources:
   - ../../base
 patches:
-  - patch: |
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: monitoring
-        labels:
-          environment: dev
   - target:
       kind: StatefulSet
       name: prometheus-alertmanager

--- a/apps/02-monitoring/promtail/overlays/dev/kustomization.yaml
+++ b/apps/02-monitoring/promtail/overlays/dev/kustomization.yaml
@@ -5,11 +5,3 @@ namespace: monitoring
 resources:
   - ../../base
   - ingress.yaml
-patches:
-  - patch: |
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: monitoring
-        labels:
-          environment: dev

--- a/apps/02-monitoring/promtail/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/promtail/overlays/prod/kustomization.yaml
@@ -5,16 +5,6 @@ commonLabels:
 kind: Kustomization
 namespace: monitoring
 patches:
-  - patch: |
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: monitoring
-        labels:
-          environment: prod
-  - patch: |
-      - op: replace
-        path: /spec/authentication/universalAuth/secretsScope/envSlug
         value: prod
       - op: add
         path: /spec/managedSecretReference/secretNamespace

--- a/apps/20-media/frigate/base/kustomization.yaml
+++ b/apps/20-media/frigate/base/kustomization.yaml
@@ -3,7 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: media
 resources:
-  - namespace.yaml
   - deployment.yaml
   - service.yaml
   - ingressroute-tcp.yaml

--- a/apps/20-media/frigate/base/namespace.yaml
+++ b/apps/20-media/frigate/base/namespace.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: media
-  labels:
-    goldilocks.fairwinds.com/enabled: "true"
-    pod-security.kubernetes.io/enforce: privileged

--- a/apps/20-media/frigate/overlays/prod/pvc-patch.yaml
+++ b/apps/20-media/frigate/overlays/prod/pvc-patch.yaml
@@ -7,10 +7,3 @@ spec:
   resources:
     requests:
       storage: 50Gi
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: media
-  labels:
-    environment: prod


### PR DESCRIPTION
Removed remaining namespace.yaml and patches from frigate, loki, promtail, and prometheus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined monitoring and media application configurations by removing redundant namespace patches across multiple overlays.
  * Consolidated Loki deployment to use a single targeted patch for replica configuration.
  * Centralized namespace management for monitoring applications (Prometheus, Promtail, Loki) and Frigate media application.
  * Removed duplicate namespace resource files and inline namespace creation patches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->