### PR TITLE
feat(infra): deploy kube-janitor

### DIFF
--- a/apps/70-tools/kube-janitor/base/configmap.yaml
+++ b/apps/70-tools/kube-janitor/base/configmap.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-janitor-rules
+data:
+  rules.yaml: |
+    # Clean up Failed/Succeeded Pods after 24h
+    - id: clean-pods-completed
+      resources:
+        - pods
+      jmespath: "status.phase == 'Succeeded' || status.phase == 'Failed'"
+      ttl: 24h
+
+    # Clean up Evicted Pods faster (1h)
+    - id: clean-pods-evicted
+      resources:
+        - pods
+      jmespath: "status.reason == 'Evicted'"
+      ttl: 1h
+
+    # Clean up old ReplicaSets (history) after 7 days
+    - id: clean-replicasets-history
+      resources:
+        - replicasets
+      jmespath: "spec.replicas == 0"
+      ttl: 7d

--- a/apps/70-tools/kube-janitor/base/deployment.yaml
+++ b/apps/70-tools/kube-janitor/base/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-janitor
+  labels:
+    app: kube-janitor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-janitor
+  template:
+    metadata:
+      labels:
+        app: kube-janitor
+      annotations:
+        checksum/config: "init" # Will be managed by Kustomize if ConfigMapGenerator is used, but hardcoding for now
+    spec:
+      serviceAccountName: kube-janitor
+      priorityClassName: vixens-low
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: kube-janitor
+          image: hjacobs/kube-janitor:21.5.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --rules-file=/config/rules.yaml
+            - --interval=60
+            - --dry-run=false
+          volumeMounts:
+            - name: config
+              mountPath: /config
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+      volumes:
+        - name: config
+          configMap:
+            name: kube-janitor-rules

--- a/apps/70-tools/kube-janitor/base/kustomization.yaml
+++ b/apps/70-tools/kube-janitor/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rbac.yaml
+  - configmap.yaml
+  - deployment.yaml
+commonLabels:
+  app: kube-janitor

--- a/apps/70-tools/kube-janitor/base/rbac.yaml
+++ b/apps/70-tools/kube-janitor/base/rbac.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-janitor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-janitor
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "persistentvolumeclaims", "services", "configmaps", "secrets", "namespaces"]
+    verbs: ["get", "list", "watch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
+    verbs: ["get", "list", "watch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-janitor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-janitor
+subjects:
+  - kind: ServiceAccount
+    name: kube-janitor
+    namespace: tools

--- a/apps/70-tools/kube-janitor/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/kube-janitor/overlays/prod/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: tools
+resources:
+  - ../../base

--- a/argocd/overlays/prod/apps/kube-janitor.yaml
+++ b/argocd/overlays/prod/apps/kube-janitor.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kube-janitor
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: prod-stable
+    path: apps/70-tools/kube-janitor/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tools
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - apps/vpa.yaml
   - apps/goldilocks.yaml
   - apps/reloader.yaml
+  - apps/kube-janitor.yaml
   - apps/kyverno.yaml
   - apps/policy-reporter.yaml
   - apps/descheduler.yaml


### PR DESCRIPTION
Implements automated cleanup for Failed/Evicted pods and unused ReplicaSets via kube-janitor. Fixes vixens-zwpi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Automated cleanup tool now deployed to production. Removes completed/failed pods (24-hour TTL), evicted pods (1-hour TTL), and replicasets without active replicas (7-day TTL) to maintain cluster health and free resources.

## Chores
* Added RBAC configuration and Argo CD deployment automation for production environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->