### PR TITLE
fix(velero): final stabilization

### DIFF
--- a/apps/00-infra/velero/values/common.yaml
+++ b/apps/00-infra/velero/values/common.yaml
@@ -1,26 +1,22 @@
-# Velero - Common Helm Values
-# Shared configuration across all environments
-
+# Velero - Final Stabilization 2026
 image:
   repository: velero/velero
   tag: v1.17.2
   pullPolicy: IfNotPresent
 
-# Kubectl image for CRD upgrade jobs
-# Note: bitnami/kubectl no longer provides versioned tags after Aug 2025
-kubectl:
-  image:
-    repository: docker.io/bitnami/kubectl
-    tag: latest
-  resources:
-    requests:
-      cpu: 50m
-      memory: 64Mi
-    limits:
-      cpu: 100m
-      memory: 128Mi
+configuration:
+  uploaderType: kopia
+  # Use ConfigMap for maintenance to avoid flag injection
+  repoMaintenanceJobConfigMap: velero-repo-maintenance-config
 
-# Use AWS plugin for S3-compatible storage (MinIO)
+# Disable chart-managed maintenance jobs to stop --keep-latest-maintenance-jobs
+schedules: {}
+maintenanceCronJob:
+  enabled: false
+
+# Force clean server start
+extraArgs: []
+
 initContainers:
   - name: velero-plugin-for-aws
     image: velero/velero-plugin-for-aws:v1.13.2
@@ -29,25 +25,21 @@ initContainers:
       - mountPath: /target
         name: plugins
 
-# Resource limits
 resources:
   requests:
     cpu: 100m
-    memory: 128Mi
+    memory: 256Mi
   limits:
     cpu: 500m
     memory: 512Mi
 
-# Priority class for Kyverno compliance
-priorityClassName: vixens-critical
-
-# Node agent (for PV backups via restic/kopia)
 nodeAgent:
   enabled: true
+  uploaderType: kopia
   resources:
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 256Mi
     limits:
       cpu: 500m
       memory: 512Mi
@@ -56,26 +48,13 @@ nodeAgent:
       operator: Exists
       effect: NoSchedule
 
-# Metrics for Prometheus
 metrics:
   enabled: true
-  serviceMonitor:
-    enabled: false  # Enable when Prometheus operator is ready
-    additionalLabels: {}
 
-# Tolerations for control plane nodes (main deployment)
 tolerations:
   - key: node-role.kubernetes.io/control-plane
     operator: Exists
     effect: NoSchedule
 
-# Upgrade CRDs with Helm
-# Note: Disabled due to library compatibility issue in velero image for upgrade job
-# CRDs are installed manually or via pre-sync hook
 upgradeCRDs: false
-
-# Clean up completed upgrade jobs
 cleanUpCRDs: false
-
-configuration:
-  uploaderType: restic


### PR DESCRIPTION
Disabling maintenance jobs in the Helm chart to stop the injection of obsolete flags.