### PR TITLE
fix(velero): disable upgradeCRDs due to library compatibility issue

### DIFF
--- a/apps/00-infra/velero/values/common.yaml
+++ b/apps/00-infra/velero/values/common.yaml
@@ -70,7 +70,9 @@ tolerations:
     effect: NoSchedule
 
 # Upgrade CRDs with Helm
-upgradeCRDs: true
+# Note: Disabled due to library compatibility issue in velero image for upgrade job
+# CRDs are installed manually or via pre-sync hook
+upgradeCRDs: false
 
 # Clean up completed upgrade jobs
 cleanUpCRDs: false


### PR DESCRIPTION
## Summary

- Disable `upgradeCRDs` due to library compatibility issue (`libreadline.so.8` missing in velero image)
- CRDs are already installed or can be managed separately

## Root cause

The velero image v1.15.2 has a missing library when running the CRD upgrade job in the Helm chart context.

## Test plan

- [ ] Verify velero deployment starts without the upgrade-crds job blocking
- [ ] Verify velero pods are running successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified Velero configuration to change how Custom Resource Definitions are managed, transitioning from automatic Helm-based updates to manual installation or pre-sync hook methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->