### PR TITLE
feat(infra): global revisionHistoryLimit patch

### DIFF
--- a/apps/00-infra/argocd/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/argocd/overlays/dev/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/argocd/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/argocd/overlays/prod/kustomization.yaml
@@ -5,3 +5,11 @@ namespace: argocd
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/argocd/overlays/staging/kustomization.yaml
+++ b/apps/00-infra/argocd/overlays/staging/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/argocd/overlays/test/kustomization.yaml
+++ b/apps/00-infra/argocd/overlays/test/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/cert-manager-webhook-gandi/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/overlays/dev/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 namespace: cert-manager
 resources:
   - ../../base
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/cert-manager-webhook-gandi/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/overlays/prod/kustomization.yaml
@@ -3,6 +3,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cert-manager
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: gandi-infisical-secret-patch.yaml
     target:
       kind: InfisicalSecret

--- a/apps/00-infra/cert-manager-webhook-gandi/overlays/staging/kustomization.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/overlays/staging/kustomization.yaml
@@ -5,6 +5,12 @@ namespace: cert-manager
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: gandi-infisical-secret-patch.yaml
     target:
       kind: InfisicalSecret

--- a/apps/00-infra/cert-manager-webhook-gandi/overlays/test/kustomization.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/overlays/test/kustomization.yaml
@@ -5,6 +5,12 @@ namespace: cert-manager
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: gandi-infisical-secret-patch.yaml
     target:
       kind: InfisicalSecret

--- a/apps/00-infra/cert-manager/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/cert-manager/overlays/dev/kustomization.yaml
@@ -7,3 +7,11 @@ resources:
   - cluster-issuer-prod.yaml
 # Note: gandi-credentials Secret déployé manuellement (hors GitOps)
 # car contient API key sensible
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/cert-manager/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/cert-manager/overlays/prod/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 namespace: cert-manager
 resources:
   - cluster-issuer-prod.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/cert-manager/overlays/staging/kustomization.yaml
+++ b/apps/00-infra/cert-manager/overlays/staging/kustomization.yaml
@@ -6,3 +6,11 @@ resources:
   - cluster-issuer-staging.yaml
 # Note: gandi-credentials Secret déployé manuellement (hors GitOps)
 # car contient API key sensible
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/cert-manager/overlays/test/kustomization.yaml
+++ b/apps/00-infra/cert-manager/overlays/test/kustomization.yaml
@@ -7,3 +7,11 @@ resources:
   - cluster-issuer-prod.yaml
 # Note: gandi-credentials Secret déployé manuellement (hors GitOps)
 # car contient API key sensible
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/cilium-lb/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/cilium-lb/overlays/dev/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - ippool.yaml
   - l2policy.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/cilium-lb/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - ippool.yaml
   - l2policy.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/cilium-lb/overlays/staging/kustomization.yaml
+++ b/apps/00-infra/cilium-lb/overlays/staging/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - ippool.yaml
   - l2policy.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/cilium-lb/overlays/test/kustomization.yaml
+++ b/apps/00-infra/cilium-lb/overlays/test/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - ippool.yaml
   - l2policy.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/kubernetes-dashboard/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/kubernetes-dashboard/overlays/dev/kustomization.yaml
@@ -6,3 +6,11 @@ resources:
   - ../../base
   - ingress.yaml
   - transport.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/kubernetes-dashboard/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/kubernetes-dashboard/overlays/prod/kustomization.yaml
@@ -5,3 +5,11 @@ namespace: kubernetes-dashboard
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/metrics-server/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/metrics-server/overlays/dev/kustomization.yaml
@@ -4,6 +4,12 @@ kind: Kustomization
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |
       - op: add
         path: /spec/template/spec/containers/0/resources

--- a/apps/00-infra/metrics-server/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/metrics-server/overlays/prod/kustomization.yaml
@@ -2,6 +2,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |
       - op: add
         path: /spec/template/spec/containers/0/resources

--- a/apps/00-infra/policy-reporter/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/policy-reporter/overlays/dev/kustomization.yaml
@@ -8,3 +8,11 @@ labels:
   - includeSelectors: false
     pairs:
       environment: dev
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/policy-reporter/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/policy-reporter/overlays/prod/kustomization.yaml
@@ -8,3 +8,11 @@ labels:
   - includeSelectors: false
     pairs:
       environment: prod
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/reloader/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/reloader/overlays/dev/kustomization.yaml
@@ -3,3 +3,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/reloader/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/reloader/overlays/prod/kustomization.yaml
@@ -3,3 +3,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/traefik-dashboard/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/traefik-dashboard/overlays/dev/kustomization.yaml
@@ -5,3 +5,11 @@ resources:
   - ../../base
   - certificate.yaml
   - ingressroute.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/traefik-dashboard/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/traefik-dashboard/overlays/prod/kustomization.yaml
@@ -5,3 +5,11 @@ resources:
   - ../../base
   - certificate.yaml
   - ingressroute.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/traefik-dashboard/overlays/staging/kustomization.yaml
+++ b/apps/00-infra/traefik-dashboard/overlays/staging/kustomization.yaml
@@ -5,3 +5,11 @@ resources:
   - ../../base
   - certificate.yaml
   - ingressroute.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/traefik-dashboard/overlays/test/kustomization.yaml
+++ b/apps/00-infra/traefik-dashboard/overlays/test/kustomization.yaml
@@ -5,3 +5,11 @@ resources:
   - ../../base
   - certificate.yaml
   - ingressroute.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/vpa/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/vpa/overlays/dev/kustomization.yaml
@@ -3,3 +3,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/00-infra/vpa/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/vpa/overlays/prod/kustomization.yaml
@@ -3,3 +3,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/01-storage/nfs-storage/overlays/dev/kustomization.yaml
+++ b/apps/01-storage/nfs-storage/overlays/dev/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 namespace: nfs-storage
 resources:
   - ../../base
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/01-storage/nfs-storage/overlays/prod/kustomization.yaml
+++ b/apps/01-storage/nfs-storage/overlays/prod/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 namespace: nfs-storage
 resources:
   - ../../base
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/01-storage/nfs-storage/overlays/staging/kustomization.yaml
+++ b/apps/01-storage/nfs-storage/overlays/staging/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 namespace: nfs-storage
 resources:
   - ../../base
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/01-storage/synology-csi/infisical/overlays/dev/kustomization.yaml
+++ b/apps/01-storage/synology-csi/infisical/overlays/dev/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 namespace: synology-csi
 resources:
   - ../../base
