### PR TITLE
fix(media): restore shared litestream secrets

### DIFF
--- a/apps/20-media/litestream-shared-secrets.yaml
+++ b/apps/20-media/litestream-shared-secrets.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: litestream-shared-secrets-sync
+  namespace: media
+spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
+  authentication:
+    universalAuth:
+      credentialsRef:
+        secretName: infisical-universal-auth
+        secretNamespace: argocd
+      secretsScope:
+        projectSlug: vixens
+        envSlug: prod
+        secretsPath: /shared/litestream
+  managedSecretReference:
+    creationPolicy: Owner
+    secretName: litestream-shared-secrets
+    secretNamespace: media
+    secretType: Opaque

--- a/argocd/overlays/prod/apps/media-shared-secrets.yaml
+++ b/argocd/overlays/prod/apps/media-shared-secrets.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: media-shared-secrets
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "9" # Deploy just before the applications
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: prod-stable
+    path: apps/20-media
+    directory:
+      include: "litestream-shared-secrets.yaml"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: media
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -47,6 +47,7 @@ resources:
   - apps/pyload.yaml
   - apps/qbittorrent.yaml
   - apps/amule.yaml
+  - apps/media-shared-secrets.yaml
   - apps/radarr.yaml
   - apps/frigate.yaml
   - apps/lidarr.yaml


### PR DESCRIPTION
Restores the missing shared secret sync for the media namespace to fix Litestream sidecars.