### PR TITLE
feat(dev): global hibernation of non-critical applications

### DIFF
--- a/apps/60-services/docspell/overlays/dev/kustomization.yaml
+++ b/apps/60-services/docspell/overlays/dev/kustomization.yaml
@@ -4,3 +4,12 @@ kind: Kustomization
 namespace: services
 resources:
   - ../../base
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: docspell
+      spec:
+        replicas: 0

--- a/apps/70-tools/headlamp/overlays/dev/kustomization.yaml
+++ b/apps/70-tools/headlamp/overlays/dev/kustomization.yaml
@@ -4,3 +4,12 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: headlamp
+      spec:
+        replicas: 0

--- a/apps/70-tools/it-tools/overlays/dev/kustomization.yaml
+++ b/apps/70-tools/it-tools/overlays/dev/kustomization.yaml
@@ -5,3 +5,12 @@ namespace: tools
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: it-tools
+      spec:
+        replicas: 0

--- a/apps/70-tools/renovate/overlays/dev/kustomization.yaml
+++ b/apps/70-tools/renovate/overlays/dev/kustomization.yaml
@@ -5,6 +5,13 @@ namespace: tools
 resources:
   - ../../base
 patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: renovate
+      spec:
+        replicas: 0
   - path: patch-infisical-env.yaml
 # Testing schedule removed - back to 6-hour schedule from base
 

--- a/apps/70-tools/stirling-pdf/overlays/dev/kustomization.yaml
+++ b/apps/70-tools/stirling-pdf/overlays/dev/kustomization.yaml
@@ -5,3 +5,12 @@ namespace: tools
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: stirling-pdf
+      spec:
+        replicas: 0

--- a/apps/99-test/farmos/overlays/dev/kustomization.yaml
+++ b/apps/99-test/farmos/overlays/dev/kustomization.yaml
@@ -6,3 +6,12 @@ resources:
   - ../../base
 commonLabels:
   environment: dev
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: farmos
+      spec:
+        replicas: 0

--- a/apps/99-test/tandoor/overlays/dev/kustomization.yaml
+++ b/apps/99-test/tandoor/overlays/dev/kustomization.yaml
@@ -6,3 +6,12 @@ resources:
   - ../../base
 commonLabels:
   environment: dev
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: tandoor
+      spec:
+        replicas: 0

--- a/apps/99-test/whoami/overlays/dev/kustomization.yaml
+++ b/apps/99-test/whoami/overlays/dev/kustomization.yaml
@@ -8,6 +8,13 @@ resources:
 
 
 patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: whoami
+      spec:
+        replicas: 0
 
   - patch: |-
       apiVersion: apps/v1


### PR DESCRIPTION
Set replicas to 0 for all non-critical applications in dev environment to conserve resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Multiple services in the development environment have been scaled down for resource optimization, including DocSpell, Headlamp, IT-Tools, Renovate, Stirling-PDF, Farmos, Tandoor, and Whoami.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->