### PR TITLE
fix(penpot): use single-line PENPOT_FLAGS to fix sed error

### DIFF
--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -35,12 +35,7 @@ spec:
                 name: penpot-secrets
           env:
             - name: PENPOT_FLAGS
-              value: >
-                enable-registration
-                enable-login-with-password
-                disable-secure-session-cookies
-                enable-smtp
-                enable-email-verification
+              value: "enable-registration enable-login-with-password disable-secure-session-cookies enable-smtp enable-email-verification"
             - name: PENPOT_PUBLIC_URI
               value: "https://design.truxonline.com"
             - name: PENPOT_DATABASE_URI

--- a/apps/70-tools/penpot/base/deployment-frontend.yaml
+++ b/apps/70-tools/penpot/base/deployment-frontend.yaml
@@ -32,12 +32,7 @@ spec:
             - name: PENPOT_BACKEND_URI
               value: "http://penpot-backend:6060"
             - name: PENPOT_FLAGS
-              value: >
-                enable-registration
-                enable-login-with-password
-                disable-secure-session-cookies
-                enable-smtp
-                enable-email-verification
+              value: "enable-registration enable-login-with-password disable-secure-session-cookies enable-smtp enable-email-verification"
           ports:
             - containerPort: 80
               name: http


### PR DESCRIPTION
## Summary
- Fix frontend CrashLoopBackOff caused by sed error in entrypoint script
- The YAML folded style (`>`) was adding a trailing newline to PENPOT_FLAGS
- Changed to single-line quoted strings in both frontend and backend deployments

## Test plan
- [ ] Verify frontend pod starts without sed errors
- [ ] Verify Penpot is accessible at https://design.truxonline.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)