### PR TITLE
fix(firefly-iii): S3 region and no SSL

### DIFF
--- a/apps/60-services/firefly-iii/base/deployment.yaml
+++ b/apps/60-services/firefly-iii/base/deployment.yaml
@@ -43,6 +43,8 @@ spec:
               export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=$LITESTREAM_SECRET_ACCESS_KEY
               export RCLONE_CONFIG_S3_ENDPOINT=$LITESTREAM_ENDPOINT
               export RCLONE_CONFIG_S3_FORCE_PATH_STYLE=true
+              export RCLONE_CONFIG_S3_REGION=us-east-1
+              export RCLONE_CONFIG_S3_DISABLE_SSL=true
               rclone copy s3:$LITESTREAM_BUCKET/upload /upload --transfers 4 --ignore-existing || true
           envFrom:
             - secretRef:
@@ -131,6 +133,8 @@ spec:
               export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=$LITESTREAM_SECRET_ACCESS_KEY
               export RCLONE_CONFIG_S3_ENDPOINT=$LITESTREAM_ENDPOINT
               export RCLONE_CONFIG_S3_FORCE_PATH_STYLE=true
+              export RCLONE_CONFIG_S3_REGION=us-east-1
+              export RCLONE_CONFIG_S3_DISABLE_SSL=true
               sync_s3() { 
                 rclone sync /upload s3:\$LITESTREAM_BUCKET/upload
               }


### PR DESCRIPTION
Adding S3 region and disabling SSL for rclone to ensure compatibility with local Minio setup.