### PR TITLE
fix(shared): restore missing auth namespace

### DIFF
--- a/apps/_shared/namespaces/auth/base/kustomization.yaml
+++ b/apps/_shared/namespaces/auth/base/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/apps/_shared/namespaces/auth/base/namespace.yaml
+++ b/apps/_shared/namespaces/auth/base/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: auth
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"


### PR DESCRIPTION
Restored the auth namespace directory which was missing in the previous merges.