### PR TITLE
fix(firefly-iii): force importer https

### DIFF
--- a/apps/60-services/firefly-iii-importer/base/deployment.yaml
+++ b/apps/60-services/firefly-iii-importer/base/deployment.yaml
@@ -27,7 +27,9 @@ spec:
             - name: APP_URL
               value: "https://importer.truxonline.com"
             - name: TRUSTED_PROXIES
-              value: "*"
+              value: "**"
+            - name: HTTPS_ONLY
+              value: "true"
             - name: TZ
               value: "Europe/Paris"
             - name: IGNORE_DUPLICATE_ERRORS


### PR DESCRIPTION
Sets TRUSTED_PROXIES to ** and adds HTTPS_ONLY=true to force the application to use HTTPS for all generated links and headers.