### PR TITLE
fix(velero): restructure to follow project standards

### DIFF
--- a/apps/00-infra/velero/README.md
+++ b/apps/00-infra/velero/README.md
@@ -8,7 +8,7 @@ Velero provides backup and restore capabilities for Kubernetes cluster resources
 
 Before deploying Velero, create the following secret in Infisical:
 
-**Path:** `/shared/velero`
+**Path:** `/apps/00-infra/velero`
 **Environment:** `prod` (or `dev` for development)
 
 **Required key:**

--- a/apps/00-infra/velero/base/namespace.yaml
+++ b/apps/00-infra/velero/base/namespace.yaml
@@ -1,7 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: velero
-  labels:
-    app.kubernetes.io/name: velero

--- a/apps/00-infra/velero/infisical/base/kustomization.yaml
+++ b/apps/00-infra/velero/infisical/base/kustomization.yaml
@@ -1,7 +1,5 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: velero
 resources:
-  - namespace.yaml
-  - velero-credentials-secret.yaml
+  - velero-infisical-secret.yaml

--- a/apps/00-infra/velero/infisical/base/velero-infisical-secret.yaml
+++ b/apps/00-infra/velero/infisical/base/velero-infisical-secret.yaml
@@ -2,10 +2,8 @@
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
-  name: velero-s3-credentials
+  name: velero-credentials-sync
   namespace: velero
-  annotations:
-    argocd.argoproj.io/sync-wave: "0"
 spec:
   hostAPI: http://192.168.111.69:8085
   resyncInterval: 60
@@ -17,8 +15,9 @@ spec:
       secretsScope:
         projectSlug: vixens
         envSlug: dev
-        secretsPath: /shared/velero
+        secretsPath: /apps/00-infra/velero
   managedSecretReference:
     secretName: velero-s3-credentials
     creationPolicy: Owner
+    secretType: Opaque
     secretNamespace: velero

--- a/apps/00-infra/velero/infisical/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/velero/infisical/overlays/dev/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: velero
+resources:
+  - ../../base

--- a/apps/00-infra/velero/infisical/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/velero/infisical/overlays/prod/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: velero
+resources:
+  - ../../base
+patches:
+  - path: velero-infisical-secret-patch.yaml
+    target:
+      kind: InfisicalSecret
+      name: velero-credentials-sync

--- a/apps/00-infra/velero/infisical/overlays/prod/velero-infisical-secret-patch.yaml
+++ b/apps/00-infra/velero/infisical/overlays/prod/velero-infisical-secret-patch.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: velero-credentials-sync
+  namespace: velero
+spec:
+  authentication:
+    universalAuth:
+      secretsScope:
+        envSlug: prod

--- a/apps/00-infra/velero/infisical/overlays/staging/kustomization.yaml
+++ b/apps/00-infra/velero/infisical/overlays/staging/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: velero
+resources:
+  - ../../base
+patches:
+  - target:
+      kind: InfisicalSecret
+      name: velero-credentials-sync
+    patch: |-
+      - op: replace
+        path: /spec/authentication/universalAuth/secretsScope/envSlug
+        value: staging

--- a/apps/00-infra/velero/infisical/overlays/test/kustomization.yaml
+++ b/apps/00-infra/velero/infisical/overlays/test/kustomization.yaml
@@ -7,12 +7,8 @@ resources:
 patches:
   - target:
       kind: InfisicalSecret
-      name: velero-s3-credentials
+      name: velero-credentials-sync
     patch: |-
       - op: replace
         path: /spec/authentication/universalAuth/secretsScope/envSlug
-        value: prod
-labels:
-  - pairs:
-      environment: prod
-    includeSelectors: false
+        value: test

--- a/argocd/overlays/prod/apps/velero-secrets.yaml
+++ b/argocd/overlays/prod/apps/velero-secrets.yaml
@@ -1,0 +1,33 @@
+---
+# velero-secrets - prod environment
+# Manages Infisical integration for Velero S3 credentials
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: velero-secrets
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"  # Deploy before velero
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: velero
+  source:
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: prod-stable
+    path: apps/00-infra/velero/infisical/overlays/prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/overlays/prod/apps/velero.yaml
+++ b/argocd/overlays/prod/apps/velero.yaml
@@ -7,7 +7,7 @@ metadata:
   name: velero
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "1"  # After velero-secrets
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -24,14 +24,10 @@ spec:
         valueFiles:
           - $values/apps/00-infra/velero/values/common.yaml
           - $values/apps/00-infra/velero/values/prod.yaml
-    # Values and additional resources from Git
+    # Values from Git repository
     - repoURL: https://github.com/charchess/vixens.git
       targetRevision: prod-stable
       ref: values
-    # Kustomize overlay for secrets
-    - repoURL: https://github.com/charchess/vixens.git
-      targetRevision: prod-stable
-      path: apps/00-infra/velero/overlays/prod
   syncPolicy:
     automated:
       prune: true

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: argocd
 resources:
   - apps/shared-namespaces.yaml
   - apps/infisical-operator.yaml
+  - apps/velero-secrets.yaml
   - apps/velero.yaml
   - apps/cilium-lb.yaml
   - apps/traefik.yaml


### PR DESCRIPTION
## Summary
Corrects Velero structure to follow project standards:

- Move secrets to `infisical/` subdirectory with `base/overlays` structure
- Create separate `velero-secrets` ArgoCD Application (sync-wave 0)
- Use `/apps/00-infra/velero` path in Infisical (not `/shared/velero`)
- Remove incorrect `base/overlays` for Helm-only app

## Structure After
```
apps/00-infra/velero/
├── README.md
├── values/
│   ├── common.yaml
│   └── prod.yaml
└── infisical/
    ├── base/
    │   ├── kustomization.yaml
    │   └── velero-infisical-secret.yaml
    └── overlays/
        ├── dev/
        ├── prod/
        ├── staging/
        └── test/
```

## Infisical Secret Required
**Path:** `/apps/00-infra/velero`
**Key:** `cloud`
```
[default]
aws_access_key_id=<access_key>
aws_secret_access_key=<secret_key>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated secret management configuration paths in Velero setup documentation.

* **Chores**
  * Restructured Velero infrastructure configuration with improved environment-specific overlays (dev, staging, test, prod).
  * Integrated secret management automation for Velero deployments.
  * Simplified and reorganized Kubernetes resource definitions for better maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->