### PR TITLE
fix(robusta): correct field name for envFrom

### DIFF
--- a/apps/02-monitoring/robusta/overlays/dev/values.yaml
+++ b/apps/02-monitoring/robusta/overlays/dev/values.yaml
@@ -10,6 +10,6 @@ sinksConfig:
       url: "{{ env.DISCORD_WEBHOOK_URL }}"
 
 runner:
-  envFrom:
+  additional_env_froms:
     - secretRef:
         name: robusta-secrets

--- a/apps/02-monitoring/robusta/overlays/prod/values.yaml
+++ b/apps/02-monitoring/robusta/overlays/prod/values.yaml
@@ -10,6 +10,6 @@ sinksConfig:
       url: "{{ env.DISCORD_WEBHOOK_URL }}"
 
 runner:
-  envFrom:
+  additional_env_froms:
     - secretRef:
         name: robusta-secrets


### PR DESCRIPTION
Changes runner.envFrom to runner.additional_env_froms to match the Robusta Helm chart specification.