### PR TITLE
chore(postgresql): increase shared cluster storage to 200Gi

### DIFF
--- a/apps/04-databases/postgresql-shared/base/cluster.yaml
+++ b/apps/04-databases/postgresql-shared/base/cluster.yaml
@@ -69,7 +69,7 @@ spec:
       secret:
         name: postgresql-admin-credentials
   storage:
-    size: 50Gi # Shared across multiple databases
+    size: 200Gi # Shared across multiple databases
     storageClass: synelia-iscsi-retain
   resources:
     requests:


### PR DESCRIPTION
## Summary
- Increase PostgreSQL shared cluster storage from 50Gi to 200Gi
- The 50Gi PVC was 100% full, causing PostgreSQL to refuse to start
- This was blocking Penpot and potentially other apps

## Context
This reflects the change already applied live to resolve the disk space issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased persistent storage capacity for PostgreSQL cluster from 50GB to 200GB.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->