### PR TITLE
fix(homeassistant): increase litestream memory limits

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/resources-patch.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/resources-patch.yaml
@@ -18,11 +18,11 @@ spec:
         - name: restore-db
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
-            limits:
-              cpu: 200m
+              cpu: 100m
               memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
       containers:
         - name: homeassistant
           resources:
@@ -36,10 +36,10 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
+              memory: 1Gi
             limits:
               cpu: 500m
-              memory: 512Mi
+              memory: 1Gi
         - name: config-syncer
           resources:
             requests:


### PR DESCRIPTION
Litestream is crashing with OOM due to a 1.3GB database. Increasing limits to 1Gi.