### PR TITLE
feat(firefly-iii): add firefly-iii-importer

### DIFF
--- a/apps/60-services/firefly-iii-importer/base/deployment.yaml
+++ b/apps/60-services/firefly-iii-importer/base/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: firefly-iii-importer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: firefly-iii-importer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: firefly-iii-importer
+    spec:
+      containers:
+        - name: importer
+          image: fireflyiii/data-importer:latest
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: FIREFLY_III_URL
+              value: "http://firefly-iii.finance.svc.cluster.local"
+            - name: VANITY_URL
+              value: "https://importer.truxonline.com"
+            - name: TZ
+              value: "Europe/Paris"
+            - name: IGNORE_DUPLICATE_ERRORS
+              value: "false"
+            - name: CAN_POST_AUTOIMPORT
+              value: "true"
+            - name: CAN_POST_FILES
+              value: "true"
+          envFrom:
+            - secretRef:
+                name: firefly-iii-importer-secrets
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 256Mi

--- a/apps/60-services/firefly-iii-importer/base/infisical-secret.yaml
+++ b/apps/60-services/firefly-iii-importer/base/infisical-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: firefly-iii-importer-secrets-sync
+spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
+  authentication:
+    universalAuth:
+      credentialsRef:
+        secretName: infisical-universal-auth
+        secretNamespace: argocd
+      secretsScope:
+        projectSlug: vixens
+        envSlug: dev
+        secretsPath: /apps/60-services/firefly-iii-importer
+  managedSecretReference:
+    secretName: firefly-iii-importer-secrets
+    creationPolicy: Owner
+    secretNamespace: finance

--- a/apps/60-services/firefly-iii-importer/base/ingress.yaml
+++ b/apps/60-services/firefly-iii-importer/base/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: firefly-iii-importer
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  rules:
+    - host: importer.truxonline.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: firefly-iii-importer
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - importer.truxonline.com
+      secretName: firefly-iii-importer-tls

--- a/apps/60-services/firefly-iii-importer/base/kustomization.yaml
+++ b/apps/60-services/firefly-iii-importer/base/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: finance
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - infisical-secret.yaml

--- a/apps/60-services/firefly-iii-importer/base/service.yaml
+++ b/apps/60-services/firefly-iii-importer/base/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: firefly-iii-importer
+spec:
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: firefly-iii-importer

--- a/apps/60-services/firefly-iii-importer/overlays/dev/kustomization.yaml
+++ b/apps/60-services/firefly-iii-importer/overlays/dev/kustomization.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+patches:
+  - target:
+      kind: Ingress
+      name: firefly-iii-importer
+    patch: |-
+      - op: replace
+        path: /spec/rules/0/host
+        value: importer.dev.truxonline.com
+      - op: replace
+        path: /spec/tls/0/hosts/0
+        value: importer.dev.truxonline.com
+      - op: replace
+        path: /metadata/annotations/cert-manager.io~1cluster-issuer
+        value: letsencrypt-staging
+  - target:
+      kind: Deployment
+      name: firefly-iii-importer
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/env/1/value
+        value: "https://importer.dev.truxonline.com"

--- a/apps/60-services/firefly-iii-importer/overlays/prod/kustomization.yaml
+++ b/apps/60-services/firefly-iii-importer/overlays/prod/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+patches:
+  - target:
+      kind: InfisicalSecret
+      name: firefly-iii-importer-secrets-sync
+    patch: |-
+      - op: replace
+        path: /spec/authentication/universalAuth/secretsScope/envSlug
+        value: prod

--- a/argocd/overlays/dev/apps/firefly-iii-importer.yaml
+++ b/argocd/overlays/dev/apps/firefly-iii-importer.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: firefly-iii-importer
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    path: apps/60-services/firefly-iii-importer/overlays/dev
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: main
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: finance
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/overlays/dev/kustomization.yaml
+++ b/argocd/overlays/dev/kustomization.yaml
@@ -93,3 +93,4 @@ resources:
   - apps/mariadb-shared.yaml
   - apps/penpot.yaml
   - apps/robusta.yaml
+  - apps/firefly-iii-importer.yaml

--- a/argocd/overlays/prod/apps/firefly-iii-importer.yaml
+++ b/argocd/overlays/prod/apps/firefly-iii-importer.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: firefly-iii-importer
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    path: apps/60-services/firefly-iii-importer/overlays/prod
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: prod-stable
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: finance
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -51,6 +51,7 @@ resources:
   - apps/radarr.yaml
   - apps/frigate.yaml
   - apps/firefly-iii.yaml
+  - apps/firefly-iii-importer.yaml
   - apps/lidarr.yaml
   - apps/lazylibrarian.yaml
   - apps/booklore.yaml

--- a/docs/applications/60-services/firefly-iii-importer.md
+++ b/docs/applications/60-services/firefly-iii-importer.md
@@ -1,0 +1,32 @@
+# Firefly III Data Importer
+
+## Deployment Information
+| Environment | Deployed | Configured | Tested | Version |
+|-------------|----------|-----------|-------|---------|
+| Dev         | [x]      | [ ]       | [ ]   | latest  |
+| Prod        | [x]      | [ ]       | [ ]   | latest  |
+
+## Validation
+**URL:** [https://importer.truxonline.com](https://importer.truxonline.com)
+
+### Automatic Validation (CLI)
+```bash
+# Check pod status
+kubectl get pods -n finance -l app.kubernetes.io/name=firefly-iii-importer
+```
+
+### Manual Validation
+1. Open URL in browser.
+2. The UI should display the import options (CSV, Nordigen, etc.).
+3. Note: Requires `FIREFLY_III_ACCESS_TOKEN` in Infisical to work.
+
+## Technical Notes
+- **Namespace:** `finance`
+- **Category:** `60-services`
+- **Dependencies:**
+    - Firefly III (Internal URL: `http://firefly-iii.finance.svc.cluster.local`)
+    - Infisical (Secrets management)
+- **Specifics:** 
+    - Uses `fireflyiii/data-importer:latest` image.
+    - Configuration handled via environment variables and secrets.
+    - Automated sync possible via CronJob (planned).


### PR DESCRIPTION
Adds Firefly III Data Importer application to the cluster. Configured with Infisical secrets and Ingress for both dev and prod environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Firefly III Importer service now available in production and development environments with secure HTTPS access and automated certificate provisioning.

* **Documentation**
  * Added deployment and validation documentation for the Firefly III Importer service, including setup instructions and configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->