### PR TITLE
fix(penpot): use /readyz for backend health endpoint

### DIFF
--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -66,13 +66,13 @@ spec:
               memory: "1536Mi"
           readinessProbe:
             httpGet:
-              path: /api/health
+              path: /readyz
               port: http
             initialDelaySeconds: 60
             periodSeconds: 10
           livenessProbe:
             httpGet:
-              path: /api/health
+              path: /readyz
               port: http
             initialDelaySeconds: 120
             periodSeconds: 30


### PR DESCRIPTION
## Summary
- Fix backend readiness/liveness probes: endpoint is `/readyz`, not `/api/health`
- Probes were returning 404 causing pod to never become ready

## Test plan
- [ ] Backend pod becomes Ready (1/1)
- [ ] ArgoCD app shows Healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend health check configuration to improve system monitoring and diagnostics procedures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->