### PR TITLE
fix(velero): disable CRD upgrade

### DIFF
--- a/apps/00-infra/velero/values/common.yaml
+++ b/apps/00-infra/velero/values/common.yaml
@@ -56,7 +56,7 @@ schedules:
 # CLEANUP SETTINGS
 maintenanceCronJob:
   enabled: false
-upgradeCRDs: true
+upgradeCRDs: false
 cleanUpCRDs: false
 
 kubectl:


### PR DESCRIPTION
Disables upgradeCRDs to unblock deployment. The hook job fails due to binary incompatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backup infrastructure configuration with adjustments to automated upgrade handling and system tool versioning.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->