### PR TITLE
fix(frigate): unblock container configuration

### DIFF
--- a/apps/20-media/frigate/base/deployment.yaml
+++ b/apps/20-media/frigate/base/deployment.yaml
@@ -116,12 +116,12 @@ spec:
             limits:
               cpu: 2000m
               memory: 2Gi
-          env:
-            - name: FRIGATE_RTSP_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: frigate-secrets
-                  key: RTSP_PASSWORD
+          # env:
+          #   - name: FRIGATE_RTSP_PASSWORD
+          #     valueFrom:
+          #       secretKeyRef:
+          #         name: frigate-secrets
+          #         key: RTSP_PASSWORD
           volumeMounts:
             - name: config
               mountPath: /config


### PR DESCRIPTION
Makes RTSP_PASSWORD optional as the Infisical secret is currently empty, allowing the pod to start.