### PR TITLE
fix(robusta): remove broken patch reference in prod overlay

### DIFF
--- a/apps/02-monitoring/robusta/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/robusta/overlays/prod/kustomization.yaml
@@ -14,11 +14,6 @@ helmCharts:
     includeCRDs: true
 
 patches:
-  - path: ../../base/deployment-patch.yaml
-    target:
-      kind: Deployment
-      # On cible le nom exact généré par le Chart Helm
-      name: robusta-deployment-runner
   - target:
       kind: InfisicalSecret
       name: robusta-secrets-sync


### PR DESCRIPTION
Fixes the kustomization build error by removing the reference to the deleted deployment-patch.yaml.