+
+patches:
+  - path: ../../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/01-storage/synology-csi/infisical/overlays/prod/kustomization.yaml
+++ b/apps/01-storage/synology-csi/infisical/overlays/prod/kustomization.yaml
@@ -3,6 +3,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: synology-csi
 patches:
+  - path: ../../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: synology-infisical-secret-patch.yaml
     target:
       kind: InfisicalSecret

--- a/apps/01-storage/synology-csi/infisical/overlays/staging/kustomization.yaml
+++ b/apps/01-storage/synology-csi/infisical/overlays/staging/kustomization.yaml
@@ -5,6 +5,12 @@ namespace: synology-csi
 resources:
   - ../../base
 patches:
+  - path: ../../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: synology-infisical-secret-patch.yaml
     target:
       kind: InfisicalSecret

--- a/apps/01-storage/synology-csi/infisical/overlays/test/kustomization.yaml
+++ b/apps/01-storage/synology-csi/infisical/overlays/test/kustomization.yaml
@@ -5,6 +5,12 @@ namespace: synology-csi
 resources:
   - ../../base
 patches:
+  - path: ../../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: synology-infisical-secret-patch.yaml
     target:
       kind: InfisicalSecret

--- a/apps/01-storage/synology-csi/overlays/dev/kustomization.yaml
+++ b/apps/01-storage/synology-csi/overlays/dev/kustomization.yaml
@@ -5,6 +5,12 @@ namespace: synology-csi
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   # Patch du storage class pour dev
   - target:
       kind: StorageClass

--- a/apps/01-storage/synology-csi/overlays/prod/kustomization.yaml
+++ b/apps/01-storage/synology-csi/overlays/prod/kustomization.yaml
@@ -7,6 +7,12 @@ labels:
       vixens.lab/environment: prod
 namespace: synology-csi
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       - op: replace
         path: /parameters/igroup

--- a/apps/01-storage/synology-csi/overlays/staging/kustomization.yaml
+++ b/apps/01-storage/synology-csi/overlays/staging/kustomization.yaml
@@ -5,6 +5,12 @@ namespace: synology-csi
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   # Patch du storage class pour staging
   - target:
       kind: StorageClass

--- a/apps/01-storage/synology-csi/overlays/test/kustomization.yaml
+++ b/apps/01-storage/synology-csi/overlays/test/kustomization.yaml
@@ -5,6 +5,12 @@ namespace: synology-csi
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   # Patch du storage class pour test
   - target:
       kind: StorageClass

--- a/apps/02-monitoring/descheduler/overlays/dev/kustomization.yaml
+++ b/apps/02-monitoring/descheduler/overlays/dev/kustomization.yaml
@@ -7,3 +7,11 @@ labels:
   - pairs:
       environment: dev
     includeSelectors: false
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/02-monitoring/descheduler/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/descheduler/overlays/prod/kustomization.yaml
@@ -7,3 +7,11 @@ labels:
       environment: prod
 resources:
   - ../../base
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/02-monitoring/goldilocks/overlays/dev/kustomization.yaml
+++ b/apps/02-monitoring/goldilocks/overlays/dev/kustomization.yaml
@@ -5,3 +5,11 @@ namespace: monitoring
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/02-monitoring/goldilocks/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/goldilocks/overlays/prod/kustomization.yaml
@@ -5,6 +5,12 @@ commonLabels:
 kind: Kustomization
 namespace: monitoring
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patch-infisical-env.yaml
 resources:
   - ingress.yaml

--- a/apps/02-monitoring/grafana-ingress/overlays/dev/kustomization.yaml
+++ b/apps/02-monitoring/grafana-ingress/overlays/dev/kustomization.yaml
@@ -9,3 +9,11 @@ labels:
   - includeSelectors: false
     pairs:
       environment: dev
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/02-monitoring/grafana-ingress/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/grafana-ingress/overlays/prod/kustomization.yaml
@@ -9,3 +9,11 @@ namespace: monitoring
 resources:
   - ../../base
   - grafana-ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/02-monitoring/grafana-ingress/overlays/staging/kustomization.yaml
+++ b/apps/02-monitoring/grafana-ingress/overlays/staging/kustomization.yaml
@@ -9,3 +9,11 @@ labels:
   - includeSelectors: false
     pairs:
       environment: staging
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/02-monitoring/grafana-ingress/overlays/test/kustomization.yaml
+++ b/apps/02-monitoring/grafana-ingress/overlays/test/kustomization.yaml
@@ -9,3 +9,11 @@ labels:
   - includeSelectors: false
     pairs:
       environment: test
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/02-monitoring/grafana/overlays/dev/kustomization.yaml
+++ b/apps/02-monitoring/grafana/overlays/dev/kustomization.yaml
@@ -9,4 +9,10 @@ labels:
     pairs:
       environment: dev
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patch-infisical-env.yaml

--- a/apps/02-monitoring/grafana/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/grafana/overlays/prod/kustomization.yaml
@@ -7,6 +7,12 @@ labels:
       environment: prod
 namespace: monitoring
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patch-infisical-env.yaml
 resources:
   - ../../base

--- a/apps/02-monitoring/grafana/overlays/staging/kustomization.yaml
+++ b/apps/02-monitoring/grafana/overlays/staging/kustomization.yaml
@@ -9,4 +9,10 @@ labels:
     pairs:
       environment: staging
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patch-infisical-env.yaml

--- a/apps/02-monitoring/grafana/overlays/test/kustomization.yaml
+++ b/apps/02-monitoring/grafana/overlays/test/kustomization.yaml
@@ -9,4 +9,10 @@ labels:
     pairs:
       environment: test
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patch-infisical-env.yaml

