### PR TITLE
feat(firefly-iii): update core version

### DIFF
--- a/apps/60-services/firefly-iii/base/cronjob.yaml
+++ b/apps/60-services/firefly-iii/base/cronjob.yaml
@@ -13,7 +13,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: firefly-iii-cron
-              image: fireflyiii/core:version-6.1.22
+              image: fireflyiii/core:version-6.2.9
               command:
                 - php
                 - artisan

--- a/apps/60-services/firefly-iii/base/deployment.yaml
+++ b/apps/60-services/firefly-iii/base/deployment.yaml
@@ -54,7 +54,7 @@ spec:
               mountPath: /upload
       containers:
         - name: firefly-iii
-          image: fireflyiii/core:version-6.1.22
+          image: fireflyiii/core:version-6.2.9
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Updates Firefly III Core from 6.1.22 to 6.2.9. This is required by the Data Importer which needs a more recent API version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Firefly III service container image to version 6.2.9 across deployment and scheduled job configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->