### PR TITLE
fix(homeassistant): exclude litestream dir from rclone sync

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ingressroute-udp.yaml
   - infisical-filebrowser-auth.yaml
 patches:
+  - path: rclone-patch.yaml
   - path: infisical-config-patch.yaml
   - path: litestream-secret-patch.yaml
     target:

--- a/apps/10-home/homeassistant/overlays/prod/rclone-patch.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/rclone-patch.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homeassistant
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: restore-config
+          args:
+            - |
+              export RCLONE_CONFIG_S3_TYPE=s3
+              export RCLONE_CONFIG_S3_PROVIDER=Other
+              export RCLONE_CONFIG_S3_ACCESS_KEY_ID=$LITESTREAM_ACCESS_KEY_ID
+              export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=$LITESTREAM_SECRET_ACCESS_KEY
+              export RCLONE_CONFIG_S3_ENDPOINT=$LITESTREAM_ENDPOINT
+              rclone copy s3:$LITESTREAM_BUCKET/homeassistant/config /config --transfers 4 --exclude "*.db*" --exclude "*.log" --exclude "tts/**" --exclude "tmp_backups/**" --exclude ".home-assistant_v2.db-litestream/**" 2>/dev/null || true
+      containers:
+        - name: config-syncer
+          args:
+            - |
+              apk add --no-cache rclone inotify-tools
+              export RCLONE_CONFIG_S3_TYPE=s3
+              export RCLONE_CONFIG_S3_PROVIDER=Other
+              export RCLONE_CONFIG_S3_ACCESS_KEY_ID=$LITESTREAM_ACCESS_KEY_ID
+              export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=$LITESTREAM_SECRET_ACCESS_KEY
+              export RCLONE_CONFIG_S3_ENDPOINT=$LITESTREAM_ENDPOINT
+              sync_s3() { rclone sync /config s3:$LITESTREAM_BUCKET/homeassistant/config --exclude "*.db*" --exclude "*.log" --exclude "tts/**" --exclude "tmp_backups/**" --exclude ".home-assistant_v2.db-litestream/**"; }
+              sync_s3
+              while true; do inotifywait -r -e modify,create,delete,move /config --exclude ".*\.db.*"; sync_s3; sleep 10; done


### PR DESCRIPTION
Excludes the Litestream working directory (`.home-assistant_v2.db-litestream`) from rclone's restore and sync operations. This directory was causing massive storage bloat (145GB) on both the local PVC and S3 storage, leading to 100% disk usage and constant pod restarts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration synchronization capability with cloud storage, enabling automatic backup and restoration of settings while excluding system-managed directories and database files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->