### PR TITLE
fix(velero): move extraEnvVars under configuration section

### DIFF
--- a/apps/00-infra/velero/values/prod.yaml
+++ b/apps/00-infra/velero/values/prod.yaml
@@ -4,21 +4,21 @@
 credentials:
   useSecret: false
 
-# Map LITESTREAM_* to AWS_* via environment variables
-extraEnvVars:
-  - name: AWS_ACCESS_KEY_ID
-    valueFrom:
-      secretKeyRef:
-        name: velero-s3-credentials
-        key: LITESTREAM_ACCESS_KEY_ID
-  - name: AWS_SECRET_ACCESS_KEY
-    valueFrom:
-      secretKeyRef:
-        name: velero-s3-credentials
-        key: LITESTREAM_SECRET_ACCESS_KEY
-
 # Backup storage location - MinIO on Synology NAS
 configuration:
+  # Map LITESTREAM_* to AWS_* via environment variables
+  extraEnvVars:
+    - name: AWS_ACCESS_KEY_ID
+      valueFrom:
+        secretKeyRef:
+          name: velero-s3-credentials
+          key: LITESTREAM_ACCESS_KEY_ID
+    - name: AWS_SECRET_ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          name: velero-s3-credentials
+          key: LITESTREAM_SECRET_ACCESS_KEY
+
   backupStorageLocation:
     - name: default
       provider: aws


### PR DESCRIPTION
## Summary

- Move `extraEnvVars` under `configuration:` section where Velero Helm chart expects it
- This fixes S3 credentials injection that was not working at the top level

## Test plan

- [ ] Verify AWS_* env vars are now set in velero pod
- [ ] Verify BackupStorageLocation becomes available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized infrastructure configuration for improved code structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->