### PR TITLE
fix(infisical): restore ownerReferences for secrets

### DIFF
--- a/apps/20-media/hydrus-client/base/infisical-secret.yaml
+++ b/apps/20-media/hydrus-client/base/infisical-secret.yaml
@@ -7,6 +7,7 @@ spec:
   hostAPI: http://192.168.111.69:8085
   managedSecretReference:
     secretName: hydrus-client-secrets
+    creationPolicy: Owner
     secretNamespace: media
   authentication:
     universalAuth:

--- a/apps/20-media/hydrus-client/base/litestream-secret.yaml
+++ b/apps/20-media/hydrus-client/base/litestream-secret.yaml
@@ -7,6 +7,7 @@ spec:
   hostAPI: http://192.168.111.69:8085
   managedSecretReference:
     secretName: litestream-shared-secrets
+    creationPolicy: Owner
     secretNamespace: media
   authentication:
     universalAuth:

--- a/apps/20-media/mylar/base/infisical-secret.yaml
+++ b/apps/20-media/mylar/base/infisical-secret.yaml
@@ -7,6 +7,7 @@ spec:
   hostAPI: http://192.168.111.69:8085
   managedSecretReference:
     secretName: mylar-secrets
+    creationPolicy: Owner
     secretNamespace: media
   authentication:
     universalAuth:

--- a/apps/20-media/whisparr/base/infisical-secret.yaml
+++ b/apps/20-media/whisparr/base/infisical-secret.yaml
@@ -7,6 +7,7 @@ spec:
   hostAPI: http://192.168.111.69:8085
   managedSecretReference:
     secretName: whisparr-secrets
+    creationPolicy: Owner
     secretNamespace: media
   authentication:
     universalAuth:

--- a/apps/40-network/netbird/base/infra.yaml
+++ b/apps/40-network/netbird/base/infra.yaml
@@ -30,4 +30,5 @@ spec:
         secretsPath: /apps/40-network/netbird
   managedSecretReference:
     secretName: netbird-secrets
+    creationPolicy: Owner
     secretNamespace: networking

--- a/argocd/overlays/prod/apps/hydrus-client.yaml
+++ b/argocd/overlays/prod/apps/hydrus-client.yaml
@@ -15,6 +15,17 @@ spec:
     path: apps/20-media/hydrus-client/overlays/prod
     repoURL: https://github.com/charchess/vixens.git
     targetRevision: prod-stable
+  ignoreDifferences:
+    - group: ""
+      kind: Secret
+      name: litestream-shared-secrets
+      jsonPointers:
+        - /data
+    - group: ""
+      kind: Secret
+      name: hydrus-client-secrets
+      jsonPointers:
+        - /data
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
Added creationPolicy: Owner to InfisicalSecret bases. This fixes ArgoCD OutOfSync by ensuring Secrets have correct ownerReferences.