### PR TITLE
fix(postgresql): use correct S3 bucket for backups

### DIFF
--- a/apps/04-databases/postgresql-shared/overlays/prod/backup-patch.yaml
+++ b/apps/04-databases/postgresql-shared/overlays/prod/backup-patch.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   backup:
     barmanObjectStore:
-      destinationPath: s3://postgresql-backups/
+      destinationPath: s3://backups-vixens-prod/postgresql/
       endpointURL: http://192.168.111.69:9000
       s3Credentials:
         accessKeyId:


### PR DESCRIPTION
## Summary
- Use shared litestream bucket (`backups-vixens-prod/postgresql/`) instead of non-existent `postgresql-backups` bucket

## Problem
After fixing S3 credentials (#1025), backup was still failing with `403 Forbidden` because the bucket `postgresql-backups` doesn't exist. The credentials are for the shared litestream bucket.

## Test plan
- [ ] ArgoCD syncs successfully
- [ ] WAL archiving starts working (check for successful archive logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backup storage configuration in the production environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->