### PR TITLE
fix(velero): use kubectl:latest image

### DIFF
--- a/apps/00-infra/velero/values/common.yaml
+++ b/apps/00-infra/velero/values/common.yaml
@@ -62,7 +62,7 @@ cleanUpCRDs: false
 kubectl:
   image:
     repository: bitnami/kubectl
-    tag: 1.31.1
+    tag: latest
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
Specific tag 1.31.1 failed to pull. Switching to 'latest' which is verified to work on this cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure resource configurations and memory allocations
  * Enhanced diagnostic logging for troubleshooting aborted sessions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->