### PR TITLE
fix(firefly-iii): importer internal url

### DIFF
--- a/apps/60-services/firefly-iii-importer/base/deployment.yaml
+++ b/apps/60-services/firefly-iii-importer/base/deployment.yaml
@@ -21,7 +21,7 @@ spec:
               name: http
           env:
             - name: FIREFLY_III_URL
-              value: "https://firefly.truxonline.com"
+              value: "http://firefly-iii.finance.svc.cluster.local"
             - name: VANITY_URL
               value: "https://importer.truxonline.com"
             - name: APP_URL


### PR DESCRIPTION
Sets FIREFLY_III_URL back to the internal cluster service URL. This fixes the server-side connection error while keeping HTTPS for browser links via APP_URL and TRUSTED_PROXIES.