### PR TITLE
fix(velero): restore production deployment (v1.17.2)

### DIFF
--- a/apps/00-infra/velero/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/velero/overlays/prod/kustomization.yaml
@@ -2,11 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-patches:
-  - target:
-      kind: Deployment
-      name: velero
-    patch: |-
-      - op: replace
-        path: /spec/template/spec/containers/0/args
-        value: ["server", "--uploader-type=kopia", "--repo-maintenance-job-configmap=velero-repo-maintenance-config", "--default-backup-ttl=720h"]

--- a/apps/00-infra/velero/values/common.yaml
+++ b/apps/00-infra/velero/values/common.yaml
@@ -56,7 +56,7 @@ schedules:
 # CLEANUP SETTINGS
 maintenanceCronJob:
   enabled: false
-upgradeCRDs: false
+upgradeCRDs: true
 cleanUpCRDs: false
 
 resources:

--- a/argocd/overlays/prod/apps/velero.yaml
+++ b/argocd/overlays/prod/apps/velero.yaml
@@ -16,7 +16,7 @@ spec:
   sources:
     - repoURL: https://vmware-tanzu.github.io/helm-charts
       chart: velero
-      targetRevision: 8.5.0
+      targetRevision: 11.3.2
       helm:
         valueFiles:
           - $values/apps/00-infra/velero/values/common.yaml


### PR DESCRIPTION
Upgrades Velero to v1.17.2 and Helm Chart to v11.3.2 to fix missing deployment in prod. Enables CRD upgrades.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configured backup schedules for critical, home, and full backups
  * Added AWS S3-compatible backup storage location with volume snapshot support
  * Introduced CRD upgrade and cleanup management options (CRD upgrades enabled)

* **Chores**
  * Updated Velero to version 11.3.2
  * Simplified deployment configuration by removing a custom deployment patch

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->