### PR TITLE
fix(penpot): increase backend resources and probe delays for JVM startup

### DIFF
--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -64,22 +64,22 @@ spec:
               name: http
           resources:
             requests:
-              cpu: "100m"
+              cpu: "200m"
               memory: "512Mi"
             limits:
-              cpu: "500m"
-              memory: "1Gi"
+              cpu: "1000m"
+              memory: "1536Mi"
           readinessProbe:
             httpGet:
               path: /api/health
               port: http
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /api/health
               port: http
-            initialDelaySeconds: 60
+            initialDelaySeconds: 120
             periodSeconds: 30
-            failureThreshold: 3
+            failureThreshold: 5
       restartPolicy: Always


### PR DESCRIPTION
## Summary
JVM apps need more time and resources to start. Backend was being killed by liveness probe before it could finish initializing.

## Changes
- CPU limit: 500m → 1000m
- Memory limit: 1Gi → 1536Mi  
- Liveness probe initialDelaySeconds: 60s → 120s
- Liveness probe failureThreshold: 3 → 5
- Readiness probe initialDelaySeconds: 30s → 60s

🤖 Generated with [Claude Code](https://claude.ai/code)