### PR TITLE
fix(penpot): frontend listens on port 8080, not 80

### DIFF
--- a/apps/70-tools/penpot/base/deployment-frontend.yaml
+++ b/apps/70-tools/penpot/base/deployment-frontend.yaml
@@ -34,7 +34,7 @@ spec:
             - name: PENPOT_FLAGS
               value: "enable-registration enable-login-with-password disable-secure-session-cookies enable-smtp enable-email-verification"
           ports:
-            - containerPort: 80
+            - containerPort: 8080
               name: http
           resources:
             requests:


### PR DESCRIPTION
## Summary
- Fix frontend container port: nginx listens on 8080, not 80
- This was causing readiness/liveness probes to fail

## Test plan
- [ ] Frontend pods become Ready
- [ ] Penpot accessible at https://design.truxonline.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the frontend service port configuration from port 80 to port 8080 for container deployment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->