### PR TITLE
fix(postgresql): use shared S3 credentials for backup

### DIFF
--- a/apps/04-databases/postgresql-shared/base/credentials/backup-s3-secret.yaml
+++ b/apps/04-databases/postgresql-shared/base/credentials/backup-s3-secret.yaml
@@ -17,7 +17,7 @@ spec:
       secretsScope:
         projectSlug: vixens
         envSlug: dev
-        secretsPath: /apps/04-databases/postgresql-shared
+        secretsPath: /shared/litestream
   managedSecretReference:
     secretName: postgresql-backup-s3
     creationPolicy: Owner

--- a/apps/04-databases/postgresql-shared/overlays/prod/backup-patch.yaml
+++ b/apps/04-databases/postgresql-shared/overlays/prod/backup-patch.yaml
@@ -11,8 +11,8 @@ spec:
       s3Credentials:
         accessKeyId:
           name: postgresql-backup-s3
-          key: accessKey
+          key: LITESTREAM_ACCESS_KEY_ID
         secretAccessKey:
           name: postgresql-backup-s3
-          key: secretKey
+          key: LITESTREAM_SECRET_ACCESS_KEY
     retentionPolicy: 30d

--- a/apps/04-databases/postgresql-shared/overlays/prod/backup-s3-secret-patch.yaml
+++ b/apps/04-databases/postgresql-shared/overlays/prod/backup-s3-secret-patch.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: postgresql-backup-s3
+spec:
+  authentication:
+    universalAuth:
+      secretsScope:
+        envSlug: prod

--- a/apps/04-databases/postgresql-shared/overlays/prod/kustomization.yaml
+++ b/apps/04-databases/postgresql-shared/overlays/prod/kustomization.yaml
@@ -6,6 +6,10 @@ resources:
   - ../../base
 patches:
   - path: patch-credentials-env.yaml
+  - target:
+      kind: InfisicalSecret
+      name: postgresql-backup-s3
+    path: backup-s3-secret-patch.yaml
   - path: backup-patch.yaml
     target:
       group: postgresql.cnpg.io


### PR DESCRIPTION
## Summary
- Update InfisicalSecret to use `/shared/litestream` path (shared S3 credentials)
- Use correct key names (`LITESTREAM_ACCESS_KEY_ID`, `LITESTREAM_SECRET_ACCESS_KEY`)
- Add prod overlay patch for `envSlug: prod`

## Problem
PostgreSQL WAL files were accumulating (50GB) because backup archiving was failing with `failed to get envs: cache miss`. The `postgresql-backup-s3` secret was empty because no credentials existed in Infisical at the original path `/apps/04-databases/postgresql-shared`.

## Solution
Reuse the existing shared S3 credentials from `/shared/litestream` path, following the DRY pattern used by other apps (sonarr, radarr, etc.).

## Test plan
- [ ] ArgoCD syncs successfully
- [ ] InfisicalSecret syncs credentials (check `kubectl get secret postgresql-backup-s3 -n databases -o jsonpath='{.data}' | jq 'keys'`)
- [ ] WAL archiving starts working (check CNPG logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL backup credentials path resolution to reference new shared location for improved organization and accessibility
  * Modified S3 credential environment variable mappings and naming conventions for backup operations
  * Added production environment backup secret configuration with associated deployment patches and configurations
  * Enhanced infrastructure for improved credential and secret management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->