### PR TITLE
feat(robusta): add prometheus_url

### DIFF
--- a/apps/02-monitoring/robusta/overlays/dev/values.yaml
+++ b/apps/02-monitoring/robusta/overlays/dev/values.yaml
@@ -8,6 +8,7 @@ enabledManagedConfiguration: true
 globalConfig:
   signing_key: "{{ env.ROBUSTA_SIGNING_KEY }}"
   account_id: "{{ env.ROBUSTA_ACCOUNT_ID }}"
+  prometheus_url: "http://prometheus-server.monitoring.svc.cluster.local"
 
 sinksConfig:
   - robusta_sink:

--- a/apps/02-monitoring/robusta/overlays/prod/values.yaml
+++ b/apps/02-monitoring/robusta/overlays/prod/values.yaml
@@ -8,6 +8,7 @@ enabledManagedConfiguration: true
 globalConfig:
   signing_key: "{{ env.ROBUSTA_SIGNING_KEY }}"
   account_id: "{{ env.ROBUSTA_ACCOUNT_ID }}"
+  prometheus_url: "http://prometheus-server.monitoring.svc.cluster.local"
 
 sinksConfig:
   - robusta_sink:


### PR DESCRIPTION
Configures the internal Prometheus URL in Robusta globalConfig to enable metric-based enrichments and dashboard graphs.