### PR TITLE
feat(velero): add Velero for cluster backups

### DIFF
--- a/apps/00-infra/velero/README.md
+++ b/apps/00-infra/velero/README.md
@@ -1,0 +1,64 @@
+# Velero - Kubernetes Backup Solution
+
+Velero provides backup and restore capabilities for Kubernetes cluster resources and persistent volumes.
+
+## Configuration
+
+### Infisical Secret Setup
+
+Before deploying Velero, create the following secret in Infisical:
+
+**Path:** `/shared/velero`
+**Environment:** `prod` (or `dev` for development)
+
+**Required key:**
+- `cloud` - AWS credentials file format:
+  ```
+  [default]
+  aws_access_key_id=<your_minio_access_key>
+  aws_secret_access_key=<your_minio_secret_key>
+  ```
+
+You can reuse the same credentials as litestream if they have access to the backup bucket.
+
+### Backup Schedules (Production)
+
+| Schedule | Frequency | Retention | Namespaces |
+|----------|-----------|-----------|------------|
+| daily-critical | 2 AM daily | 30 days | databases, tools, security |
+| weekly-full | 3 AM Sunday | 90 days | All (except kube-*) |
+| daily-home | 4 AM daily | 7 days | home |
+
+### Storage
+
+Backups are stored in MinIO on the Synology NAS:
+- **Endpoint:** `http://192.168.111.69:9000`
+- **Bucket:** `backups-vixens-prod`
+- **Prefix:** `velero/`
+
+## Manual Operations
+
+### Create a manual backup
+```bash
+velero backup create my-backup --include-namespaces=my-namespace
+```
+
+### Restore from backup
+```bash
+velero restore create --from-backup my-backup
+```
+
+### List backups
+```bash
+velero backup get
+```
+
+### Check backup logs
+```bash
+velero backup logs my-backup
+```
+
+## References
+
+- [Velero Documentation](https://velero.io/docs/)
+- [Velero Helm Chart](https://github.com/vmware-tanzu/helm-charts/tree/main/charts/velero)

--- a/apps/00-infra/velero/base/kustomization.yaml
+++ b/apps/00-infra/velero/base/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: velero
+resources:
+  - namespace.yaml
+  - velero-credentials-secret.yaml

--- a/apps/00-infra/velero/base/namespace.yaml
+++ b/apps/00-infra/velero/base/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velero
+  labels:
+    app.kubernetes.io/name: velero

--- a/apps/00-infra/velero/base/velero-credentials-secret.yaml
+++ b/apps/00-infra/velero/base/velero-credentials-secret.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: velero-s3-credentials
+  namespace: velero
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
+  authentication:
+    universalAuth:
+      credentialsRef:
+        secretName: infisical-universal-auth
+        secretNamespace: argocd
+      secretsScope:
+        projectSlug: vixens
+        envSlug: dev
+        secretsPath: /shared/velero
+  managedSecretReference:
+    secretName: velero-s3-credentials
+    creationPolicy: Owner
+    secretNamespace: velero

--- a/apps/00-infra/velero/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/velero/overlays/prod/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: velero
+resources:
+  - ../../base
+patches:
+  - target:
+      kind: InfisicalSecret
+      name: velero-s3-credentials
+    patch: |-
+      - op: replace
+        path: /spec/authentication/universalAuth/secretsScope/envSlug
+        value: prod
+labels:
+  - pairs:
+      environment: prod
+    includeSelectors: false

--- a/apps/00-infra/velero/values/common.yaml
+++ b/apps/00-infra/velero/values/common.yaml
@@ -1,0 +1,62 @@
+# Velero - Common Helm Values
+# Shared configuration across all environments
+
+image:
+  repository: velero/velero
+  tag: v1.15.2
+  pullPolicy: IfNotPresent
+
+# Use AWS plugin for S3-compatible storage (MinIO)
+initContainers:
+  - name: velero-plugin-for-aws
+    image: velero/velero-plugin-for-aws:v1.11.1
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+      - mountPath: /target
+        name: plugins
+
+# Resource limits
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+# Node agent (for PV backups via restic/kopia)
+nodeAgent:
+  enabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# Metrics for Prometheus
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: false  # Enable when Prometheus operator is ready
+    additionalLabels: {}
+
+# Tolerations for control plane nodes
+tolerations:
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
+
+# Node agent tolerations
+nodeAgent:
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+
+# Upgrade CRDs with Helm
+upgradeCRDs: true
+
+# Clean up completed upgrade jobs
+cleanUpCRDs: false

--- a/apps/00-infra/velero/values/prod.yaml
+++ b/apps/00-infra/velero/values/prod.yaml
@@ -1,0 +1,74 @@
+# Velero - Production Environment Values
+
+# Use existing secret for credentials (created by InfisicalSecret)
+credentials:
+  useSecret: true
+  existingSecret: velero-s3-credentials
+
+# Backup storage location - MinIO on Synology NAS
+configuration:
+  backupStorageLocation:
+    - name: default
+      provider: aws
+      bucket: backups-vixens-prod
+      prefix: velero
+      default: true
+      accessMode: ReadWrite
+      config:
+        region: us-east-1  # MinIO default
+        s3ForcePathStyle: "true"
+        s3Url: http://192.168.111.69:9000
+
+  # Volume snapshot location (optional, for CSI snapshots)
+  volumeSnapshotLocation: []
+
+  # Default backup TTL
+  defaultBackupTTL: 720h  # 30 days
+
+  # Garbage collection frequency
+  garbageCollectionFrequency: 1h
+
+  # Default repo maintenance frequency
+  defaultRepoMaintainFrequency: 1h
+
+# Backup schedules
+schedules:
+  # Daily backup of critical namespaces
+  daily-critical:
+    disabled: false
+    schedule: "0 2 * * *"  # 2 AM daily
+    template:
+      ttl: "720h"  # 30 days retention
+      storageLocation: default
+      includedNamespaces:
+        - databases
+        - tools
+        - security
+      snapshotVolumes: true
+      snapshotMoveData: false
+
+  # Weekly full cluster backup
+  weekly-full:
+    disabled: false
+    schedule: "0 3 * * 0"  # 3 AM Sunday
+    template:
+      ttl: "2160h"  # 90 days retention
+      storageLocation: default
+      includedNamespaces:
+        - "*"
+      excludedNamespaces:
+        - kube-system
+        - kube-public
+        - kube-node-lease
+      snapshotVolumes: true
+
+  # Daily backup of home automation
+  daily-home:
+    disabled: false
+    schedule: "0 4 * * *"  # 4 AM daily
+    template:
+      ttl: "168h"  # 7 days retention
+      storageLocation: default
+      includedNamespaces:
+        - home
+      snapshotVolumes: true

--- a/argocd/overlays/prod/apps/velero.yaml
+++ b/argocd/overlays/prod/apps/velero.yaml
@@ -1,0 +1,46 @@
+---
+# Velero - Kubernetes Backup Solution
+# prod environment
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: velero
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: velero
+  sources:
+    # Helm chart from VMware-Tanzu repository
+    - repoURL: https://vmware-tanzu.github.io/helm-charts
+      chart: velero
+      targetRevision: 8.5.0
+      helm:
+        valueFiles:
+          - $values/apps/00-infra/velero/values/common.yaml
+          - $values/apps/00-infra/velero/values/prod.yaml
+    # Values and additional resources from Git
+    - repoURL: https://github.com/charchess/vixens.git
+      targetRevision: prod-stable
+      ref: values
+    # Kustomize overlay for secrets
+    - repoURL: https://github.com/charchess/vixens.git
+      targetRevision: prod-stable
+      path: apps/00-infra/velero/overlays/prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: argocd
 resources:
   - apps/shared-namespaces.yaml
   - apps/infisical-operator.yaml
+  - apps/velero.yaml
   - apps/cilium-lb.yaml
   - apps/traefik.yaml
   - apps/traefik-middlewares.yaml


### PR DESCRIPTION
## Summary
- Add Velero Helm chart configuration with S3/MinIO backend
- Configure backup schedules for production
- Use InfisicalSecret for credentials from `/shared/velero`

## Backup Schedules
| Schedule | Frequency | Retention | Namespaces |
|----------|-----------|-----------|------------|
| daily-critical | 2 AM daily | 30 days | databases, tools, security |
| weekly-full | 3 AM Sunday | 90 days | All (except kube-*) |
| daily-home | 4 AM daily | 7 days | home |

## Pre-requisites
Create Infisical secret at `/shared/velero` (env: prod) with key `cloud`:
```
[default]
aws_access_key_id=<minio_access_key>
aws_secret_access_key=<minio_secret_key>
```

## Test plan
- [ ] Create Infisical secret
- [ ] ArgoCD syncs successfully
- [ ] Velero pod is running
- [ ] `velero backup-location get` shows valid storage
- [ ] Manual backup test: `velero backup create test-backup --include-namespaces=tools`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Velero backup solution now available with automated backup schedules for production environments
  * MinIO storage backend configured for backup storage
  
* **Documentation**
  * Added comprehensive Velero setup and usage guide covering configuration, backup schedules, manual operations, and troubleshooting references
  
* **Chores**
  * Infrastructure deployment configuration and ArgoCD integration for Velero established

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->