--- a/apps/02-monitoring/hubble-ui/overlays/dev/kustomization.yaml
+++ b/apps/02-monitoring/hubble-ui/overlays/dev/kustomization.yaml
@@ -4,6 +4,12 @@ kind: Kustomization
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: ingress-patch.yaml
     target:
       kind: Ingress

--- a/apps/02-monitoring/hubble-ui/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/hubble-ui/overlays/prod/kustomization.yaml
@@ -5,6 +5,12 @@ commonLabels:
 kind: Kustomization
 namespace: monitoring
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: ingress-patch.yaml
     target:
       kind: Ingress

--- a/apps/02-monitoring/hubble-ui/overlays/staging/kustomization.yaml
+++ b/apps/02-monitoring/hubble-ui/overlays/staging/kustomization.yaml
@@ -4,6 +4,12 @@ kind: Kustomization
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: ingress-patch.yaml
     target:
       kind: Ingress

--- a/apps/02-monitoring/hubble-ui/overlays/test/kustomization.yaml
+++ b/apps/02-monitoring/hubble-ui/overlays/test/kustomization.yaml
@@ -4,6 +4,12 @@ kind: Kustomization
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: ingress-patch.yaml
     target:
       kind: Ingress

--- a/apps/02-monitoring/loki/overlays/dev/kustomization.yaml
+++ b/apps/02-monitoring/loki/overlays/dev/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: Deployment
       name: loki

--- a/apps/02-monitoring/loki/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/loki/overlays/prod/kustomization.yaml
@@ -7,6 +7,12 @@ commonLabels:
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: infisical-patch.yaml
     target:
       kind: InfisicalSecret

--- a/apps/02-monitoring/loki/overlays/staging/kustomization.yaml
+++ b/apps/02-monitoring/loki/overlays/staging/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: infisical-patch.yaml
     target:
       kind: InfisicalSecret

--- a/apps/02-monitoring/loki/overlays/test/kustomization.yaml
+++ b/apps/02-monitoring/loki/overlays/test/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: infisical-patch.yaml
     target:
       kind: InfisicalSecret

--- a/apps/02-monitoring/prometheus-ingress/overlays/dev/kustomization.yaml
+++ b/apps/02-monitoring/prometheus-ingress/overlays/dev/kustomization.yaml
@@ -9,3 +9,11 @@ labels:
   - includeSelectors: false
     pairs:
       environment: dev
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/02-monitoring/prometheus-ingress/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/prometheus-ingress/overlays/prod/kustomization.yaml
@@ -9,3 +9,11 @@ namespace: monitoring
 resources:
   - ../../base
   - prometheus-ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/02-monitoring/prometheus-ingress/overlays/staging/kustomization.yaml
+++ b/apps/02-monitoring/prometheus-ingress/overlays/staging/kustomization.yaml
@@ -9,3 +9,11 @@ labels:
   - includeSelectors: false
     pairs:
       environment: staging
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/02-monitoring/prometheus-ingress/overlays/test/kustomization.yaml
+++ b/apps/02-monitoring/prometheus-ingress/overlays/test/kustomization.yaml
@@ -9,3 +9,11 @@ labels:
   - includeSelectors: false
     pairs:
       environment: test
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/02-monitoring/prometheus/overlays/dev/kustomization.yaml
+++ b/apps/02-monitoring/prometheus/overlays/dev/kustomization.yaml
@@ -7,6 +7,12 @@ commonLabels:
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: StatefulSet
       name: prometheus-alertmanager

--- a/apps/02-monitoring/prometheus/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/prometheus/overlays/prod/kustomization.yaml
@@ -5,6 +5,12 @@ commonLabels:
 kind: Kustomization
 namespace: monitoring
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patch-alertmanager-command.yaml
     target:
       kind: StatefulSet

--- a/apps/02-monitoring/prometheus/overlays/staging/kustomization.yaml
+++ b/apps/02-monitoring/prometheus/overlays/staging/kustomization.yaml
@@ -9,3 +9,11 @@ labels:
   - includeSelectors: false
     pairs:
       environment: staging
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/02-monitoring/prometheus/overlays/test/kustomization.yaml
+++ b/apps/02-monitoring/prometheus/overlays/test/kustomization.yaml
@@ -9,3 +9,11 @@ labels:
   - includeSelectors: false
     pairs:
       environment: test
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/02-monitoring/promtail/overlays/dev/kustomization.yaml
+++ b/apps/02-monitoring/promtail/overlays/dev/kustomization.yaml
@@ -5,3 +5,10 @@ namespace: monitoring
 resources:
   - ../../base
   - ingress.yaml
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/02-monitoring/promtail/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/promtail/overlays/prod/kustomization.yaml
@@ -8,6 +8,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: promtail-secrets-sync

--- a/apps/02-monitoring/promtail/overlays/staging/kustomization.yaml
+++ b/apps/02-monitoring/promtail/overlays/staging/kustomization.yaml
@@ -5,3 +5,11 @@ namespace: monitoring
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/02-monitoring/promtail/overlays/test/kustomization.yaml
+++ b/apps/02-monitoring/promtail/overlays/test/kustomization.yaml
@@ -5,3 +5,11 @@ namespace: monitoring
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/03-security/authentik/overlays/dev/kustomization.yaml
+++ b/apps/03-security/authentik/overlays/dev/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - ingress.yaml
   - cors-middleware.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: deployment-patch.yaml
     target:
       kind: Deployment

--- a/apps/03-security/authentik/overlays/prod/kustomization.yaml
+++ b/apps/03-security/authentik/overlays/prod/kustomization.yaml
@@ -7,6 +7,12 @@ labels:
       environment: prod
     includeSelectors: false
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |
       - op: replace
         path: /spec/authentication/universalAuth/secretsScope/envSlug

--- a/apps/03-security/authentik/overlays/staging/kustomization.yaml
+++ b/apps/03-security/authentik/overlays/staging/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: infisical-patch.yaml
     target:
       kind: InfisicalSecret

