### PR TITLE
fix(firefly-iii): discord bot fixed tag

### DIFF
--- a/apps/60-services/firefly-iii-bot/base/deployment.yaml
+++ b/apps/60-services/firefly-iii-bot/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       priorityClassName: vixens-low
       containers:
         - name: bot
-          image: dvonlehman/firefly-iii-bot:latest
+          image: dvonlehman/firefly-iii-bot:0.5.0
           env:
             - name: FIREFLY_III_URL
               value: "http://firefly-iii.finance.svc.cluster.local"


### PR DESCRIPTION
Switches to a fixed version tag (0.5.0) for the Discord bot to avoid latest tag resolution issues.