### PR TITLE
fix(firefly-iii): importer https links

### DIFF
--- a/apps/60-services/firefly-iii-importer/base/deployment.yaml
+++ b/apps/60-services/firefly-iii-importer/base/deployment.yaml
@@ -24,6 +24,10 @@ spec:
               value: "https://firefly.truxonline.com"
             - name: VANITY_URL
               value: "https://importer.truxonline.com"
+            - name: APP_URL
+              value: "https://importer.truxonline.com"
+            - name: TRUSTED_PROXIES
+              value: "*"
             - name: TZ
               value: "Europe/Paris"
             - name: IGNORE_DUPLICATE_ERRORS

--- a/apps/60-services/firefly-iii-importer/overlays/dev/kustomization.yaml
+++ b/apps/60-services/firefly-iii-importer/overlays/dev/kustomization.yaml
@@ -27,3 +27,6 @@ patches:
       - op: replace
         path: /spec/template/spec/containers/0/env/1/value
         value: "https://importer.dev.truxonline.com"
+      - op: replace
+        path: /spec/template/spec/containers/0/env/2/value
+        value: "https://importer.dev.truxonline.com"


### PR DESCRIPTION
Fixes the 'Configuration or connection error' by setting TRUSTED_PROXIES and APP_URL. This ensures the application generates HTTPS links and the browser doesn't block cross-site requests.