--- a/apps/03-security/authentik/overlays/test/kustomization.yaml
+++ b/apps/03-security/authentik/overlays/test/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: infisical-patch.yaml
     target:
       kind: InfisicalSecret

--- a/apps/04-databases/cloudnative-pg/overlays/dev/kustomization.yaml
+++ b/apps/04-databases/cloudnative-pg/overlays/dev/kustomization.yaml
@@ -5,6 +5,12 @@ namespace: cnpg-system
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: resources-patch.yaml
 labels:
   - pairs:

--- a/apps/04-databases/cloudnative-pg/overlays/prod/kustomization.yaml
+++ b/apps/04-databases/cloudnative-pg/overlays/prod/kustomization.yaml
@@ -8,3 +8,11 @@ labels:
   - pairs:
       environment: prod
     includeSelectors: false
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/04-databases/mariadb-shared/overlays/dev/kustomization.yaml
+++ b/apps/04-databases/mariadb-shared/overlays/dev/kustomization.yaml
@@ -8,3 +8,11 @@ labels:
   - pairs:
       environment: dev
     includeSelectors: false
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/04-databases/mariadb-shared/overlays/prod/kustomization.yaml
+++ b/apps/04-databases/mariadb-shared/overlays/prod/kustomization.yaml
@@ -5,6 +5,12 @@ namespace: databases
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patch-infisical-env.yaml
 labels:
   - pairs:

--- a/apps/04-databases/postgresql-shared/overlays/dev/kustomization.yaml
+++ b/apps/04-databases/postgresql-shared/overlays/dev/kustomization.yaml
@@ -8,3 +8,11 @@ labels:
   - pairs:
       environment: dev
     includeSelectors: false
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/04-databases/postgresql-shared/overlays/prod/kustomization.yaml
+++ b/apps/04-databases/postgresql-shared/overlays/prod/kustomization.yaml
@@ -5,6 +5,12 @@ namespace: databases
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patch-credentials-env.yaml
   - path: backup-patch.yaml
     target:

--- a/apps/04-databases/postgresql-shared/overlays/staging/kustomization.yaml
+++ b/apps/04-databases/postgresql-shared/overlays/staging/kustomization.yaml
@@ -9,5 +9,11 @@ labels:
       environment: staging
     includeSelectors: false
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patch-credentials-env.yaml
   - path: patch-instances.yaml

--- a/apps/04-databases/postgresql-shared/overlays/test/kustomization.yaml
+++ b/apps/04-databases/postgresql-shared/overlays/test/kustomization.yaml
@@ -9,4 +9,10 @@ labels:
       environment: test
     includeSelectors: false
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patch-credentials-env.yaml

--- a/apps/04-databases/redis-shared/overlays/dev/kustomization.yaml
+++ b/apps/04-databases/redis-shared/overlays/dev/kustomization.yaml
@@ -8,3 +8,11 @@ labels:
   - pairs:
       environment: dev
     includeSelectors: false
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/04-databases/redis-shared/overlays/prod/kustomization.yaml
+++ b/apps/04-databases/redis-shared/overlays/prod/kustomization.yaml
@@ -5,6 +5,12 @@ namespace: databases
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patch-infisical-env.yaml
 labels:
   - pairs:

--- a/apps/10-home/homeassistant/overlays/dev/kustomization.yaml
+++ b/apps/10-home/homeassistant/overlays/dev/kustomization.yaml
@@ -10,6 +10,12 @@ resources:
 
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
@@ -8,6 +8,12 @@ resources:
   - ingressroute-udp.yaml
   - infisical-filebrowser-auth.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: infisical-config-patch.yaml
   - path: litestream-secret-patch.yaml
     target:

--- a/apps/10-home/homeassistant/overlays/staging/kustomization.yaml
+++ b/apps/10-home/homeassistant/overlays/staging/kustomization.yaml
@@ -7,3 +7,11 @@ resources:
   - ingress.yaml
   - ingressroute-udp.yaml
   - infisical-filebrowser-auth.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/10-home/homeassistant/overlays/test/kustomization.yaml
+++ b/apps/10-home/homeassistant/overlays/test/kustomization.yaml
@@ -7,3 +7,11 @@ resources:
   - ingress.yaml
   - ingressroute-udp.yaml
   - infisical-filebrowser-auth.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/10-home/mealie/overlays/dev/kustomization.yaml
+++ b/apps/10-home/mealie/overlays/dev/kustomization.yaml
@@ -10,6 +10,12 @@ labels:
 
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/10-home/mealie/overlays/prod/kustomization.yaml
+++ b/apps/10-home/mealie/overlays/prod/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: resources-patch.yaml
 labels:
   - pairs:

--- a/apps/10-home/mosquitto/overlays/dev/kustomization.yaml
+++ b/apps/10-home/mosquitto/overlays/dev/kustomization.yaml
@@ -9,6 +9,12 @@ resources:
 
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: StatefulSet

--- a/apps/10-home/mosquitto/overlays/prod/kustomization.yaml
+++ b/apps/10-home/mosquitto/overlays/prod/kustomization.yaml
@@ -6,3 +6,11 @@ resources:
   - ../../base
   - infisical-mosquitto-auth.yaml
   - mosquitto-tcp-ingressroute.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/10-home/mosquitto/overlays/staging/kustomization.yaml
+++ b/apps/10-home/mosquitto/overlays/staging/kustomization.yaml
@@ -6,3 +6,11 @@ resources:
   - ../../base
   - infisical-mosquitto-auth.yaml
   - mosquitto-tcp-ingressroute.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/10-home/mosquitto/overlays/test/kustomization.yaml
+++ b/apps/10-home/mosquitto/overlays/test/kustomization.yaml
@@ -6,3 +6,11 @@ resources:
   - ../../base
   - infisical-mosquitto-auth.yaml
   - mosquitto-tcp-ingressroute.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/20-media/amule/overlays/dev/kustomization.yaml
+++ b/apps/20-media/amule/overlays/dev/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patch-infisical-env.yaml
     target:
       kind: InfisicalSecret

