### PR TITLE
fix(velero): correct extraEnvVars format to list

### DIFF
--- a/apps/00-infra/velero/values/prod.yaml
+++ b/apps/00-infra/velero/values/prod.yaml
@@ -6,12 +6,12 @@ credentials:
 
 # Map LITESTREAM_* to AWS_* via environment variables
 extraEnvVars:
-  AWS_ACCESS_KEY_ID:
+  - name: AWS_ACCESS_KEY_ID
     valueFrom:
       secretKeyRef:
         name: velero-s3-credentials
         key: LITESTREAM_ACCESS_KEY_ID
-  AWS_SECRET_ACCESS_KEY:
+  - name: AWS_SECRET_ACCESS_KEY
     valueFrom:
       secretKeyRef:
         name: velero-s3-credentials


### PR DESCRIPTION
## Summary

- Fix `extraEnvVars` format: must be a list with `name`/`valueFrom` fields, not a map
- This fixes the S3 credentials injection issue causing BackupStorageLocation validation failure

## Test plan

- [ ] Verify AWS_* env vars are set in velero pod
- [ ] Verify BackupStorageLocation becomes available

🤖 Generated with [Claude Code](https://claude.com/claude-code)