### PR TITLE
fix(homeassistant): update prod litestream limits

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/resources-patch.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/resources-patch.yaml
@@ -48,3 +48,4 @@ spec:
             limits:
               cpu: 200m
               memory: 256Mi
+# trigger


### PR DESCRIPTION
Previous fix was overridden by prod resources-patch.yaml. Correcting now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted resource allocations to improve stability: increased CPU and memory for the database restore init container and raised memory for the main application and replication services.
  * Minor manifest tidy: added a trailing marker line to the config sync component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->