### PR TITLE
fix(velero): resolve image pull and credentials issues

### DIFF
--- a/apps/00-infra/velero/README.md
+++ b/apps/00-infra/velero/README.md
@@ -4,22 +4,13 @@ Velero provides backup and restore capabilities for Kubernetes cluster resources
 
 ## Configuration
 
-### Infisical Secret Setup
+### Credentials
 
-Before deploying Velero, create the following secret in Infisical:
+Velero uses the **shared litestream credentials** from `/shared/litestream` in Infisical.
 
-**Path:** `/apps/00-infra/velero`
-**Environment:** `prod` (or `dev` for development)
+No additional secret creation needed - the existing litestream S3 credentials are reused.
 
-**Required key:**
-- `cloud` - AWS credentials file format:
-  ```
-  [default]
-  aws_access_key_id=<your_minio_access_key>
-  aws_secret_access_key=<your_minio_secret_key>
-  ```
-
-You can reuse the same credentials as litestream if they have access to the backup bucket.
+The Helm values map `LITESTREAM_ACCESS_KEY_ID` → `AWS_ACCESS_KEY_ID` automatically.
 
 ### Backup Schedules (Production)
 

--- a/apps/00-infra/velero/infisical/base/velero-infisical-secret.yaml
+++ b/apps/00-infra/velero/infisical/base/velero-infisical-secret.yaml
@@ -15,7 +15,7 @@ spec:
       secretsScope:
         projectSlug: vixens
         envSlug: dev
-        secretsPath: /apps/00-infra/velero
+        secretsPath: /shared/litestream
   managedSecretReference:
     secretName: velero-s3-credentials
     creationPolicy: Owner

--- a/apps/00-infra/velero/values/common.yaml
+++ b/apps/00-infra/velero/values/common.yaml
@@ -6,6 +6,20 @@ image:
   tag: v1.15.2
   pullPolicy: IfNotPresent
 
+# Kubectl image for CRD upgrade jobs
+# Note: bitnami/kubectl no longer provides versioned tags after Aug 2025
+kubectl:
+  image:
+    repository: docker.io/bitnami/kubectl
+    tag: latest
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+
 # Use AWS plugin for S3-compatible storage (MinIO)
 initContainers:
   - name: velero-plugin-for-aws
@@ -24,6 +38,9 @@ resources:
     cpu: 500m
     memory: 512Mi
 
+# Priority class for Kyverno compliance
+priorityClassName: vixens-infrastructure
+
 # Node agent (for PV backups via restic/kopia)
 nodeAgent:
   enabled: true
@@ -34,6 +51,10 @@ nodeAgent:
     limits:
       cpu: 500m
       memory: 512Mi
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
 
 # Metrics for Prometheus
 metrics:
@@ -42,18 +63,11 @@ metrics:
     enabled: false  # Enable when Prometheus operator is ready
     additionalLabels: {}
 
-# Tolerations for control plane nodes
+# Tolerations for control plane nodes (main deployment)
 tolerations:
   - key: node-role.kubernetes.io/control-plane
     operator: Exists
     effect: NoSchedule
-
-# Node agent tolerations
-nodeAgent:
-  tolerations:
-    - key: node-role.kubernetes.io/control-plane
-      operator: Exists
-      effect: NoSchedule
 
 # Upgrade CRDs with Helm
 upgradeCRDs: true

--- a/apps/00-infra/velero/values/prod.yaml
+++ b/apps/00-infra/velero/values/prod.yaml
@@ -1,9 +1,21 @@
 # Velero - Production Environment Values
 
-# Use existing secret for credentials (created by InfisicalSecret)
+# Disable built-in credentials - we use env vars from shared litestream secret
 credentials:
-  useSecret: true
-  existingSecret: velero-s3-credentials
+  useSecret: false
+
+# Map LITESTREAM_* to AWS_* via environment variables
+extraEnvVars:
+  AWS_ACCESS_KEY_ID:
+    valueFrom:
+      secretKeyRef:
+        name: velero-s3-credentials
+        key: LITESTREAM_ACCESS_KEY_ID
+  AWS_SECRET_ACCESS_KEY:
+    valueFrom:
+      secretKeyRef:
+        name: velero-s3-credentials
+        key: LITESTREAM_SECRET_ACCESS_KEY
 
 # Backup storage location - MinIO on Synology NAS
 configuration:


### PR DESCRIPTION
## Summary

- Use `bitnami/kubectl:latest` - versioned tags deprecated after Aug 2025
- Add `priorityClassName: vixens-infrastructure` for Kyverno compliance
- Consolidate duplicate `nodeAgent` blocks
- Switch to shared litestream credentials from `/shared/litestream`
- Use `extraEnvVars` to map `LITESTREAM_*` to `AWS_*` environment variables

## Test plan

- [ ] Verify ArgoCD syncs velero-secrets app successfully
- [ ] Verify InfisicalSecret syncs credentials (should show >0 secrets)
- [ ] Verify velero-upgrade-crds job completes without ImagePullBackOff
- [ ] Verify Velero deployment starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined credentials documentation; clarified that shared litestream credentials are reused.

* **Chores**
  * Updated secret path configuration to use shared credentials.
  * Enhanced Kubernetes configuration with kubectl image settings, priority class, node tolerations, and metrics.
  * Switched credential handling to environment-based mapping.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->