### PR TITLE
feat(velero): add credentials sync CronJob for AWS key transformation

### DIFF
--- a/apps/00-infra/velero/infisical/base/kustomization.yaml
+++ b/apps/00-infra/velero/infisical/base/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - velero-infisical-secret.yaml
+  - velero-credentials-transform.yaml

--- a/apps/00-infra/velero/infisical/base/velero-credentials-transform.yaml
+++ b/apps/00-infra/velero/infisical/base/velero-credentials-transform.yaml
@@ -1,0 +1,78 @@
+---
+# Transform InfisicalSecret output to Velero-compatible format
+# This CronJob syncs LITESTREAM_* keys to AWS_* keys in the 'velero' secret
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: velero-credentials-sync
+  namespace: velero
+spec:
+  schedule: "*/5 * * * *"  # Every 5 minutes
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: velero-credentials-sync
+          restartPolicy: OnFailure
+          priorityClassName: vixens-low
+          tolerations:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+              effect: NoSchedule
+          containers:
+            - name: sync
+              image: bitnami/kubectl:latest
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  # Read source secret
+                  ACCESS_KEY=$(kubectl get secret velero-s3-credentials -n velero -o jsonpath='{.data.LITESTREAM_ACCESS_KEY_ID}')
+                  SECRET_KEY=$(kubectl get secret velero-s3-credentials -n velero -o jsonpath='{.data.LITESTREAM_SECRET_ACCESS_KEY}')
+
+                  # Create/update velero secret with AWS_ keys
+                  kubectl create secret generic velero -n velero \
+                    --from-literal=AWS_ACCESS_KEY_ID="$(echo $ACCESS_KEY | base64 -d)" \
+                    --from-literal=AWS_SECRET_ACCESS_KEY="$(echo $SECRET_KEY | base64 -d)" \
+                    --dry-run=client -o yaml | kubectl apply -f -
+
+                  echo "Velero credentials synced successfully"
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 50m
+                  memory: 64Mi
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: velero-credentials-sync
+  namespace: velero
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: velero-credentials-sync
+  namespace: velero
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: velero-credentials-sync
+  namespace: velero
+subjects:
+  - kind: ServiceAccount
+    name: velero-credentials-sync
+    namespace: velero
+roleRef:
+  kind: Role
+  name: velero-credentials-sync
+  apiGroup: rbac.authorization.k8s.io

--- a/apps/00-infra/velero/values/prod.yaml
+++ b/apps/00-infra/velero/values/prod.yaml
@@ -1,13 +1,9 @@
 # Velero - Production Environment Values
 
-# Disable file-based credentials, use env vars instead
+# Use velero secret for AWS credentials (created by credentials-sync CronJob)
 credentials:
   useSecret: false
-  # Map litestream secret keys to AWS_ env vars
-  extraEnvVars:
-    AWS_ACCESS_KEY_ID: LITESTREAM_ACCESS_KEY_ID
-    AWS_SECRET_ACCESS_KEY: LITESTREAM_SECRET_ACCESS_KEY
-  extraSecretRef: velero-s3-credentials
+  extraSecretRef: velero
 
 # Backup storage location - MinIO on Synology NAS
 configuration:


### PR DESCRIPTION
## Summary

- Add CronJob to transform `LITESTREAM_*` keys to `AWS_*` keys every 5 minutes
- Creates/updates `velero` secret with AWS credentials format expected by velero-plugin-for-aws
- Includes ServiceAccount, Role, and RoleBinding for proper RBAC
- Simplifies prod.yaml credentials configuration

## Why

The Infisical secret syncs with `LITESTREAM_*` keys (shared credentials), but velero-plugin-for-aws expects `AWS_*` keys. The CronJob bridges this gap in a GitOps-compliant way.

## Test plan

- [x] Velero pod starts successfully (1/1 Running)
- [x] BackupStorageLocation is Available
- [x] All 3 schedules are Enabled
- [ ] CronJob runs successfully every 5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated credential synchronization service for infrastructure that executes every 5 minutes to ensure AWS credentials remain synchronized and current across the system.
  * Updated system configuration to reference the new credential synchronization mechanism, enhancing security practices and providing consistent, automated credential management across infrastructure components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->