### PR TITLE
fix(velero): use correct priorityClassName vixens-critical

### DIFF
--- a/apps/00-infra/velero/values/common.yaml
+++ b/apps/00-infra/velero/values/common.yaml
@@ -39,7 +39,7 @@ resources:
     memory: 512Mi
 
 # Priority class for Kyverno compliance
-priorityClassName: vixens-infrastructure
+priorityClassName: vixens-critical
 
 # Node agent (for PV backups via restic/kopia)
 nodeAgent:


### PR DESCRIPTION
## Summary

- Fix PriorityClass name: `vixens-infrastructure` → `vixens-critical`
- `vixens-infrastructure` doesn't exist in the cluster

## Test plan

- [ ] Verify velero pods start successfully with the correct PriorityClass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Velero's Kubernetes priority class configuration to optimize scheduling behavior and resource allocation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->