### PR TITLE
fix(robusta): fix holmes token injection

### DIFF
--- a/apps/02-monitoring/robusta/overlays/dev/values.yaml
+++ b/apps/02-monitoring/robusta/overlays/dev/values.yaml
@@ -27,3 +27,8 @@ holmes:
   additionalEnvVars:
     - name: ROBUSTA_AI
       value: "true"
+    - name: ROBUSTA_UI_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: robusta-secrets
+          key: ROBUSTA_UI_TOKEN

--- a/apps/02-monitoring/robusta/overlays/prod/values.yaml
+++ b/apps/02-monitoring/robusta/overlays/prod/values.yaml
@@ -27,3 +27,8 @@ holmes:
   additionalEnvVars:
     - name: ROBUSTA_AI
       value: "true"
+    - name: ROBUSTA_UI_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: robusta-secrets
+          key: ROBUSTA_UI_TOKEN


### PR DESCRIPTION
Explicitly maps ROBUSTA_UI_TOKEN from secret to environment variable in Holmes configuration, as it does not inherit from runner envFrom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure UI token authentication to monitoring system using secret-based credential management

* **Chores**
  * Updated development and production environment configurations to support token-based authentication
  * Implemented secret reference management for secure handling of authentication credentials

<!-- end of auto-generated comment: release notes by coderabbit.ai -->