### PR TITLE
fix(scripts): ensure validate.py skips scripts toolset

### DIFF
--- a/scripts/validation/validate.py
+++ b/scripts/validation/validate.py
@@ -10,10 +10,13 @@ def run_cmd(cmd):
 
 def validate_app(app_name, env):
     print(f"🔍 Validating {app_name} in {env}...")
+    if app_name == "scripts":
+        print("✅ Validation skipped for 'scripts' toolset")
+        return True
     import os
     kubeconfig = os.getenv("KUBECONFIG")
     if not kubeconfig:
-        kubeconfig = f"terraform/environments/{env}/kubeconfig-{env}"
+        kubeconfig = f".secrets/{env}/kubeconfig-{env}"
     
     # 1. Pod Status
     extra_opts = ""


### PR DESCRIPTION
Ensure the validation script doesn't fail when checking the non-pod 'scripts' toolset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation logic to properly handle special application cases during configuration validation.

* **Chores**
  * Updated default configuration path resolution for authentication credentials, improving deployment setup consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->