### PR TITLE
fix: media applications sync restoration

### DIFF
--- a/apps/20-media/hydrus-client/overlays/prod/infisical-shared-patch.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/infisical-shared-patch.yaml
@@ -2,7 +2,7 @@
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
-  name: litestream-shared-secrets
+  name: hydrus-client-secrets-sync
 spec:
   authentication:
     universalAuth:

--- a/apps/20-media/sonarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/sonarr/overlays/prod/kustomization.yaml
@@ -13,7 +13,3 @@ patches:
       - op: replace
         path: /spec/authentication/universalAuth/secretsScope/envSlug
         value: prod
-  - target:
-      kind: InfisicalSecret
-      name: sonarr-litestream-secret
-patchesStrategicMerge:


### PR DESCRIPTION
Fixes naming mismatches and orphaned patches that were blocking manifest generation for Sonarr and Hydrus.