### PR TITLE
fix(frigate): litestream configuration

### DIFF
--- a/apps/20-media/frigate/base/litestream-config.yaml
+++ b/apps/20-media/frigate/base/litestream-config.yaml
@@ -8,6 +8,6 @@ data:
     dbs:
       - path: /config/frigate.db
         replicas:
-          - url: s3://$LITESTREAM_BUCKET/frigate/frigate.db
-            endpoint: $LITESTREAM_ENDPOINT
+          - url: s3://vixens-litestream/frigate/frigate.db
+            endpoint: http://192.168.111.69:9000
     addr: ":9090"


### PR DESCRIPTION
Interpolates S3 variables in litestream.yml to fix hanging restore-db container.