### PR TITLE
fix(homeassistant): add netatmo configuration

### DIFF
--- a/apps/10-home/homeassistant/base/configmap.yaml
+++ b/apps/10-home/homeassistant/base/configmap.yaml
@@ -93,6 +93,10 @@ data:
     #       arming_time: 0
     #       delay_time: 0
 
+    netatmo:
+      client_id: !env_var NETATMO_CLIENT_ID
+      client_secret: !env_var NETATMO_CLIENT_SECRET
+
     notify:
       - name: notify_charchess_SMS
         platform: free_mobile


### PR DESCRIPTION
Adds Netatmo client_id and client_secret from env vars to configuration.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Netatmo integration support has been added to Home Assistant, enabling users to connect and manage their Netatmo devices within the platform for centralized monitoring and automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->