### PR TITLE
chore(descheduler): activate real eviction mode

### DIFF
--- a/apps/02-monitoring/descheduler/base/descheduler-gen.yaml
+++ b/apps/02-monitoring/descheduler/base/descheduler-gen.yaml
@@ -225,7 +225,7 @@ spec:
               args:
                 - --policy-config-file=/policy-dir/policy.yaml
                 - --v=3
-                - --dry-run=true
+                - --dry-run=false
               livenessProbe:
                 failureThreshold: 3
                 httpGet:


### PR DESCRIPTION
Activate real eviction mode for descheduler by setting dry-run to false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled active workload rescheduling in the descheduler. The system will now actively reschedule workloads according to configured policies instead of simulating actions in test mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->