### PR TITLE
feat(firefly-iii): add discord bot

### DIFF
--- a/apps/60-services/firefly-iii-bot/base/deployment.yaml
+++ b/apps/60-services/firefly-iii-bot/base/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: firefly-iii-bot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: firefly-iii-bot
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: firefly-iii-bot
+    spec:
+      priorityClassName: vixens-low
+      containers:
+        - name: bot
+          image: arisk/firefly-iii-discord-bot:latest
+          env:
+            - name: FIREFLY_III_URL
+              value: "http://firefly-iii.finance.svc.cluster.local"
+          envFrom:
+            - secretRef:
+                name: firefly-iii-bot-secrets
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi

--- a/apps/60-services/firefly-iii-bot/base/infisical-secret.yaml
+++ b/apps/60-services/firefly-iii-bot/base/infisical-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: firefly-iii-bot-secrets-sync
+spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
+  authentication:
+    universalAuth:
+      credentialsRef:
+        secretName: infisical-universal-auth
+        secretNamespace: argocd
+      secretsScope:
+        projectSlug: vixens
+        envSlug: dev
+        secretsPath: /apps/60-services/firefly-iii-bot
+  managedSecretReference:
+    secretName: firefly-iii-bot-secrets
+    creationPolicy: Owner
+    secretNamespace: finance

--- a/apps/60-services/firefly-iii-bot/base/kustomization.yaml
+++ b/apps/60-services/firefly-iii-bot/base/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: finance
+resources:
+  - deployment.yaml
+  - infisical-secret.yaml

--- a/apps/60-services/firefly-iii-bot/overlays/dev/kustomization.yaml
+++ b/apps/60-services/firefly-iii-bot/overlays/dev/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base

--- a/apps/60-services/firefly-iii-bot/overlays/prod/kustomization.yaml
+++ b/apps/60-services/firefly-iii-bot/overlays/prod/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+patches:
+  - target:
+      kind: InfisicalSecret
+      name: firefly-iii-bot-secrets-sync
+    patch: |-
+      - op: replace
+        path: /spec/authentication/universalAuth/secretsScope/envSlug
+        value: prod

--- a/argocd/overlays/dev/apps/firefly-iii-bot.yaml
+++ b/argocd/overlays/dev/apps/firefly-iii-bot.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: firefly-iii-bot
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    path: apps/60-services/firefly-iii-bot/overlays/dev
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: main
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: finance
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/overlays/dev/kustomization.yaml
+++ b/argocd/overlays/dev/kustomization.yaml
@@ -94,3 +94,4 @@ resources:
   - apps/penpot.yaml
   - apps/robusta.yaml
   - apps/firefly-iii-importer.yaml
+  - apps/firefly-iii-bot.yaml

--- a/argocd/overlays/prod/apps/firefly-iii-bot.yaml
+++ b/argocd/overlays/prod/apps/firefly-iii-bot.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: firefly-iii-bot
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    path: apps/60-services/firefly-iii-bot/overlays/prod
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: prod-stable
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: finance
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -52,6 +52,7 @@ resources:
   - apps/frigate.yaml
   - apps/firefly-iii.yaml
   - apps/firefly-iii-importer.yaml
+  - apps/firefly-iii-bot.yaml
   - apps/lidarr.yaml
   - apps/lazylibrarian.yaml
   - apps/booklore.yaml


### PR DESCRIPTION
Adds Firefly III Discord Bot to the cluster. Configured with Infisical secrets for the provided bot token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deployed Firefly III Discord bot service with Kubernetes infrastructure for development and production environments
  * Implemented automated secret management with environment-specific synchronization and configuration
  * Configured self-healing deployment orchestration with automatic namespace provisioning
  * Applied resource constraints and priority class assignments for optimal cluster utilization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->