### PR TITLE
fix(velero): enable node agent (v11 chart)

### DIFF
--- a/apps/00-infra/velero/values/common.yaml
+++ b/apps/00-infra/velero/values/common.yaml
@@ -79,8 +79,9 @@ resources:
     cpu: 500m
     memory: 512Mi
 
+deployNodeAgent: true
+
 nodeAgent:
-  enabled: true
   uploaderType: kopia
   resources:
     requests:


### PR DESCRIPTION
The parameter changed from 'nodeAgent.enabled' to 'deployNodeAgent' in the new Helm Chart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Velero node agent configuration settings for streamlined deployment management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->