### PR TITLE
fix(frigate): NFS subPath restoration

### DIFF
--- a/apps/20-media/frigate/base/deployment.yaml
+++ b/apps/20-media/frigate/base/deployment.yaml
@@ -127,6 +127,7 @@ spec:
               mountPath: /config
             - name: storage
               mountPath: /media/frigate
+              subPath: Frigate
             - name: shm
               mountPath: /dev/shm
         - name: litestream
@@ -208,7 +209,7 @@ spec:
         - name: storage
           nfs:
             server: 192.168.111.69
-            path: /volume3/Internal/Frigate
+            path: /volume3/Internal
         - name: shm
           emptyDir:
             medium: Memory


### PR DESCRIPTION
Uses the root export /volume3/Internal with subPath Frigate to bypass NFS server directory restrictions.