### PR TITLE
fix(robusta): holmes secret interpolation

### DIFF
--- a/apps/02-monitoring/robusta/overlays/dev/holmes-patch.yaml
+++ b/apps/02-monitoring/robusta/overlays/dev/holmes-patch.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: robusta-holmes
+spec:
+  template:
+    spec:
+      volumes:
+        - name: playbooks-config-processed
+          emptyDir: {}
+      initContainers:
+        - name: config-interpolator
+          image: busybox
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "Interpolating ROBUSTA_UI_TOKEN..."
+              sed "s|{{ env.ROBUSTA_UI_TOKEN }}|$ROBUSTA_UI_TOKEN|g" /etc/robusta/config-src/active_playbooks.yaml > /etc/robusta/config/active_playbooks.yaml
+              echo "Done."
+          env:
+            - name: ROBUSTA_UI_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: robusta-secrets
+                  key: ROBUSTA_UI_TOKEN
+          volumeMounts:
+            - name: playbooks-config-secret
+              mountPath: /etc/robusta/config-src
+            - name: playbooks-config-processed
+              mountPath: /etc/robusta/config
+      containers:
+        - name: holmes
+          volumeMounts:
+            - name: playbooks-config-processed
+              mountPath: /etc/robusta/config

--- a/apps/02-monitoring/robusta/overlays/dev/kustomization.yaml
+++ b/apps/02-monitoring/robusta/overlays/dev/kustomization.yaml
@@ -3,3 +3,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+
+patches:
+  - path: holmes-patch.yaml
+    target:
+      kind: Deployment
+      name: robusta-holmes

--- a/apps/02-monitoring/robusta/overlays/prod/holmes-patch.yaml
+++ b/apps/02-monitoring/robusta/overlays/prod/holmes-patch.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: robusta-holmes
+spec:
+  template:
+    spec:
+      volumes:
+        - name: playbooks-config-processed
+          emptyDir: {}
+      initContainers:
+        - name: config-interpolator
+          image: busybox
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "Interpolating ROBUSTA_UI_TOKEN..."
+              sed "s|{{ env.ROBUSTA_UI_TOKEN }}|$ROBUSTA_UI_TOKEN|g" /etc/robusta/config-src/active_playbooks.yaml > /etc/robusta/config/active_playbooks.yaml
+              echo "Done."
+          env:
+            - name: ROBUSTA_UI_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: robusta-secrets
+                  key: ROBUSTA_UI_TOKEN
+          volumeMounts:
+            - name: playbooks-config-secret
+              mountPath: /etc/robusta/config-src
+            - name: playbooks-config-processed
+              mountPath: /etc/robusta/config
+      containers:
+        - name: holmes
+          volumeMounts:
+            - name: playbooks-config-processed
+              mountPath: /etc/robusta/config

--- a/apps/02-monitoring/robusta/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/robusta/overlays/prod/kustomization.yaml
@@ -5,6 +5,10 @@ resources:
   - ../../base
 
 patches:
+  - path: holmes-patch.yaml
+    target:
+      kind: Deployment
+      name: robusta-holmes
   - target:
       kind: InfisicalSecret
       name: robusta-secrets-sync


### PR DESCRIPTION
Adds an initContainer to robusta-holmes deployment to manually interpolate the ROBUSTA_UI_TOKEN in the config file, as Holmes does not support Jinja2 interpolation natively.