### PR TITLE
chore: cleanup broken shared patches

### DIFF
--- a/apps/01-storage/synology-csi/infisical/overlays/dev/kustomization.yaml
+++ b/apps/01-storage/synology-csi/infisical/overlays/dev/kustomization.yaml
@@ -6,9 +6,3 @@ resources:
   - ../../base
 
 patches:
-  - path: ../../../../../_shared/patches/revision-history-limit-statefulset.yaml
-    target:
-      kind: StatefulSet
-  - path: ../../../../../_shared/patches/revision-history-limit-deployment.yaml
-    target:
-      kind: Deployment

--- a/apps/01-storage/synology-csi/infisical/overlays/prod/kustomization.yaml
+++ b/apps/01-storage/synology-csi/infisical/overlays/prod/kustomization.yaml
@@ -3,12 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: synology-csi
 patches:
-  - path: ../../../../../_shared/patches/revision-history-limit-statefulset.yaml
-    target:
-      kind: StatefulSet
-  - path: ../../../../../_shared/patches/revision-history-limit-deployment.yaml
-    target:
-      kind: Deployment
   - path: synology-infisical-secret-patch.yaml
     target:
       kind: InfisicalSecret

--- a/apps/01-storage/synology-csi/infisical/overlays/staging/kustomization.yaml
+++ b/apps/01-storage/synology-csi/infisical/overlays/staging/kustomization.yaml
@@ -5,12 +5,6 @@ namespace: synology-csi
 resources:
   - ../../base
 patches:
-  - path: ../../../../../_shared/patches/revision-history-limit-statefulset.yaml
-    target:
-      kind: StatefulSet
-  - path: ../../../../../_shared/patches/revision-history-limit-deployment.yaml
-    target:
-      kind: Deployment
   - path: synology-infisical-secret-patch.yaml
     target:
       kind: InfisicalSecret

--- a/apps/01-storage/synology-csi/infisical/overlays/test/kustomization.yaml
+++ b/apps/01-storage/synology-csi/infisical/overlays/test/kustomization.yaml
@@ -5,12 +5,6 @@ namespace: synology-csi
 resources:
   - ../../base
 patches:
-  - path: ../../../../../_shared/patches/revision-history-limit-statefulset.yaml
-    target:
-      kind: StatefulSet
-  - path: ../../../../../_shared/patches/revision-history-limit-deployment.yaml
-    target:
-      kind: Deployment
   - path: synology-infisical-secret-patch.yaml
     target:
       kind: InfisicalSecret


### PR DESCRIPTION
Removes references to the non-existent _shared/patches directory which was blocking Kustomize builds for Synology secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration across development, production, staging, and test environments by removing revision history limit controls for certain resource types. This streamlines the deployment configuration while maintaining other essential settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->