### PR TITLE
fix(velero): correct kubectl image for CRD upgrade

### DIFF
--- a/DEADJOE
+++ b/DEADJOE
@@ -130,3 +130,47 @@ justfile
 *** Fichier '* Startup Log *'
 Traitement de '/etc/joe/editorrc'...Traitement de '/etc/joe/ftyperc'...Finished processing /etc/joe/ftyperc
 Finished processing /etc/joe/editorrc
+
+*** These modified files were found in JOE when it aborted on Fri Jan 30 09:47:43 2026
+*** JOE was aborted by UNIX signal 15
+
+*** Fichier '(Sans nom)'
+null_resource.wait_install_ip
+3.17
+3.1.7
+quay.io/argoproj/argocd:v3.1.7
+tmux send-keys
+environments
+daphne
+diva
+dulce
+                             | 
+
+*** Fichier '(Sans nom)'
+comyui
+nano
+uuid
+^    
+   | 
+github
+token
+token
+Lisa
+lisa
+
+*** Fichier '(Sans nom)'
+/root/vixens/.git/MERGE_MSG
+/root/vixens/.git/MERGE_MSG
+/root/vixens/.git/MERGE_MSG
+/root/vixens/.git/MERGE_MSG
+/root/vixens/.git/MERGE_MSG
+/root/vixens/.git/MERGE_MSG
+/root/vixens/.git/MERGE_MSG
+/root/vixens/.git/MERGE_MSG
+/root/vixens/.git/MERGE_MSG
+/root/vixens/.git/MERGE_MSG
+/root/vixens/.git/MERGE_MSG
+
+*** Fichier '* Startup Log *'
+Traitement de '/etc/joe/editorrc'...Traitement de '/etc/joe/ftyperc'...Finished processing /etc/joe/ftyperc
+Finished processing /etc/joe/editorrc

--- a/apps/00-infra/velero/values/common.yaml
+++ b/apps/00-infra/velero/values/common.yaml
@@ -59,6 +59,18 @@ maintenanceCronJob:
 upgradeCRDs: true
 cleanUpCRDs: false
 
+kubectl:
+  image:
+    repository: bitnami/kubectl
+    tag: 1.31.1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi
+
 resources:
   requests:
     cpu: 100m


### PR DESCRIPTION
Fixes ImagePullBackOff in velero-upgrade-crds job by specifying a valid bitnami/kubectl image tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure resource configuration with enhanced memory and CPU specifications
  * Improved system component resource allocations for enhanced stability and performance
  * Added diagnostic logging for system session management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->