### PR TITLE
fix(renovate): fix duplicate dashboard labels

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "dependencyDashboard": true,
   "dependencyDashboardTitle": "📦 Dependency Dashboard - Control Tower",
   "dependencyDashboardAutoclose": true,
+  "dependencyDashboardLabels": ["dependencies", "renovate"],
   "baseBranches": ["main"],
   "gitAuthor": "Renovate Bot <renovate@vixens.local>",
   "platformAutomerge": true,


### PR DESCRIPTION
Ensures the dependency dashboard is correctly labeled so Renovate can find it.