### PR TITLE
fix(homeassistant): increase init-containers memory limits

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/resources-patch.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/resources-patch.yaml
@@ -6,6 +6,23 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+        - name: restore-config
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 512Mi
+        - name: restore-db
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 512Mi
       containers:
         - name: homeassistant
           resources:


### PR DESCRIPTION
## Description
This PR increases the memory limits for Home Assistant init-containers (`restore-config` and `restore-db`) from 128Mi to 512Mi.

## Context
The production Home Assistant instance was stuck in a `CrashLoopBackOff` due to `OOMKilled` errors during the configuration restoration phase. This prevented the application from starting and caused integrations (like Shelly) to fail due to bootstrap timeouts.

## Changes
- Updated `apps/10-home/homeassistant/overlays/prod/resources-patch.yaml` to include resource limits for init-containers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated deployment configuration with two initialization stages, each configured with defined resource allocations (CPU requests: 50m, limits: 200m; memory requests: 128Mi, limits: 512Mi) to execute prior to application startup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->