### PR TITLE
fix(frigate): NFS mount path

### DIFF
--- a/apps/20-media/frigate/base/deployment.yaml
+++ b/apps/20-media/frigate/base/deployment.yaml
@@ -208,7 +208,7 @@ spec:
         - name: storage
           nfs:
             server: 192.168.111.69
-            path: /volume3/Content/Frigate
+            path: /volume3/Internal/Frigate
         - name: shm
           emptyDir:
             medium: Memory


### PR DESCRIPTION
Corrects the NFS path to /volume3/Internal/Frigate to resolve the mount error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal storage configuration for improved infrastructure management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->