### PR TITLE
fix(frigate): unblock scheduling

### DIFF
--- a/apps/20-media/frigate/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/frigate/overlays/prod/resources-patch.yaml
@@ -13,7 +13,7 @@ spec:
               cpu: 8000m
               memory: 8Gi
             requests:
-              cpu: 2000m
+              cpu: 1000m
               memory: 4Gi
         - name: litestream
           resources:


### PR DESCRIPTION
Lowers CPU requests from 2000m to 1000m to allow the scheduler to place the Frigate pod.