### PR TITLE
revert: remove netatmo configuration from configmap

### DIFF
--- a/apps/10-home/homeassistant/base/configmap.yaml
+++ b/apps/10-home/homeassistant/base/configmap.yaml
@@ -93,10 +93,6 @@ data:
     #       arming_time: 0
     #       delay_time: 0
 
-    netatmo:
-      client_id: !env_var NETATMO_CLIENT_ID
-      client_secret: !env_var NETATMO_CLIENT_SECRET
-
     notify:
       - name: notify_charchess_SMS
         platform: free_mobile


### PR DESCRIPTION
Reverts commit 59f25577. Configuration is stateful and should not be in ConfigMap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Netatmo integration configuration from the base system settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->