### PR TITLE
chore(adguard): single replica for stability

### DIFF
--- a/apps/40-network/adguard-home/base/adguard-ss.yaml
+++ b/apps/40-network/adguard-home/base/adguard-ss.yaml
@@ -7,7 +7,7 @@ metadata:
     app: adguard-home
 spec:
   serviceName: adguard-home-headless
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: adguard-home

--- a/apps/40-network/adguard-home/overlays/prod/ingress.yaml
+++ b/apps/40-network/adguard-home/overlays/prod/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: adguard-home
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
+
 spec:
   rules:
     - host: adguard.truxonline.com


### PR DESCRIPTION
Scaling down AdGuard Home to 1 replica to resolve redirect loops and internal DNS timeouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AdGuard Home deployment replica count to 1
  * Removed sticky cookie annotation from production ingress configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->