### PR TITLE
fix(homeassistant): memory limits for OOM prevention

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -157,11 +157,11 @@ spec:
               mountPath: /config
           resources:
             requests:
-              cpu: 500m
-              memory: 2048Mi
+              cpu: 100m
+              memory: 512Mi
             limits:
-              cpu: 2000m
-              memory: 4096Mi
+              cpu: 1000m
+              memory: 1Gi
         - name: filebrowser
           image: filebrowser/filebrowser:v2.55.0
           ports:

--- a/apps/10-home/homeassistant/overlays/prod/resources-patch.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/resources-patch.yaml
@@ -7,19 +7,11 @@ spec:
   template:
     spec:
       containers:
-        - name: filebrowser
-          resources:
-            limits:
-              cpu: 500m
-              memory: 128Mi
-            requests:
-              cpu: 11m
-              memory: 64Mi
         - name: homeassistant
           resources:
-            limits:
-              cpu: 572m
-              memory: 2930Mi
             requests:
-              cpu: 143m
-              memory: 1500Mi
+              cpu: 500m
+              memory: 2Gi
+            limits:
+              cpu: 2000m
+              memory: 4Gi


### PR DESCRIPTION
Sets Prod to 4Gi limit, Base to 1Gi limit.