### PR TITLE
fix(infisical): add envSlug prod patch for mealie and lazylibrarian

### DIFF
--- a/apps/10-home/mealie/overlays/prod/kustomization.yaml
+++ b/apps/10-home/mealie/overlays/prod/kustomization.yaml
@@ -6,6 +6,13 @@ resources:
   - ingress.yaml
 patches:
   - path: resources-patch.yaml
+  - target:
+      kind: InfisicalSecret
+      name: mealie-secrets-sync
+    patch: |-
+      - op: replace
+        path: /spec/authentication/universalAuth/secretsScope/envSlug
+        value: prod
 labels:
   - pairs:
       environment: prod

--- a/apps/20-media/lazylibrarian/overlays/prod/kustomization.yaml
+++ b/apps/20-media/lazylibrarian/overlays/prod/kustomization.yaml
@@ -9,3 +9,10 @@ components:
   - ../../../../_shared/components/revision-history-limit
 
 patches:
+  - target:
+      kind: InfisicalSecret
+      name: lazylibrarian-secrets-sync
+    patch: |-
+      - op: replace
+        path: /spec/authentication/universalAuth/secretsScope/envSlug
+        value: prod


### PR DESCRIPTION
## Summary

- Mealie and lazylibrarian had `envSlug: dev` in their base InfisicalSecret with no prod overlay patch
- In prod, the Infisical controller was fetching from the `dev` environment → empty secrets → CrashLoopBackOff
- Adds the standard JSON patch (same as sonarr, radarr, etc.) to set `envSlug: prod`

## Test plan
- [ ] Merge → promote → verify mealie and lazylibrarian pods become Running
- [ ] Verify secrets contain LITESTREAM_* vars: `kubectl get secret mealie-secrets -n mealie`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production environment configurations for Mealie and LazyLibrarian services to use the prod environment slug in authentication settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->