### PR TITLE
fix(gluetun): restore namespace directive

### DIFF
--- a/apps/60-services/gluetun/base/kustomization.yaml
+++ b/apps/60-services/gluetun/base/kustomization.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: services
 resources:
   - infisical-secret.yaml
   - deployment.yaml


### PR DESCRIPTION
Restored 'namespace: services' in gluetun base kustomization which was accidentally removed.