### PR TITLE
fix(firefly-iii): importer URLs

### DIFF
--- a/apps/60-services/firefly-iii-importer/base/deployment.yaml
+++ b/apps/60-services/firefly-iii-importer/base/deployment.yaml
@@ -21,7 +21,7 @@ spec:
               name: http
           env:
             - name: FIREFLY_III_URL
-              value: "http://firefly-iii.finance.svc.cluster.local"
+              value: "https://firefly.truxonline.com"
             - name: VANITY_URL
               value: "https://importer.truxonline.com"
             - name: TZ

--- a/apps/60-services/firefly-iii-importer/overlays/dev/kustomization.yaml
+++ b/apps/60-services/firefly-iii-importer/overlays/dev/kustomization.yaml
@@ -22,5 +22,8 @@ patches:
       name: firefly-iii-importer
     patch: |-
       - op: replace
+        path: /spec/template/spec/containers/0/env/0/value
+        value: "https://firefly.dev.truxonline.com"
+      - op: replace
         path: /spec/template/spec/containers/0/env/1/value
         value: "https://importer.dev.truxonline.com"


### PR DESCRIPTION
Changes internal service URLs to external public URLs. This is required for the Data Importer because the browser needs to be able to contact Firefly III during the authentication and import flow.