--- a/apps/20-media/amule/overlays/prod/kustomization.yaml
+++ b/apps/20-media/amule/overlays/prod/kustomization.yaml
@@ -10,4 +10,10 @@ labels:
     pairs:
       environment: prod
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patch-infisical-env.yaml

--- a/apps/20-media/birdnet-go/overlays/dev/kustomization.yaml
+++ b/apps/20-media/birdnet-go/overlays/dev/kustomization.yaml
@@ -8,6 +8,12 @@ resources:
 
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/20-media/birdnet-go/overlays/prod/kustomization.yaml
+++ b/apps/20-media/birdnet-go/overlays/prod/kustomization.yaml
@@ -5,3 +5,11 @@ namespace: birdnet-go
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/20-media/birdnet-go/overlays/staging/kustomization.yaml
+++ b/apps/20-media/birdnet-go/overlays/staging/kustomization.yaml
@@ -5,3 +5,11 @@ namespace: birdnet-go
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/20-media/birdnet-go/overlays/test/kustomization.yaml
+++ b/apps/20-media/birdnet-go/overlays/test/kustomization.yaml
@@ -5,3 +5,11 @@ namespace: birdnet-go
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/20-media/booklore/overlays/dev/kustomization.yaml
+++ b/apps/20-media/booklore/overlays/dev/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: booklore-secrets-sync

--- a/apps/20-media/booklore/overlays/prod/kustomization.yaml
+++ b/apps/20-media/booklore/overlays/prod/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: booklore-secrets-sync

--- a/apps/20-media/booklore/overlays/staging/kustomization.yaml
+++ b/apps/20-media/booklore/overlays/staging/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: booklore-secrets-sync

--- a/apps/20-media/booklore/overlays/test/kustomization.yaml
+++ b/apps/20-media/booklore/overlays/test/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: booklore-secrets-sync

--- a/apps/20-media/frigate/overlays/dev/kustomization.yaml
+++ b/apps/20-media/frigate/overlays/dev/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: frigate-secrets-sync

--- a/apps/20-media/frigate/overlays/prod/kustomization.yaml
+++ b/apps/20-media/frigate/overlays/prod/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: frigate-secrets-sync

--- a/apps/20-media/frigate/overlays/staging/kustomization.yaml
+++ b/apps/20-media/frigate/overlays/staging/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: frigate-secrets-sync

--- a/apps/20-media/frigate/overlays/test/kustomization.yaml
+++ b/apps/20-media/frigate/overlays/test/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: frigate-secrets-sync

--- a/apps/20-media/hydrus-client/overlays/dev/kustomization.yaml
+++ b/apps/20-media/hydrus-client/overlays/dev/kustomization.yaml
@@ -8,6 +8,12 @@ resources:
 
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/20-media/hydrus-client/overlays/prod/kustomization.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/kustomization.yaml
@@ -8,3 +8,11 @@ patchesStrategicMerge:
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/20-media/jellyfin/overlays/dev/kustomization.yaml
+++ b/apps/20-media/jellyfin/overlays/dev/kustomization.yaml
@@ -7,6 +7,12 @@ resources:
 
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/20-media/jellyfin/overlays/prod/kustomization.yaml
+++ b/apps/20-media/jellyfin/overlays/prod/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/20-media/jellyfin/overlays/staging/kustomization.yaml
+++ b/apps/20-media/jellyfin/overlays/staging/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/20-media/jellyfin/overlays/test/kustomization.yaml
+++ b/apps/20-media/jellyfin/overlays/test/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/20-media/jellyseerr/overlays/dev/kustomization.yaml
+++ b/apps/20-media/jellyseerr/overlays/dev/kustomization.yaml
@@ -7,6 +7,12 @@ resources:
 
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/20-media/jellyseerr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/jellyseerr/overlays/prod/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/20-media/jellyseerr/overlays/staging/kustomization.yaml
+++ b/apps/20-media/jellyseerr/overlays/staging/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/20-media/jellyseerr/overlays/test/kustomization.yaml
+++ b/apps/20-media/jellyseerr/overlays/test/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/20-media/lazylibrarian/overlays/dev/kustomization.yaml
+++ b/apps/20-media/lazylibrarian/overlays/dev/kustomization.yaml
@@ -7,6 +7,12 @@ resources:
 
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/20-media/lazylibrarian/overlays/prod/kustomization.yaml
+++ b/apps/20-media/lazylibrarian/overlays/prod/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/20-media/lidarr/overlays/dev/kustomization.yaml
+++ b/apps/20-media/lidarr/overlays/dev/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/20-media/lidarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/lidarr/overlays/prod/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: lidarr-secrets-sync

--- a/apps/20-media/lidarr/overlays/staging/kustomization.yaml
+++ b/apps/20-media/lidarr/overlays/staging/kustomization.yaml
@@ -6,3 +6,11 @@ resources:
   - ../../base
   - ingress.yaml
   - infisical-patch.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/20-media/lidarr/overlays/test/kustomization.yaml
+++ b/apps/20-media/lidarr/overlays/test/kustomization.yaml
@@ -6,3 +6,11 @@ resources:
   - ../../base
   - ingress.yaml
   - infisical-patch.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/20-media/music-assistant/overlays/dev/kustomization.yaml
+++ b/apps/20-media/music-assistant/overlays/dev/kustomization.yaml
@@ -7,6 +7,12 @@ resources:
 
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/20-media/music-assistant/overlays/prod/kustomization.yaml
+++ b/apps/20-media/music-assistant/overlays/prod/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/20-media/mylar/overlays/dev/kustomization.yaml
+++ b/apps/20-media/mylar/overlays/dev/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/20-media/mylar/overlays/prod/kustomization.yaml
+++ b/apps/20-media/mylar/overlays/prod/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: mylar-secrets-sync

--- a/apps/20-media/prowlarr/overlays/dev/kustomization.yaml
+++ b/apps/20-media/prowlarr/overlays/dev/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/20-media/prowlarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/prowlarr/overlays/prod/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: prowlarr-secrets-sync

