### PR TITLE
fix(velero): use manual secret for credentials

### DIFF
--- a/apps/00-infra/velero/values/prod.yaml
+++ b/apps/00-infra/velero/values/prod.yaml
@@ -3,7 +3,7 @@
 
 credentials:
   useSecret: false
-  extraSecretRef: velero
+  extraSecretRef: velero-manual
 
 # Specific production storage location
 configuration:


### PR DESCRIPTION
Bypassing Infisical sync issue by pointing Velero to manually created secret 'velero-manual' containing correct MinIO credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production infrastructure configuration for backup and disaster recovery systems to use an updated secret reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->