### PR TITLE
chore: force argocd refresh

### DIFF
--- a/argocd/overlays/prod/apps/homeassistant.yaml
+++ b/argocd/overlays/prod/apps/homeassistant.yaml
@@ -7,6 +7,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
+    gitops.vixens.io/force-refresh: "20260129-0455"
     argocd.argoproj.io/sync-wave: "10"
 spec:
   project: default

--- a/argocd/overlays/prod/apps/vaultwarden.yaml
+++ b/argocd/overlays/prod/apps/vaultwarden.yaml
@@ -7,6 +7,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
+    gitops.vixens.io/force-refresh: "20260129-0455"
     argocd.argoproj.io/sync-wave: "10"
 spec:
   project: default


### PR DESCRIPTION
Annotation update to trigger sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configurations for Home Assistant and Vaultwarden services to ensure proper synchronization and refresh during deployment operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->