### PR TITLE
fix(promtail): fix health probes

### DIFF
--- a/apps/02-monitoring/promtail/base/daemonset.yaml
+++ b/apps/02-monitoring/promtail/base/daemonset.yaml
@@ -39,7 +39,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /ready
-              port: http-metrics
+              port: 9080
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 1
@@ -47,7 +47,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /ready
-              port: http-metrics
+              port: 9080
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 1


### PR DESCRIPTION
Fixed invalid port syntax in health probes by using numeric port 9080.