### PR TITLE
fix(homeassistant): fix liveness/readiness probe path after HA upgrade

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -125,15 +125,15 @@ spec:
               value: Europe/Paris
           livenessProbe:
             httpGet:
-              path: /alive
+              path: /
               port: http
-            initialDelaySeconds: 60
+            initialDelaySeconds: 120
             periodSeconds: 30
           readinessProbe:
             httpGet:
-              path: /alive
+              path: /
               port: http
-            initialDelaySeconds: 90
+            initialDelaySeconds: 30
             periodSeconds: 15
           resources:
             requests:


### PR DESCRIPTION
## Summary
- Fix health check probe path from `/alive` (non-existent) to `/` (returns 200 when HA is running)
- Increase liveness probe `initialDelaySeconds` from 60 to 120 to give HA more startup time
- Decrease readiness probe `initialDelaySeconds` from 90 to 30 for faster traffic routing

## Root Cause
The Home Assistant image was upgraded from 2025.1.2 to 2026.1.3 in commit 5dbecbf8, but the probe path `/alive` was never a standard HA endpoint. It returns 404, causing the liveness probe to kill the container in a restart loop.

## Test plan
- [x] Verified `/` returns HTTP 200 from within the pod
- [x] Verified `/alive` returns HTTP 404 (confirms the issue)
- [x] `kubectl kustomize` validates for prod overlay
- [ ] Pod stabilizes without restart loops after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)