### PR TITLE
fix(penpot): switch from S3 to filesystem storage with PVC

### DIFF
--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -49,11 +49,9 @@ spec:
                   name: penpot-secrets
                   key: PENPOT_REDIS_URI
             - name: PENPOT_OBJECTS_STORAGE_BACKEND
-              value: "s3"
-            - name: PENPOT_OBJECTS_STORAGE_S3_REGION
-              value: "eu-west-3"
-            - name: PENPOT_OBJECTS_STORAGE_S3_BUCKET
-              value: "penpot-assets"
+              value: "fs"
+            - name: PENPOT_OBJECTS_STORAGE_FS_DIRECTORY
+              value: "/opt/data/objects"
           ports:
             - containerPort: 6060
               name: http
@@ -77,4 +75,11 @@ spec:
             initialDelaySeconds: 120
             periodSeconds: 30
             failureThreshold: 5
+          volumeMounts:
+            - name: data
+              mountPath: /opt/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: penpot-data
       restartPolicy: Always

--- a/apps/70-tools/penpot/base/kustomization.yaml
+++ b/apps/70-tools/penpot/base/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - pvc.yaml
   - deployment-backend.yaml
   - deployment-frontend.yaml
   - deployment-exporter.yaml

--- a/apps/70-tools/penpot/base/pvc.yaml
+++ b/apps/70-tools/penpot/base/pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: penpot-data
+  namespace: tools
+  labels:
+    app: penpot
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: synelia-iscsi-retain
+  resources:
+    requests:
+      storage: 50Gi


### PR DESCRIPTION
## Summary
- Add penpot-data PVC (50Gi, synelia-iscsi-retain) for persistent storage
- Configure backend to use filesystem storage at `/opt/data/objects`
- Remove unused S3 configuration (no credentials were configured anyway)
- Uses Recreate deployment strategy for RWO PVC compatibility

## Context
Penpot was configured for S3 storage but had no credentials, making file storage non-functional. The filesystem backend is the recommended approach for self-hosted deployments and doesn't require external S3 infrastructure.

## Test plan
- [ ] ArgoCD syncs successfully
- [ ] Penpot backend pod starts with new volume mount
- [ ] PVC is created and bound
- [ ] Verify file uploads work at https://design.truxonline.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated Penpot object storage from cloud-based backend to local filesystem storage.
  * Configured persistent volume storage with 50Gi capacity for data retention.
  * Added necessary storage mounting and persistence configurations to the deployment infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->