### PR TITLE
fix(docspell): add missing secretNamespace to InfisicalSecret

### DIFF
--- a/apps/60-services/docspell/base/db-credentials-secret.yaml
+++ b/apps/60-services/docspell/base/db-credentials-secret.yaml
@@ -18,4 +18,5 @@ spec:
         secretsPath: /apps/60-services/docspell
   managedSecretReference:
     secretName: docspell-db-credentials
+    secretNamespace: services
     creationPolicy: Owner

--- a/apps/60-services/docspell/base/infisical-secret.yaml
+++ b/apps/60-services/docspell/base/infisical-secret.yaml
@@ -18,4 +18,5 @@ spec:
         secretsPath: /apps/60-services/docspell
   managedSecretReference:
     secretName: docspell-secrets
+    secretNamespace: services
     creationPolicy: Owner


### PR DESCRIPTION
Add required secretNamespace field to docspell InfisicalSecret resources to resolve validation error in dev.