### PR TITLE
fix(shared): restore pod security for services

### DIFF
--- a/apps/_shared/namespaces/downloads/base/namespace.yaml
+++ b/apps/_shared/namespaces/downloads/base/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   name: downloads
   labels:
     goldilocks.fairwinds.com/enabled: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/apps/_shared/namespaces/services/base/namespace.yaml
+++ b/apps/_shared/namespaces/services/base/namespace.yaml
@@ -4,5 +4,7 @@ kind: Namespace
 metadata:
   name: services
   labels:
-    pod-security.kubernetes.io/enforce: privileged
     goldilocks.fairwinds.com/enabled: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
Added privileged labels to 'services' namespace to allow Gluetun (NET_ADMIN) to run.