### PR TITLE
fix(stirling): resolve probes handler conflict

### DIFF
--- a/apps/70-tools/stirling-pdf/base/values.yaml
+++ b/apps/70-tools/stirling-pdf/base/values.yaml
@@ -25,13 +25,15 @@ tolerations:
 probes:
   liveness:
     enabled: true
-    tcpSocket:
+    httpGet:
+      path: /
       port: 8080
     initialDelaySeconds: 60
     periodSeconds: 10
   readiness:
     enabled: true
-    tcpSocket:
+    httpGet:
+      path: /
       port: 8080
     initialDelaySeconds: 30
     periodSeconds: 10


### PR DESCRIPTION
Replaces tcpSocket with httpGet in values.yaml to fix Kubernetes validation error.