### PR TITLE
fix(penpot): disable email verification (no SMTP configured)

### DIFF
--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -35,7 +35,7 @@ spec:
                 name: penpot-secrets
           env:
             - name: PENPOT_FLAGS
-              value: "enable-registration enable-login-with-password disable-secure-session-cookies enable-smtp enable-email-verification"
+              value: "enable-registration enable-login-with-password disable-secure-session-cookies"
             - name: PENPOT_PUBLIC_URI
               value: "https://design.truxonline.com"
             - name: PENPOT_DATABASE_URI


### PR DESCRIPTION
## Summary
- Remove `enable-smtp` and `enable-email-verification` flags
- No SMTP server is configured, so email verification was blocking user registration

## Test plan
- [ ] ArgoCD syncs
- [ ] Create a new account on https://design.truxonline.com
- [ ] Verify registration works without email confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend deployment configuration, disabling email verification and SMTP notification features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->