### PR TITLE
fix(penpot): explicitly disable email verification

### DIFF
--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -35,7 +35,7 @@ spec:
                 name: penpot-secrets
           env:
             - name: PENPOT_FLAGS
-              value: "enable-registration enable-login-with-password disable-secure-session-cookies"
+              value: "enable-registration enable-login-with-password disable-secure-session-cookies disable-email-verification"
             - name: PENPOT_PUBLIC_URI
               value: "https://design.truxonline.com"
             - name: PENPOT_DATABASE_URI


### PR DESCRIPTION
## Summary
Add `disable-email-verification` flag - Penpot enables email verification by default, so we need to explicitly disable it.

## Context
Previous PR removed `enable-email-verification` but Penpot has this enabled by default. Backend logs showed `email-verification` still active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Backend configuration updated to disable email verification functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->