--- a/apps/20-media/pyload/overlays/dev/kustomization.yaml
+++ b/apps/20-media/pyload/overlays/dev/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patch-infisical-env.yaml
     target:
       kind: InfisicalSecret

--- a/apps/20-media/pyload/overlays/prod/kustomization.yaml
+++ b/apps/20-media/pyload/overlays/prod/kustomization.yaml
@@ -10,4 +10,10 @@ labels:
     pairs:
       environment: prod
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patch-infisical-env.yaml

--- a/apps/20-media/qbittorrent/overlays/dev/kustomization.yaml
+++ b/apps/20-media/qbittorrent/overlays/dev/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patch-infisical-env.yaml
     target:
       kind: InfisicalSecret

--- a/apps/20-media/qbittorrent/overlays/prod/kustomization.yaml
+++ b/apps/20-media/qbittorrent/overlays/prod/kustomization.yaml
@@ -10,4 +10,10 @@ labels:
     pairs:
       environment: prod
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patch-infisical-env.yaml

--- a/apps/20-media/radarr/overlays/dev/kustomization.yaml
+++ b/apps/20-media/radarr/overlays/dev/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/20-media/radarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/radarr/overlays/prod/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: radarr-secrets-sync

--- a/apps/20-media/radarr/overlays/staging/kustomization.yaml
+++ b/apps/20-media/radarr/overlays/staging/kustomization.yaml
@@ -6,3 +6,11 @@ resources:
   - ../../base
   - ingress.yaml
   - infisical-patch.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/20-media/radarr/overlays/test/kustomization.yaml
+++ b/apps/20-media/radarr/overlays/test/kustomization.yaml
@@ -6,3 +6,11 @@ resources:
   - ../../base
   - ingress.yaml
   - infisical-patch.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/20-media/sabnzbd/overlays/dev/kustomization.yaml
+++ b/apps/20-media/sabnzbd/overlays/dev/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/20-media/sabnzbd/overlays/prod/kustomization.yaml
+++ b/apps/20-media/sabnzbd/overlays/prod/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: sabnzbd-secrets-sync

--- a/apps/20-media/sabnzbd/overlays/staging/kustomization.yaml
+++ b/apps/20-media/sabnzbd/overlays/staging/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: infisical-patch.yaml
   - target:
       kind: InfisicalSecret

--- a/apps/20-media/sabnzbd/overlays/test/kustomization.yaml
+++ b/apps/20-media/sabnzbd/overlays/test/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: infisical-patch.yaml
   - target:
       kind: InfisicalSecret

--- a/apps/20-media/sonarr/overlays/dev/kustomization.yaml
+++ b/apps/20-media/sonarr/overlays/dev/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/20-media/sonarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/sonarr/overlays/prod/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: sonarr-secrets-sync

--- a/apps/20-media/sonarr/overlays/staging/kustomization.yaml
+++ b/apps/20-media/sonarr/overlays/staging/kustomization.yaml
@@ -6,3 +6,11 @@ resources:
   - ../../base
   - ingress.yaml
   - infisical-patch.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/20-media/sonarr/overlays/test/kustomization.yaml
+++ b/apps/20-media/sonarr/overlays/test/kustomization.yaml
@@ -6,3 +6,11 @@ resources:
   - ../../base
   - ingress.yaml
   - infisical-patch.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/20-media/whisparr/overlays/dev/kustomization.yaml
+++ b/apps/20-media/whisparr/overlays/dev/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/20-media/whisparr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/whisparr/overlays/prod/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: whisparr-secrets-sync

--- a/apps/40-network/adguard-home/overlays/dev/kustomization.yaml
+++ b/apps/40-network/adguard-home/overlays/dev/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: Deployment
       name: adguard-home

--- a/apps/40-network/adguard-home/overlays/prod/kustomization.yaml
+++ b/apps/40-network/adguard-home/overlays/prod/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |
       - op: replace
         path: /spec/authentication/universalAuth/secretsScope/envSlug

--- a/apps/40-network/adguard-home/overlays/staging/kustomization.yaml
+++ b/apps/40-network/adguard-home/overlays/staging/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/40-network/adguard-home/overlays/test/kustomization.yaml
+++ b/apps/40-network/adguard-home/overlays/test/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/40-network/contacts/overlays/dev/kustomization.yaml
+++ b/apps/40-network/contacts/overlays/dev/kustomization.yaml
@@ -5,3 +5,11 @@ namespace: contacts
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/40-network/contacts/overlays/prod/kustomization.yaml
+++ b/apps/40-network/contacts/overlays/prod/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/40-network/external-dns-gandi/overlays/prod/kustomization.yaml
+++ b/apps/40-network/external-dns-gandi/overlays/prod/kustomization.yaml
@@ -8,3 +8,11 @@ labels:
   - pairs:
       environment: prod
     includeSelectors: false
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/40-network/external-dns-unifi/overlays/dev/kustomization.yaml
+++ b/apps/40-network/external-dns-unifi/overlays/dev/kustomization.yaml
@@ -4,6 +4,12 @@ kind: Kustomization
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: infisical-patch.yaml
     target:
       kind: InfisicalSecret

--- a/apps/40-network/external-dns-unifi/overlays/prod/kustomization.yaml
+++ b/apps/40-network/external-dns-unifi/overlays/prod/kustomization.yaml
@@ -3,3 +3,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/40-network/mail-gateway/overlays/dev/kustomization.yaml
+++ b/apps/40-network/mail-gateway/overlays/dev/kustomization.yaml
@@ -6,3 +6,11 @@ bases:
   - ../../base
 resources:
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/40-network/mail-gateway/overlays/prod/kustomization.yaml
+++ b/apps/40-network/mail-gateway/overlays/prod/kustomization.yaml
@@ -5,3 +5,11 @@ namespace: mail-gateway
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/40-network/mail-gateway/overlays/staging/kustomization.yaml
+++ b/apps/40-network/mail-gateway/overlays/staging/kustomization.yaml
@@ -6,3 +6,11 @@ bases:
   - ../../base
 resources:
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/40-network/mail-gateway/overlays/test/kustomization.yaml
+++ b/apps/40-network/mail-gateway/overlays/test/kustomization.yaml
@@ -6,3 +6,11 @@ bases:
   - ../../base
 resources:
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/40-network/netbird/overlays/dev/kustomization.yaml
+++ b/apps/40-network/netbird/overlays/dev/kustomization.yaml
@@ -8,4 +8,10 @@ resources:
   - ingress.yaml
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patches.yaml

