### PR TITLE
fix(infisical): add priority class

### DIFF
--- a/argocd/overlays/prod/apps/infisical-operator.yaml
+++ b/argocd/overlays/prod/apps/infisical-operator.yaml
@@ -22,13 +22,14 @@ spec:
             image:
               repository: infisical/kubernetes-operator
               tag: v0.10.1
+            priorityClassName: vixens-critical
             resources:
               limits:
                 cpu: 500m
                 memory: 256Mi
               requests:
-                cpu: 100m
-                memory: 128Mi
+                cpu: 10m
+                memory: 64Mi
           kubeRbacProxy:
             image:
               repository: gcr.io/kubebuilder/kube-rbac-proxy
@@ -38,8 +39,8 @@ spec:
                 cpu: 100m
                 memory: 64Mi
               requests:
-                cpu: 50m
-                memory: 32Mi
+                cpu: 5m
+                memory: 16Mi
           tolerations:
             - key: node-role.kubernetes.io/control-plane
               operator: Exists


### PR DESCRIPTION
Added 'vixens-critical' priority class to infisical-operator to help scheduling on saturated cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized resource allocation for improved efficiency by reducing memory and CPU requests.
  * Added priority class designation to ensure critical operations maintain appropriate scheduling priority.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->