### PR TITLE
fix(media,services): remove duplicate YAML keys in 5 base deployments

### DIFF
--- a/apps/20-media/frigate/base/deployment.yaml
+++ b/apps/20-media/frigate/base/deployment.yaml
@@ -63,22 +63,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /config
-          envFrom:
-            - secretRef:
-                name: frigate-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
-          volumeMounts:
-            - name: config
-              mountPath: /config
-            - name: frigate-litestream-config
-              mountPath: /etc/litestream.yml
-              subPath: litestream.yml
       containers:
         - name: frigate
           image: ghcr.io/blakeblackshear/frigate:0.17.0-beta2
@@ -116,15 +100,6 @@ spec:
               mountPath: /dev/shm
             - name: dri
               mountPath: /dev/dri
-          envFrom:
-            - secretRef:
-                name: frigate-secrets
-          volumeMounts:
-            - name: config
-              mountPath: /config
-            - name: frigate-litestream-config
-              mountPath: /etc/litestream.yml
-              subPath: litestream.yml
         - name: config-syncer
           image: rclone/rclone:1.73
           securityContext:

--- a/apps/20-media/radarr/base/deployment.yaml
+++ b/apps/20-media/radarr/base/deployment.yaml
@@ -69,22 +69,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /config
-          envFrom:
-            - secretRef:
-                name: radarr-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
-          volumeMounts:
-            - name: config
-              mountPath: /config
-            - name: radarr-litestream-config
-              mountPath: /etc/litestream.yml
-              subPath: litestream.yml
       containers:
         - name: radarr
           image: ghcr.io/linuxserver/radarr:version-6.0.4.10291

--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -63,22 +63,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /config
-          envFrom:
-            - secretRef:
-                name: sabnzbd-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
-          volumeMounts:
-            - name: config
-              mountPath: /config
-            - name: sabnzbd-litestream-config
-              mountPath: /etc/litestream.yml
-              subPath: litestream.yml
       containers:
         - name: sabnzbd
           image: ghcr.io/linuxserver/sabnzbd:version-4.4.1

--- a/apps/20-media/whisparr/base/deployment.yaml
+++ b/apps/20-media/whisparr/base/deployment.yaml
@@ -69,22 +69,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /config
-          envFrom:
-            - secretRef:
-                name: whisparr-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
-          volumeMounts:
-            - name: config
-              mountPath: /config
-            - name: whisparr-litestream-config
-              mountPath: /etc/litestream.yml
-              subPath: litestream.yml
       containers:
         - name: whisparr
           image: ghcr.io/hotio/whisparr:nightly

--- a/apps/60-services/vaultwarden/base/deployment.yaml
+++ b/apps/60-services/vaultwarden/base/deployment.yaml
@@ -63,22 +63,6 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
-          envFrom:
-            - secretRef:
-                name: vaultwarden-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
-          volumeMounts:
-            - name: data
-              mountPath: /data
-            - name: vaultwarden-litestream-config
-              mountPath: /etc/litestream.yml
-              subPath: litestream.yml
       containers:
         - name: vaultwarden
           image: vaultwarden/server:1.35.2


### PR DESCRIPTION
## Summary
- Fix 5 ArgoCD apps stuck in `Unknown` sync status due to invalid YAML (duplicate mapping keys)
- Affected apps: **frigate**, **radarr**, **sabnzbd**, **vaultwarden**, **whisparr**
- Remove duplicate `envFrom`, `resources`, `volumeMounts` from `restore-config` init containers
- Remove duplicate `envFrom`/`volumeMounts` from frigate's main container

## Root Cause
The `restore-config` init container in each base deployment.yaml had fields defined twice (envFrom, resources, volumeMounts). The second occurrence also incorrectly mounted the litestream-config in the init container. YAML parsers reject duplicate keys at parse time, before Kustomize can process patches.

## Test plan
- [x] `kubectl kustomize` builds successfully for all 5 prod overlays
- [x] `kubectl kustomize` builds successfully for all 5 dev overlays
- [ ] ArgoCD apps transition from `Unknown` to `Synced` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up redundant and duplicate initialization configuration entries across deployment manifests for Frigate, Radarr, Sabnzbd, Whisparr, and Vaultwarden applications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->