--- a/apps/40-network/netbird/overlays/prod/kustomization.yaml
+++ b/apps/40-network/netbird/overlays/prod/kustomization.yaml
@@ -8,6 +8,12 @@ resources:
   - ingress.yaml
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |
       - op: replace
         path: /spec/authentication/universalAuth/secretsScope/envSlug

--- a/apps/40-network/netvisor/overlays/dev/kustomization.yaml
+++ b/apps/40-network/netvisor/overlays/dev/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: netvisor-secrets-sync

--- a/apps/40-network/netvisor/overlays/prod/kustomization.yaml
+++ b/apps/40-network/netvisor/overlays/prod/kustomization.yaml
@@ -2,6 +2,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       - op: replace
         path: /spec/authentication/universalAuth/secretsScope/envSlug

--- a/apps/40-network/netvisor/overlays/staging/kustomization.yaml
+++ b/apps/40-network/netvisor/overlays/staging/kustomization.yaml
@@ -7,6 +7,12 @@ resources:
 patchesStrategicMerge:
   - server-url-patch.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: netvisor-secrets-sync

--- a/apps/40-network/netvisor/overlays/test/kustomization.yaml
+++ b/apps/40-network/netvisor/overlays/test/kustomization.yaml
@@ -7,6 +7,12 @@ resources:
 patchesStrategicMerge:
   - server-url-patch.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: netvisor-secrets-sync

--- a/apps/60-services/docspell-native/overlays/dev/kustomization.yaml
+++ b/apps/60-services/docspell-native/overlays/dev/kustomization.yaml
@@ -10,6 +10,12 @@ labels:
 
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: StatefulSet

--- a/apps/60-services/docspell-native/overlays/prod/kustomization.yaml
+++ b/apps/60-services/docspell-native/overlays/prod/kustomization.yaml
@@ -6,6 +6,12 @@ labels:
       environment: prod
 namespace: services
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patch-infisical-secrets.yaml
 patchesStrategicMerge:
   - patch-resources.yaml

--- a/apps/60-services/docspell/overlays/dev/kustomization.yaml
+++ b/apps/60-services/docspell/overlays/dev/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - ../../base
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/60-services/gluetun/overlays/dev/kustomization.yaml
+++ b/apps/60-services/gluetun/overlays/dev/kustomization.yaml
@@ -9,6 +9,12 @@ commonLabels:
 
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/60-services/gluetun/overlays/prod/kustomization.yaml
+++ b/apps/60-services/gluetun/overlays/prod/kustomization.yaml
@@ -8,3 +8,11 @@ patchesStrategicMerge:
   - patch-infisical-env.yaml
 resources:
   - ../../base
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/60-services/gluetun/overlays/staging/kustomization.yaml
+++ b/apps/60-services/gluetun/overlays/staging/kustomization.yaml
@@ -8,3 +8,11 @@ patchesStrategicMerge:
   - patch-infisical-env.yaml
 commonLabels:
   environment: staging
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/60-services/gluetun/overlays/test/kustomization.yaml
+++ b/apps/60-services/gluetun/overlays/test/kustomization.yaml
@@ -8,3 +8,11 @@ patchesStrategicMerge:
   - patch-infisical-env.yaml
 commonLabels:
   environment: test
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/60-services/vaultwarden/overlays/dev/kustomization.yaml
+++ b/apps/60-services/vaultwarden/overlays/dev/kustomization.yaml
@@ -7,6 +7,12 @@ resources:
 
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/60-services/vaultwarden/overlays/prod/kustomization.yaml
+++ b/apps/60-services/vaultwarden/overlays/prod/kustomization.yaml
@@ -2,6 +2,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: infisical-patch.yaml
     target:
       kind: InfisicalSecret

--- a/apps/70-tools/changedetection/overlays/dev/kustomization.yaml
+++ b/apps/70-tools/changedetection/overlays/dev/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: changedetection-secrets-sync

--- a/apps/70-tools/changedetection/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/changedetection/overlays/prod/kustomization.yaml
@@ -2,6 +2,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       - op: replace
         path: /spec/authentication/universalAuth/secretsScope/envSlug

--- a/apps/70-tools/changedetection/overlays/staging/kustomization.yaml
+++ b/apps/70-tools/changedetection/overlays/staging/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: changedetection-secrets-sync

--- a/apps/70-tools/changedetection/overlays/test/kustomization.yaml
+++ b/apps/70-tools/changedetection/overlays/test/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: changedetection-secrets-sync

--- a/apps/70-tools/headlamp/overlays/dev/kustomization.yaml
+++ b/apps/70-tools/headlamp/overlays/dev/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
   - ingress.yaml
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/70-tools/headlamp/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/headlamp/overlays/prod/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/70-tools/headlamp/overlays/staging/kustomization.yaml
+++ b/apps/70-tools/headlamp/overlays/staging/kustomization.yaml
@@ -4,6 +4,12 @@ kind: Kustomization
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: ingress-patch.yaml
     target:
       kind: Ingress

--- a/apps/70-tools/headlamp/overlays/test/kustomization.yaml
+++ b/apps/70-tools/headlamp/overlays/test/kustomization.yaml
@@ -4,6 +4,12 @@ kind: Kustomization
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: ingress-patch.yaml
     target:
       kind: Ingress

--- a/apps/70-tools/homepage/overlays/dev/kustomization.yaml
+++ b/apps/70-tools/homepage/overlays/dev/kustomization.yaml
@@ -10,6 +10,12 @@ resources:
 
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/70-tools/homepage/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/homepage/overlays/prod/kustomization.yaml
@@ -3,6 +3,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: tools
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: infisical-config-patch.yaml
     target:
       kind: InfisicalSecret

