### PR TITLE
fix(penpot): sync App-of-Apps

### DIFF
--- a/argocd/overlays/prod/apps/penpot.yaml
+++ b/argocd/overlays/prod/apps/penpot.yaml
@@ -23,9 +23,3 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-  retry:
-    limit: 3
-    backoff:
-      duration: 5s
-      factor: 2
-      maxDuration: 3m


### PR DESCRIPTION
Removing optional retry block causing phantom drift in the parent App-of-Apps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automatic retry policy for synchronization operations in production environment configuration, requiring manual intervention on sync failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->