### PR TITLE
fix(firefly-iii): final sidecar tuning

### DIFF
--- a/apps/60-services/firefly-iii-ai-categorizer/base/manifests.yaml
+++ b/apps/60-services/firefly-iii-ai-categorizer/base/manifests.yaml
@@ -26,6 +26,18 @@ spec:
               value: "true"
             - name: FIREFLY_TAG
               value: "AI categorized"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
           envFrom:
             - secretRef:
                 name: firefly-iii-ai-categorizer-secrets

--- a/apps/60-services/firefly-iii-bot/base/deployment.yaml
+++ b/apps/60-services/firefly-iii-bot/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       priorityClassName: vixens-low
       containers:
         - name: bot
-          image: leoanterior/firefly-iii-discord-bot:latest
+          image: ghcr.io/firefly-iii/discord-bot:latest
           env:
             - name: FIREFLY_III_URL
               value: "http://firefly-iii.finance.svc.cluster.local"


### PR DESCRIPTION
Switches the Discord bot to the official GHCR image and adds Kubernetes probes to the AI categorizer to satisfy Kyverno policies.