### PR TITLE
fix(frigate): add missing litestream sidecar container

### DIFF
--- a/apps/20-media/frigate/base/deployment.yaml
+++ b/apps/20-media/frigate/base/deployment.yaml
@@ -100,6 +100,34 @@ spec:
               mountPath: /dev/shm
             - name: dri
               mountPath: /dev/dri
+        - name: litestream
+          image: litestream/litestream:0.5.6
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          args:
+            - replicate
+            - -config
+            - /etc/litestream.yml
+          ports:
+            - containerPort: 9090
+              name: metrics
+          envFrom:
+            - secretRef:
+                name: frigate-secrets
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: frigate-litestream-config
+              mountPath: /etc/litestream.yml
+              subPath: litestream.yml
         - name: config-syncer
           image: rclone/rclone:1.73
           securityContext:


### PR DESCRIPTION
## Summary
- Add missing `litestream` sidecar container definition to frigate base deployment
- The litestream container was part of a duplicate block removed in PR #1156

## Root Cause
The frigate base deployment never had a proper litestream container definition - it was tangled in the duplicate YAML keys. When the duplicates were cleaned up, litestream was lost. The prod `resources-patch.yaml` still references it, creating a ghost container with no image.

## Test plan
- [x] `kubectl kustomize` builds for prod and dev overlays
- [x] All 3 containers have images in rendered manifest
- [ ] ArgoCD syncs frigate to `Synced` status

🤖 Generated with [Claude Code](https://claude.com/claude-code)