### PR TITLE
fix(firefly-iii): discord bot image

### DIFF
--- a/apps/60-services/firefly-iii-bot/base/deployment.yaml
+++ b/apps/60-services/firefly-iii-bot/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       priorityClassName: vixens-low
       containers:
         - name: bot
-          image: ghcr.io/firefly-iii/discord-bot:latest
+          image: dvonlehman/firefly-iii-bot:latest
           env:
             - name: FIREFLY_III_URL
               value: "http://firefly-iii.finance.svc.cluster.local"


### PR DESCRIPTION
Switches to dvonlehman/firefly-iii-bot image which is publicly available on Docker Hub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image source for the bot deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->