--- a/apps/70-tools/it-tools/overlays/dev/kustomization.yaml
+++ b/apps/70-tools/it-tools/overlays/dev/kustomization.yaml
@@ -7,6 +7,12 @@ resources:
   - ingress.yaml
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/70-tools/it-tools/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/it-tools/overlays/prod/kustomization.yaml
@@ -5,3 +5,11 @@ namespace: tools
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/70-tools/linkwarden/overlays/dev/kustomization.yaml
+++ b/apps/70-tools/linkwarden/overlays/dev/kustomization.yaml
@@ -13,6 +13,12 @@ labels:
 
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/70-tools/linkwarden/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/linkwarden/overlays/prod/kustomization.yaml
@@ -5,6 +5,12 @@ labels:
   - pairs:
       environment: prod
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patch-nextauth-url.yaml
 resources:
   - ../../base

--- a/apps/70-tools/netbox/overlays/dev/kustomization.yaml
+++ b/apps/70-tools/netbox/overlays/dev/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: Deployment
       name: netbox

--- a/apps/70-tools/netbox/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/netbox/overlays/prod/kustomization.yaml
@@ -2,6 +2,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: deployment-patch.yaml
     target:
       kind: Deployment

--- a/apps/70-tools/netbox/overlays/staging/kustomization.yaml
+++ b/apps/70-tools/netbox/overlays/staging/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: deployment-patch.yaml
     target:
       kind: Deployment

--- a/apps/70-tools/netbox/overlays/test/kustomization.yaml
+++ b/apps/70-tools/netbox/overlays/test/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: deployment-patch.yaml
     target:
       kind: Deployment

--- a/apps/70-tools/nocodb/overlays/dev/kustomization.yaml
+++ b/apps/70-tools/nocodb/overlays/dev/kustomization.yaml
@@ -4,6 +4,12 @@ kind: Kustomization
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: Ingress
       name: nocodb

--- a/apps/70-tools/nocodb/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/nocodb/overlays/prod/kustomization.yaml
@@ -4,6 +4,12 @@ kind: Kustomization
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: Ingress
       name: nocodb

--- a/apps/70-tools/renovate/overlays/dev/kustomization.yaml
+++ b/apps/70-tools/renovate/overlays/dev/kustomization.yaml
@@ -5,6 +5,12 @@ namespace: tools
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/70-tools/renovate/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/renovate/overlays/prod/kustomization.yaml
@@ -9,6 +9,12 @@ resources:
   - ../../base
   - pvc.yaml
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - path: patch-infisical-env.yaml
   - target:
       kind: CronJob

--- a/apps/70-tools/stirling-pdf/overlays/dev/kustomization.yaml
+++ b/apps/70-tools/stirling-pdf/overlays/dev/kustomization.yaml
@@ -7,6 +7,12 @@ resources:
   - ingress.yaml
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/70-tools/stirling-pdf/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/stirling-pdf/overlays/prod/kustomization.yaml
@@ -5,3 +5,11 @@ namespace: tools
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/99-test/farmos/overlays/dev/kustomization.yaml
+++ b/apps/99-test/farmos/overlays/dev/kustomization.yaml
@@ -8,6 +8,12 @@ commonLabels:
   environment: dev
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/99-test/tandoor/overlays/dev/kustomization.yaml
+++ b/apps/99-test/tandoor/overlays/dev/kustomization.yaml
@@ -8,6 +8,12 @@ commonLabels:
   environment: dev
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/99-test/vikunja/overlays/dev/kustomization.yaml
+++ b/apps/99-test/vikunja/overlays/dev/kustomization.yaml
@@ -4,6 +4,12 @@ kind: Kustomization
 resources:
   - ../../base
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: Deployment
       name: vikunja

--- a/apps/99-test/whoami/overlays/dev/kustomization.yaml
+++ b/apps/99-test/whoami/overlays/dev/kustomization.yaml
@@ -8,6 +8,12 @@ resources:
 
 
 patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/apps/99-test/whoami/overlays/prod/kustomization.yaml
+++ b/apps/99-test/whoami/overlays/prod/kustomization.yaml
@@ -4,3 +4,10 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/99-test/whoami/overlays/staging/kustomization.yaml
+++ b/apps/99-test/whoami/overlays/staging/kustomization.yaml
@@ -5,3 +5,11 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/99-test/whoami/overlays/test/kustomization.yaml
+++ b/apps/99-test/whoami/overlays/test/kustomization.yaml
@@ -5,3 +5,11 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+
+patches:
+  - path: ../../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/_shared/patches/revision-history-limit-deployment.yaml
+++ b/apps/_shared/patches/revision-history-limit-deployment.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: all-deployments
+spec:
+  revisionHistoryLimit: 3

--- a/apps/_shared/patches/revision-history-limit-statefulset.yaml
+++ b/apps/_shared/patches/revision-history-limit-statefulset.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: all-statefulsets
+spec:
+  revisionHistoryLimit: 3

--- a/apps/template-app/overlays/dev/kustomization.yaml
+++ b/apps/template-app/overlays/dev/kustomization.yaml
@@ -6,3 +6,11 @@ resources:
   - ingress.yaml
 commonLabels:
   environment: dev
+
+patches:
+  - path: ../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment

--- a/apps/template-app/overlays/prod/kustomization.yaml
+++ b/apps/template-app/overlays/prod/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../base
   - ingress.yaml
 patches:
+  - path: ../../../_shared/patches/revision-history-limit-statefulset.yaml
+    target:
+      kind: StatefulSet
+  - path: ../../../_shared/patches/revision-history-limit-deployment.yaml
+    target:
+      kind: Deployment
   - target:
       kind: InfisicalSecret
       name: template-app-secrets-sync


### PR DESCRIPTION
Implementation of a shared Kustomize patch to enforce revisionHistoryLimit: 3 across all Deployments and StatefulSets.