### PR TITLE
feat(security): deploy trivy operator

### DIFF
--- a/apps/02-monitoring/grafana/base/dashboards/trivy.yaml
+++ b/apps/02-monitoring/grafana/base/dashboards/trivy.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-trivy
+  labels:
+    grafana_dashboard: "1"
+data:
+  trivy.json: '{} # Placeholder - user to populate with JSON from https://grafana.com/grafana/dashboards/17813'

--- a/apps/02-monitoring/grafana/base/kustomization.yaml
+++ b/apps/02-monitoring/grafana/base/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - dashboards/traefik.yaml
   - dashboards/postgresql.yaml
   - dashboards/homeassistant.yaml
+  - dashboards/trivy.yaml
 # Helm chart managed by ArgoCD

--- a/apps/03-security/trivy/base/kustomization.yaml
+++ b/apps/03-security/trivy/base/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: security
+resources:
+  - manifests.yaml

--- a/apps/03-security/trivy/base/manifests.yaml
+++ b/apps/03-security/trivy/base/manifests.yaml
@@ -1,0 +1,2220 @@
+---
+# Source: trivy-operator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: trivy-trivy-operator
+  namespace: security
+  labels:
+    helm.sh/chart: trivy-operator-0.31.0
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy
+    app.kubernetes.io/version: "0.29.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: trivy-operator/templates/secrets/operator.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: trivy-operator
+  namespace: security
+  labels:
+    helm.sh/chart: trivy-operator-0.31.0
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy
+    app.kubernetes.io/version: "0.29.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+---
+# Source: trivy-operator/templates/secrets/trivy.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: trivy-operator-trivy-config
+  namespace: security
+  labels:
+    helm.sh/chart: trivy-operator-0.31.0
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy
+    app.kubernetes.io/version: "0.29.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+---
+# Source: trivy-operator/templates/configmaps/operator.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trivy-operator
+  namespace: security
+  labels:
+    helm.sh/chart: trivy-operator-0.31.0
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy
+    app.kubernetes.io/version: "0.29.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  nodeCollector.volumes: "[{\"hostPath\":{\"path\":\"/var/lib/etcd\"},\"name\":\"var-lib-etcd\"},{\"hostPath\":{\"path\":\"/var/lib/kubelet\"},\"name\":\"var-lib-kubelet\"},{\"hostPath\":{\"path\":\"/var/lib/kube-scheduler\"},\"name\":\"var-lib-kube-scheduler\"},{\"hostPath\":{\"path\":\"/var/lib/kube-controller-manager\"},\"name\":\"var-lib-kube-controller-manager\"},{\"hostPath\":{\"path\":\"/etc/systemd\"},\"name\":\"etc-systemd\"},{\"hostPath\":{\"path\":\"/lib/systemd\"},\"name\":\"lib-systemd\"},{\"hostPath\":{\"path\":\"/etc/kubernetes\"},\"name\":\"etc-kubernetes\"},{\"hostPath\":{\"path\":\"/etc/cni/net.d/\"},\"name\":\"etc-cni-netd\"}]"
+  nodeCollector.volumeMounts: "[{\"mountPath\":\"/var/lib/etcd\",\"name\":\"var-lib-etcd\",\"readOnly\":true},{\"mountPath\":\"/var/lib/kubelet\",\"name\":\"var-lib-kubelet\",\"readOnly\":true},{\"mountPath\":\"/var/lib/kube-scheduler\",\"name\":\"var-lib-kube-scheduler\",\"readOnly\":true},{\"mountPath\":\"/var/lib/kube-controller-manager\",\"name\":\"var-lib-kube-controller-manager\",\"readOnly\":true},{\"mountPath\":\"/etc/systemd\",\"name\":\"etc-systemd\",\"readOnly\":true},{\"mountPath\":\"/lib/systemd/\",\"name\":\"lib-systemd\",\"readOnly\":true},{\"mountPath\":\"/etc/kubernetes\",\"name\":\"etc-kubernetes\",\"readOnly\":true},{\"mountPath\":\"/etc/cni/net.d/\",\"name\":\"etc-cni-netd\",\"readOnly\":true}]"
+  scanJob.useGCRServiceAccount: "true"
+  scanJob.podTemplateContainerSecurityContext: "{\"allowPrivilegeEscalation\":false,\"capabilities\":{\"drop\":[\"ALL\"]},\"privileged\":false,\"readOnlyRootFilesystem\":true}"
+  scanJob.compressLogs: "true"
+  vulnerabilityReports.scanner: "Trivy"
+  vulnerabilityReports.scanJobsInSameNamespace: "false"
+  configAuditReports.scanner: "Trivy"
+  compliance.failEntriesLimit: "10"
+  report.recordFailedChecksOnly: "true"
+  node.collector.imageRef: "ghcr.io/aquasecurity/node-collector:0.3.1"
+  policies.bundle.oci.ref: "mirror.gcr.io/aquasec/trivy-checks:1"
+  policies.bundle.insecure: "false"
+
+  node.collector.nodeSelector: "true"
+---
+# Source: trivy-operator/templates/configmaps/trivy-operator-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: trivy-operator-config
+  namespace: security
+  labels:
+    helm.sh/chart: trivy-operator-0.31.0
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy
+    app.kubernetes.io/version: "0.29.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  OPERATOR_LOG_DEV_MODE: "false"
+  OPERATOR_SCAN_JOB_TTL: ""
+  OPERATOR_SCAN_JOB_TIMEOUT: "5m"
+  OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT: "10"
+  OPERATOR_CONCURRENT_NODE_COLLECTOR_LIMIT: "1"
+  OPERATOR_SCAN_JOB_RETRY_AFTER: "30s"
+  OPERATOR_BATCH_DELETE_LIMIT: "10"
+  OPERATOR_BATCH_DELETE_DELAY: "10s"
+  OPERATOR_METRICS_BIND_ADDRESS: ":8080"
+  OPERATOR_METRICS_FINDINGS_ENABLED: "true"
+  OPERATOR_METRICS_VULN_ID_ENABLED: "false"
+  OPERATOR_HEALTH_PROBE_BIND_ADDRESS: ":9090"
+  OPERATOR_PPROF_BIND_ADDRESS: ""
+  OPERATOR_VULNERABILITY_SCANNER_ENABLED: "true"
+  OPERATOR_SBOM_GENERATION_ENABLED: "true"
+  OPERATOR_CLUSTER_SBOM_CACHE_ENABLED: "false"
+  OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS: "true"
+  OPERATOR_SCANNER_REPORT_TTL: "24h"
+  OPERATOR_CACHE_REPORT_TTL: "120h"
+  CONTROLLER_CACHE_SYNC_TIMEOUT: "5m"
+  OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED: "true"
+  OPERATOR_RBAC_ASSESSMENT_SCANNER_ENABLED: "true"
+  OPERATOR_INFRA_ASSESSMENT_SCANNER_ENABLED: "true"
+  OPERATOR_CONFIG_AUDIT_SCANNER_SCAN_ONLY_CURRENT_REVISIONS: "true"
+  OPERATOR_EXPOSED_SECRET_SCANNER_ENABLED: "true"
+  OPERATOR_METRICS_EXPOSED_SECRET_INFO_ENABLED: "false"
+  OPERATOR_METRICS_CONFIG_AUDIT_INFO_ENABLED: "false"
+  OPERATOR_METRICS_RBAC_ASSESSMENT_INFO_ENABLED: "false"
+  OPERATOR_METRICS_INFRA_ASSESSMENT_INFO_ENABLED: "false"
+  OPERATOR_METRICS_IMAGE_INFO_ENABLED: "false"
+  OPERATOR_METRICS_CLUSTER_COMPLIANCE_INFO_ENABLED: "false"
+  OPERATOR_WEBHOOK_BROADCAST_URL: ""
+  OPERATOR_WEBHOOK_BROADCAST_TIMEOUT: "30s"
+  OPERATOR_WEBHOOK_BROADCAST_CUSTOM_HEADERS: ""
+  OPERATOR_SEND_DELETED_REPORTS: "false"
+  OPERATOR_PRIVATE_REGISTRY_SCAN_SECRETS_NAMES: "{}"
+  OPERATOR_ACCESS_GLOBAL_SECRETS_SERVICE_ACCOUNTS: "true"
+  OPERATOR_BUILT_IN_TRIVY_SERVER: "false"
+  TRIVY_SERVER_HEALTH_CHECK_CACHE_EXPIRATION: "10h"
+  OPERATOR_MERGE_RBAC_FINDING_WITH_CONFIG_AUDIT: "false"
+  OPERATOR_CLUSTER_COMPLIANCE_ENABLED: "true"
+---
+# Source: trivy-operator/templates/configmaps/trivy.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trivy-operator-trivy-config
+  namespace: security
+  labels:
+    helm.sh/chart: trivy-operator-0.31.0
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy
+    app.kubernetes.io/version: "0.29.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  trivy.repository: "mirror.gcr.io/aquasec/trivy"
+  trivy.tag: "0.66.0"
+  trivy.imagePullPolicy: "IfNotPresent"
+  trivy.additionalVulnerabilityReportFields: ""
+  trivy.severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+  trivy.slow: "true"
+  trivy.skipJavaDBUpdate: "false"
+  trivy.includeDevDeps: "false"
+  trivy.imageScanCacheDir: "/tmp/trivy/.cache"
+  trivy.filesystemScanCacheDir: "/var/trivyoperator/trivy-db"
+  trivy.dbRepository: "mirror.gcr.io/aquasec/trivy-db"
+  trivy.javaDbRepository: "mirror.gcr.io/aquasec/trivy-java-db"
+  trivy.command: "image"
+  trivy.sbomSources: ""
+  trivy.dbRepositoryInsecure: "false"
+  trivy.useBuiltinRegoPolicies: "false"
+  trivy.useEmbeddedRegoPolicies: "true"
+  trivy.supportedConfigAuditKinds: "Workload,Service,Role,ClusterRole,NetworkPolicy,Ingress,LimitRange,ResourceQuota"
+  trivy.timeout: "5m0s"
+  trivy.mode: "Standalone"
+  trivy.resources.requests.cpu: "100m"
+  trivy.resources.requests.memory: "100M"
+  trivy.resources.limits.cpu: "500m"
+  trivy.resources.limits.memory: "500M"
+---
+# Source: trivy-operator/templates/rbac/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: trivy-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - limitranges
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - resourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - clustercompliancedetailreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - clustercompliancereports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - clustercompliancereports/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - clusterconfigauditreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - clusterinfraassessmentreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - clusterrbacassessmentreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - clustersbomreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - clustervulnerabilityreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - configauditreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - exposedsecretreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - infraassessmentreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - rbacassessmentreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - sbomreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - vulnerabilityreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+- apiGroups:
+    - ""
+  resources:
+    - nodes/proxy
+  verbs:
+    - get
+---
+# Source: trivy-operator/templates/rbac/view-configauditreports-clusterrole.yaml
+# permissions for end users to view configauditreports
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregate-config-audit-reports-view
+  labels:
+    helm.sh/chart: trivy-operator-0.31.0
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy
+    app.kubernetes.io/version: "0.29.0"
+    app.kubernetes.io/managed-by: Helm
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+  - apiGroups:
+      - aquasecurity.github.io
+    resources:
+      - configauditreports
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: trivy-operator/templates/rbac/view-exposedsecretreports-clusterrole.yaml
+# permissions for end users to view exposedsecretreports
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregate-exposed-secret-reports-view
+  labels:
+    helm.sh/chart: trivy-operator-0.31.0
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy
+    app.kubernetes.io/version: "0.29.0"
+    app.kubernetes.io/managed-by: Helm
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+  - apiGroups:
+      - aquasecurity.github.io
+    resources:
+      - exposedsecretreports
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: trivy-operator/templates/rbac/view-vulnerabilityreports-clusterrole.yaml
+# permissions for end users to view vulnerabilityreports
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregate-vulnerability-reports-view
+  labels:
+    helm.sh/chart: trivy-operator-0.31.0
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy
+    app.kubernetes.io/version: "0.29.0"
+    app.kubernetes.io/managed-by: Helm
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+  - apiGroups:
+      - aquasecurity.github.io
+    resources:
+      - vulnerabilityreports
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: trivy-operator/templates/rbac/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: trivy-trivy-operator
+  labels:
+    helm.sh/chart: trivy-operator-0.31.0
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy
+    app.kubernetes.io/version: "0.29.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: trivy-operator
+subjects:
+  - kind: ServiceAccount
+    name: trivy-trivy-operator
+    namespace: security
+---
+# Source: trivy-operator/templates/rbac/leader-election-role.yaml
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: trivy-trivy-operator-leader-election
+  namespace: security
+  labels:
+    helm.sh/chart: trivy-operator-0.31.0
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy
+    app.kubernetes.io/version: "0.29.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+---
+# Source: trivy-operator/templates/rbac/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: trivy-trivy-operator
+  namespace: security
+  labels:
+    helm.sh/chart: trivy-operator-0.31.0
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy
+    app.kubernetes.io/version: "0.29.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - get
+      - delete
+      - update
+---
+# Source: trivy-operator/templates/rbac/leader-election-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: trivy-trivy-operator-leader-election
+  namespace: security
+  labels:
+    helm.sh/chart: trivy-operator-0.31.0
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy
+    app.kubernetes.io/version: "0.29.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: trivy-trivy-operator-leader-election
+subjects:
+  - kind: ServiceAccount
+    name: trivy-trivy-operator
+    namespace: security
+---
+# Source: trivy-operator/templates/rbac/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: trivy-trivy-operator
+  namespace: security
+  labels:
+    helm.sh/chart: trivy-operator-0.31.0
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy
+    app.kubernetes.io/version: "0.29.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: trivy-trivy-operator
+subjects:
+  - kind: ServiceAccount
+    name: trivy-trivy-operator
+    namespace: security
+---
+# Source: trivy-operator/templates/monitor/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: trivy-trivy-operator
+  namespace: security
+  labels:
+    helm.sh/chart: trivy-operator-0.31.0
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy
+    app.kubernetes.io/version: "0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: 80
+      targetPort: metrics
+      protocol: TCP
+      appProtocol: TCP
+  selector:
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy
+  type: ClusterIP
+---
+# Source: trivy-operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trivy-trivy-operator
+  namespace: security
+  labels:
+    helm.sh/chart: trivy-operator-0.31.0
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy
+    app.kubernetes.io/version: "0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: trivy-operator
+      app.kubernetes.io/instance: trivy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: trivy-operator
+        app.kubernetes.io/instance: trivy
+    spec:
+      serviceAccountName: trivy-trivy-operator
+      automountServiceAccountToken: true
+      containers:
+        - name: "trivy-operator"
+          image: "mirror.gcr.io/aquasec/trivy-operator:0.29.0"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: OPERATOR_NAMESPACE
+              value: security
+            - name: OPERATOR_TARGET_NAMESPACES
+              value: ""
+            - name: OPERATOR_EXCLUDE_NAMESPACES
+              value: ""
+            - name: OPERATOR_TARGET_WORKLOADS
+              value: "pod,replicaset,replicationcontroller,statefulset,daemonset,cronjob,job"
+            - name: OPERATOR_SERVICE_ACCOUNT
+              value: "trivy-trivy-operator"
+          envFrom:
+            - configMapRef:
+                name: trivy-operator-config
+          ports:
+            - name: metrics
+              containerPort: 8080
+            - name: probes
+              containerPort: 9090
+          readinessProbe:
+            httpGet:
+              path: /readyz/
+              port: probes
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz/
+              port: probes
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /tmp
+              name: cache-policies
+              readOnly: false
+      volumes:
+        - emptyDir: {}
+          name: cache-policies
+---
+# Source: trivy-operator/templates/specs/k8s-cis-1.23.yaml
+apiVersion: aquasecurity.github.io/v1alpha1
+kind: ClusterComplianceReport
+metadata:
+  name: k8s-cis-1.23
+  labels:
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy-operator
+    app.kubernetes.io/version: 0.29.0
+    app.kubernetes.io/managed-by: kubectl
+spec:
+  cron: "0 */6 * * *"
+  reportType: "summary"
+  compliance:
+    id: k8s-cis-1.23
+    title: CIS Kubernetes Benchmarks v1.23
+    description: CIS Kubernetes Benchmarks
+    platform: k8s
+    type: cis
+    relatedResources:
+      - https://www.cisecurity.org/benchmark/kubernetes
+    version: "1.23"
+    controls:
+    - id: 1.1.1
+      name: Ensure that the API server pod specification file permissions are set to
+        600 or more restrictive
+      description: Ensure that the API server pod specification file has permissions
+        of 600 or more restrictive
+      checks:
+        - id: AVD-KCV-0048
+      commands:
+        - id: CMD-0001
+      severity: HIGH
+    - id: 1.1.2
+      name: Ensure that the API server pod specification file ownership is set to
+        root:root
+      description: Ensure that the API server pod specification file ownership is set
+        to root:root
+      checks:
+        - id: AVD-KCV-0049
+      commands:
+        - id: CMD-0002
+      severity: HIGH
+    - id: 1.1.3
+      name: Ensure that the controller manager pod specification file permissions are
+        set to 600 or more restrictive
+      description: Ensure that the controller manager pod specification file has
+        permissions of 600 or more restrictive
+      checks:
+        - id: AVD-KCV-0050
+      commands:
+        - id: CMD-0003
+      severity: HIGH
+    - id: 1.1.4
+      name: Ensure that the controller manager pod specification file ownership is set
+        to root:root
+      description: Ensure that the controller manager pod specification file ownership
+        is set to root:root
+      checks:
+        - id: AVD-KCV-0051
+      commands:
+        - id: CMD-0004
+      severity: HIGH
+    - id: 1.1.5
+      name: Ensure that the scheduler pod specification file permissions are set to
+        600 or more restrictive
+      description: Ensure that the scheduler pod specification file has permissions of
+        600 or more restrictive
+      checks:
+        - id: AVD-KCV-0052
+      commands:
+        - id: CMD-0005
+      severity: HIGH
+    - id: 1.1.6
+      name: Ensure that the scheduler pod specification file ownership is set to
+        root:root
+      description: Ensure that the scheduler pod specification file ownership is set
+        to root:root
+      checks:
+        - id: AVD-KCV-0053
+      commands:
+        - id: CMD-0006
+      severity: HIGH
+    - id: 1.1.7
+      name: Ensure that the etcd pod specification file permissions are set to 600 or
+        more restrictive
+      description: Ensure that the etcd pod specification file has permissions of 600
+        or more restrictive
+      checks:
+        - id: AVD-KCV-0054
+      commands:
+        - id: CMD-0007
+      severity: HIGH
+    - id: 1.1.8
+      name: Ensure that the etcd pod specification file ownership is set to root:root
+      description: Ensure that the etcd pod specification file ownership is set to
+        root:root.
+      checks:
+        - id: AVD-KCV-0055
+      commands:
+        - id: CMD-0008
+      severity: HIGH
+    - id: 1.1.9
+      name: Ensure that the Container Network Interface file permissions are set to
+        600 or more restrictive
+      description: Ensure that the Container Network Interface files have permissions
+        of 600 or more restrictive
+      checks:
+        - id: AVD-KCV-0056
+      commands:
+        - id: CMD-0009
+      severity: HIGH
+    - id: 1.1.10
+      name: Ensure that the Container Network Interface file ownership is set to
+        root:root
+      description: Ensure that the Container Network Interface files have ownership
+        set to root:root
+      checks:
+        - id: AVD-KCV-0057
+      commands:
+        - id: CMD-0010
+      severity: HIGH
+    - id: 1.1.11
+      name: Ensure that the etcd data directory permissions are set to 700 or more
+        restrictive
+      description: Ensure that the etcd data directory has permissions of 700 or more
+        restrictive
+      checks:
+        - id: AVD-KCV-0058
+      commands:
+        - id: CMD-0011
+      severity: HIGH
+    - id: 1.1.12
+      name: Ensure that the etcd data directory ownership is set to etcd:etcd
+      description: Ensure that the etcd data directory ownership is set to etcd:etcd
+      checks:
+        - id: AVD-KCV-0059
+      commands:
+        - id: CMD-0012
+      severity: LOW
+    - id: 1.1.13
+      name: Ensure that the admin.conf file permissions are set to 600
+      description: Ensure that the admin.conf file has permissions of 600
+      checks:
+        - id: AVD-KCV-0060
+      commands:
+        - id: CMD-0013
+      severity: CRITICAL
+    - id: 1.1.14
+      name: Ensure that the admin.conf file ownership is set to root:root
+      description: Ensure that the admin.conf file ownership is set to root:root
+      checks:
+        - id: AVD-KCV-0061
+      commands:
+        - id: CMD-0014
+      severity: CRITICAL
+    - id: 1.1.15
+      name: Ensure that the scheduler.conf file permissions are set to 600 or more
+        restrictive
+      description: Ensure that the scheduler.conf file has permissions of 600 or more
+        restrictive
+      checks:
+        - id: AVD-KCV-0062
+      commands:
+        - id: CMD-0015
+      severity: HIGH
+    - id: 1.1.16
+      name: Ensure that the scheduler.conf file ownership is set to root:root
+      description: Ensure that the scheduler.conf file ownership is set to root:root
+      checks:
+        - id: AVD-KCV-0063
+      commands:
+        - id: CMD-0016
+      severity: HIGH
+    - id: 1.1.17
+      name: Ensure that the controller-manager.conf file permissions are set to 600 or
+        more restrictive
+      description: Ensure that the controller-manager.conf file has permissions of 600
+        or more restrictive
+      checks:
+        - id: AVD-KCV-0064
+      commands:
+        - id: CMD-0017
+      severity: HIGH
+    - id: 1.1.18
+      name: Ensure that the controller-manager.conf file ownership is set to root:root
+      description: Ensure that the controller-manager.conf file ownership is set to
+        root:root.
+      checks:
+        - id: AVD-KCV-0065
+      commands:
+        - id: CMD-0018
+      severity: HIGH
+    - id: 1.1.19
+      name: Ensure that the Kubernetes PKI directory and file ownership is set to
+        root:root
+      description: Ensure that the Kubernetes PKI directory and file ownership is set
+        to root:root
+      checks:
+        - id: AVD-KCV-0066
+      commands:
+        - id: CMD-0019
+      severity: CRITICAL
+    - id: 1.1.20
+      name: Ensure that the Kubernetes PKI certificate file permissions are set to 600
+        or more restrictive
+      description: Ensure that Kubernetes PKI certificate files have permissions of
+        600 or more restrictive
+      checks:
+        - id: AVD-KCV-0068
+      commands:
+        - id: CMD-0020
+      severity: CRITICAL
+    - id: 1.1.21
+      name: Ensure that the Kubernetes PKI key file permissions are set to 600
+      description: Ensure that Kubernetes PKI key files have permissions of 600
+      checks:
+        - id: AVD-KCV-0067
+      commands:
+        - id: CMD-0021
+      severity: CRITICAL
+    - id: 1.2.1
+      name: Ensure that the --anonymous-auth argument is set to false
+      description: Disable anonymous requests to the API server
+      checks:
+        - id: AVD-KCV-0001
+      severity: MEDIUM
+    - id: 1.2.2
+      name: Ensure that the --token-auth-file parameter is not set
+      description: Do not use token based authentication
+      checks:
+        - id: AVD-KCV-0002
+      severity: LOW
+    - id: 1.2.3
+      name: Ensure that the --DenyServiceExternalIPs is not set
+      description: This admission controller rejects all net-new usage of the Service
+        field externalIPs
+      checks:
+        - id: AVD-KCV-0003
+      severity: LOW
+    - id: 1.2.4
+      name: Ensure that the --kubelet-https argument is set to true
+      description: Use https for kubelet connections
+      checks:
+        - id: AVD-KCV-0004
+      severity: LOW
+    - id: 1.2.5
+      name: Ensure that the --kubelet-client-certificate and --kubelet-client-key
+        arguments are set as appropriate
+      description: Enable certificate based kubelet authentication
+      checks:
+        - id: AVD-KCV-0005
+      severity: HIGH
+    - id: 1.2.6
+      name: Ensure that the --kubelet-certificate-authority argument is set as
+        appropriate
+      description: Verify kubelets certificate before establishing connection
+      checks:
+        - id: AVD-KCV-0006
+      severity: HIGH
+    - id: 1.2.7
+      name: Ensure that the --authorization-mode argument is not set to AlwaysAllow
+      description: Do not always authorize all requests
+      checks:
+        - id: AVD-KCV-0007
+      severity: LOW
+    - id: 1.2.8
+      name: Ensure that the --authorization-mode argument includes Node
+      description: Restrict kubelet nodes to reading only objects associated with them
+      checks:
+        - id: AVD-KCV-0008
+      severity: HIGH
+    - id: 1.2.9
+      name: Ensure that the --authorization-mode argument includes RBAC
+      description: Turn on Role Based Access Control
+      checks:
+        - id: AVD-KCV-0009
+      severity: HIGH
+    - id: 1.2.10
+      name: Ensure that the admission control plugin EventRateLimit is set
+      description: Limit the rate at which the API server accepts requests
+      checks:
+        - id: AVD-KCV-0010
+      severity: HIGH
+    - id: 1.2.11
+      name: Ensure that the admission control plugin AlwaysAdmit is not set
+      description: Do not allow all requests
+      checks:
+        - id: AVD-KCV-0011
+      severity: LOW
+    - id: 1.2.12
+      name: Ensure that the admission control plugin AlwaysPullImages is set
+      description: Always pull images
+      checks:
+        - id: AVD-KCV-0012
+      severity: MEDIUM
+    - id: 1.2.13
+      name: Ensure that the admission control plugin SecurityContextDeny is set if
+        PodSecurityPolicy is not used
+      description: The SecurityContextDeny admission controller can be used to deny
+        pods which make use of some SecurityContext fields which could allow for
+        privilege escalation in the cluster. This should be used where
+        PodSecurityPolicy is not in place within the cluster
+      checks:
+        - id: AVD-KCV-0013
+      severity: MEDIUM
+    - id: 1.2.14
+      name: Ensure that the admission control plugin ServiceAccount is set
+      description: Automate service accounts management
+      checks:
+        - id: AVD-KCV-0014
+      severity: LOW
+    - id: 1.2.15
+      name: Ensure that the admission control plugin NamespaceLifecycle is set
+      description: Reject creating objects in a namespace that is undergoing termination
+      checks:
+        - id: AVD-KCV-0015
+      severity: LOW
+    - id: 1.2.16
+      name: Ensure that the admission control plugin NodeRestriction is set
+      description: Limit the Node and Pod objects that a kubelet could modify
+      checks:
+        - id: AVD-KCV-0016
+      severity: LOW
+    - id: 1.2.17
+      name: Ensure that the --secure-port argument is not set to 0
+      description: Do not disable the secure port
+      checks:
+        - id: AVD-KCV-0017
+      severity: HIGH
+    - id: 1.2.18
+      name: Ensure that the --profiling argument is set to false
+      description: Disable profiling, if not needed
+      checks:
+        - id: AVD-KCV-0018
+      severity: LOW
+    - id: 1.2.19
+      name: Ensure that the --audit-log-path argument is set
+      description: Enable auditing on the Kubernetes API Server and set the desired
+        audit log path.
+      checks:
+        - id: AVD-KCV-0019
+      severity: LOW
+    - id: 1.2.20
+      name: Ensure that the --audit-log-maxage argument is set to 30 or as appropriate
+      description: Retain the logs for at least 30 days or as appropriate
+      checks:
+        - id: AVD-KCV-0020
+      severity: LOW
+    - id: 1.2.21
+      name: Ensure that the --audit-log-maxbackup argument is set to 10 or as
+        appropriate
+      description: Retain 10 or an appropriate number of old log file
+      checks:
+        - id: AVD-KCV-0021
+      severity: LOW
+    - id: 1.2.22
+      name: Ensure that the --audit-log-maxsize argument is set to 100 or as
+        appropriate
+      description: Rotate log files on reaching 100 MB or as appropriate
+      checks:
+        - id: AVD-KCV-0022
+      severity: LOW
+    - id: 1.2.24
+      name: Ensure that the --service-account-lookup argument is set to true
+      description: Validate service account before validating token
+      checks:
+        - id: AVD-KCV-0024
+      severity: LOW
+    - id: 1.2.25
+      name: Ensure that the --service-account-key-file argument is set as appropriate
+      description: Explicitly set a service account public key file for service
+        accounts on the apiserver
+      checks:
+        - id: AVD-KCV-0025
+      severity: LOW
+    - id: 1.2.26
+      name: Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as
+        appropriate
+      description: etcd should be configured to make use of TLS encryption for client
+        connections
+      checks:
+        - id: AVD-KCV-0026
+      severity: LOW
+    - id: 1.2.27
+      name: Ensure that the --tls-cert-file and --tls-private-key-file arguments are
+        set as appropriate
+      description: Setup TLS connection on the API server
+      checks:
+        - id: AVD-KCV-0027
+      severity: MEDIUM
+    - id: 1.2.28
+      name: Ensure that the --client-ca-file argument is set appropriate
+      description: Setup TLS connection on the API server
+      checks:
+        - id: AVD-KCV-0028
+      severity: LOW
+    - id: 1.2.29
+      name: Ensure that the --etcd-cafile argument is set as appropriate
+      description: etcd should be configured to make use of TLS encryption for client
+        connections.
+      checks:
+        - id: AVD-KCV-0029
+      severity: LOW
+    - id: 1.2.30
+      name: Ensure that the --encryption-provider-config argument is set as
+        appropriate
+      description: Encrypt etcd key-value store
+      checks:
+        - id: AVD-KCV-0030
+      severity: LOW
+    - id: 1.3.1
+      name: Ensure that the --terminated-pod-gc-threshold argument is set as
+        appropriate
+      description: Activate garbage collector on pod termination, as appropriate
+      checks:
+        - id: AVD-KCV-0033
+      severity: MEDIUM
+    - id: 1.3.3
+      name: Ensure that the --use-service-account-credentials argument is set to true
+      description: Use individual service account credentials for each controller
+      checks:
+        - id: AVD-KCV-0035
+      severity: MEDIUM
+    - id: 1.3.4
+      name: Ensure that the --service-account-private-key-file argument is set as
+        appropriate
+      description: Explicitly set a service account private key file for service
+        accounts on the controller manager
+      checks:
+        - id: AVD-KCV-0036
+      severity: MEDIUM
+    - id: 1.3.5
+      name: Ensure that the --root-ca-file argument is set as appropriate
+      description: Allow pods to verify the API servers serving certificate before
+        establishing connections
+      checks:
+        - id: AVD-KCV-0037
+      severity: MEDIUM
+    - id: 1.3.6
+      name: Ensure that the RotateKubeletServerCertificate argument is set to true
+      description: Enable kubelet server certificate rotation on controller-manager
+      checks:
+        - id: AVD-KCV-0038
+      severity: MEDIUM
+    - id: 1.3.7
+      name: Ensure that the --bind-address argument is set to 127.0.0.1
+      description: Do not bind the scheduler service to non-loopback insecure addresses
+      checks:
+        - id: AVD-KCV-0039
+      severity: LOW
+    - id: 1.4.1
+      name: Ensure that the --profiling argument is set to false
+      description: Disable profiling, if not needed
+      checks:
+        - id: AVD-KCV-0034
+      severity: MEDIUM
+    - id: 1.4.2
+      name: Ensure that the --bind-address argument is set to 127.0.0.1
+      description: Do not bind the scheduler service to non-loopback insecure addresses
+      checks:
+        - id: AVD-KCV-0041
+      severity: CRITICAL
+    - id: "2.1"
+      name: Ensure that the --cert-file and --key-file arguments are set as
+        appropriate
+      description: Configure TLS encryption for the etcd service
+      checks:
+        - id: AVD-KCV-0042
+      severity: MEDIUM
+    - id: "2.2"
+      name: Ensure that the --client-cert-auth argument is set to true
+      description: Enable client authentication on etcd service
+      checks:
+        - id: AVD-KCV-0043
+      severity: CRITICAL
+    - id: "2.3"
+      name: Ensure that the --auto-tls argument is not set to true
+      description: Do not use self-signed certificates for TLS
+      checks:
+        - id: AVD-KCV-0044
+      severity: CRITICAL
+    - id: "2.4"
+      name: Ensure that the --peer-cert-file and --peer-key-file arguments are set as
+        appropriate
+      description: etcd should be configured to make use of TLS encryption for peer
+        connections.
+      checks:
+        - id: AVD-KCV-0045
+      severity: CRITICAL
+    - id: "2.5"
+      name: Ensure that the --peer-client-cert-auth argument is set to true
+      description: etcd should be configured for peer authentication
+      checks:
+        - id: AVD-KCV-0046
+      severity: CRITICAL
+    - id: "2.6"
+      name: Ensure that the --peer-auto-tls argument is not set to true
+      description: Do not use self-signed certificates for TLS
+      checks:
+        - id: AVD-KCV-0047
+      severity: HIGH
+    - id: 3.1.1
+      name: Client certificate authentication should not be used for users (Manual)
+      description: Kubernetes provides the option to use client certificates for user
+        authentication. However as there is no way to revoke these certificates
+        when a user leaves an organization or loses their credential, they are
+        not suitable for this purpose
+      severity: HIGH
+    - id: 3.2.1
+      name: Ensure that a minimal audit policy is created (Manual)
+      description: Kubernetes can audit the details of requests made to the API
+        server. The --audit- policy-file flag must be set for this logging to be
+        enabled.
+      severity: HIGH
+    - id: 3.2.2
+      name: Ensure that the audit policy covers key security concerns (Manual)
+      description: Ensure that the audit policy created for the cluster covers key
+        security concerns
+      severity: HIGH
+    - id: 4.1.1
+      name: Ensure that the kubelet service file permissions are set to 600 or more
+        restrictive
+      description: Ensure that the kubelet service file has permissions of 600 or more
+        restrictive.
+      checks:
+        - id: AVD-KCV-0069
+      commands:
+        - id: CMD-0022
+      severity: HIGH
+    - id: 4.1.2
+      name: Ensure that the kubelet service file ownership is set to root:root
+      description: Ensure that the kubelet service file ownership is set to root:root
+      checks:
+        - id: AVD-KCV-0070
+      commands:
+        - id: CMD-0023
+      severity: HIGH
+    - id: 4.1.3
+      name: If proxy kubeconfig file exists ensure permissions are set to 600 or more
+        restrictive
+      description: If kube-proxy is running, and if it is using a file-based
+        kubeconfig file, ensure that the proxy kubeconfig file has permissions
+        of 600 or more restrictive
+      checks:
+        - id: AVD-KCV-0071
+      commands:
+        - id: CMD-0024
+      severity: HIGH
+    - id: 4.1.4
+      name: If proxy kubeconfig file exists ensure ownership is set to root:root
+      description: If kube-proxy is running, ensure that the file ownership of its
+        kubeconfig file is set to root:root
+      checks:
+        - id: AVD-KCV-0072
+      commands:
+        - id: CMD-0025
+      severity: HIGH
+    - id: 4.1.5
+      name: Ensure that the --kubeconfig kubelet.conf file permissions are set to 600
+        or more restrictive
+      description: Ensure that the kubelet.conf file has permissions of 600 or more
+        restrictive
+      checks:
+        - id: AVD-KCV-0073
+      commands:
+        - id: CMD-0026
+      severity: HIGH
+    - id: 4.1.6
+      name: Ensure that the --kubeconfig kubelet.conf file ownership is set to
+        root:root
+      description: Ensure that the kubelet.conf file ownership is set to root:root
+      checks:
+        - id: AVD-KCV-0074
+      commands:
+        - id: CMD-0027
+      severity: HIGH
+    - id: 4.1.7
+      name: Ensure that the certificate authorities file permissions are set to 600 or
+        more restrictive
+      description: Ensure that the certificate authorities file has permissions of 600
+        or more restrictive
+      checks:
+        - id: AVD-KCV-0075
+      commands:
+        - id: CMD-0028
+      severity: CRITICAL
+    - id: 4.1.8
+      name: Ensure that the client certificate authorities file ownership is set to
+        root:root
+      description: Ensure that the certificate authorities file ownership is set to
+        root:root
+      checks:
+        - id: AVD-KCV-0076
+      commands:
+        - id: CMD-0029
+      severity: CRITICAL
+    - id: 4.1.9
+      name: If the kubelet config.yaml configuration file is being used validate
+        permissions set to 600 or more restrictive
+      description: Ensure that if the kubelet refers to a configuration file with the
+        --config argument, that file has permissions of 600 or more restrictive
+      checks:
+        - id: AVD-KCV-0077
+      commands:
+        - id: CMD-0030
+      severity: HIGH
+    - id: 4.1.10
+      name: If the kubelet config.yaml configuration file is being used validate file
+        ownership is set to root:root
+      description: Ensure that if the kubelet refers to a configuration file with the
+        --config argument, that file is owned by root:root
+      checks:
+        - id: AVD-KCV-0078
+      commands:
+        - id: CMD-0031
+      severity: HIGH
+    - id: 4.2.1
+      name: Ensure that the --anonymous-auth argument is set to false
+      description: Disable anonymous requests to the Kubelet server
+      checks:
+        - id: AVD-KCV-0079
+      commands:
+        - id: CMD-0032
+      severity: CRITICAL
+    - id: 4.2.2
+      name: Ensure that the --authorization-mode argument is not set to AlwaysAllow
+      description: Do not allow all requests. Enable explicit authorization
+      checks:
+        - id: AVD-KCV-0080
+      commands:
+        - id: CMD-0033
+      severity: CRITICAL
+    - id: 4.2.3
+      name: Ensure that the --client-ca-file argument is set as appropriate
+      description: Enable Kubelet authentication using certificates
+      checks:
+        - id: AVD-KCV-0081
+      commands:
+        - id: CMD-0034
+      severity: CRITICAL
+    - id: 4.2.4
+      name: Verify that the --read-only-port argument is set to 0
+      description: Disable the read-only port
+      checks:
+        - id: AVD-KCV-0082
+      commands:
+        - id: CMD-0035
+      severity: HIGH
+    - id: 4.2.5
+      name: Ensure that the --streaming-connection-idle-timeout argument is not set to
+        0
+      description: Do not disable timeouts on streaming connections
+      checks:
+        - id: AVD-KCV-0085
+      commands:
+        - id: CMD-0036
+      severity: HIGH
+    - id: 4.2.6
+      name: Ensure that the --protect-kernel-defaults argument is set to true
+      description: Protect tuned kernel parameters from overriding kubelet default
+        kernel parameter values
+      checks:
+        - id: AVD-KCV-0083
+      commands:
+        - id: CMD-0037
+      severity: HIGH
+    - id: 4.2.7
+      name: Ensure that the --make-iptables-util-chains argument is set to true
+      description: Allow Kubelet to manage iptables
+      checks:
+        - id: AVD-KCV-0084
+      commands:
+        - id: CMD-0038
+      severity: HIGH
+    - id: 4.2.8
+      name: Ensure that the --hostname-override argument is not set
+      description: Do not override node hostnames
+      checks:
+        - id: AVD-KCV-0086
+      commands:
+        - id: CMD-0039
+      severity: HIGH
+    - id: 4.2.9
+      name: Ensure that the --event-qps argument is set to 0 or a level which ensures
+        appropriate event capture
+      description: Security relevant information should be captured. The --event-qps
+        flag on the Kubelet can be used to limit the rate at which events are
+        gathered
+      checks:
+        - id: AVD-KCV-0087
+      commands:
+        - id: CMD-0040
+      severity: HIGH
+    - id: 4.2.10
+      name: Ensure that the --tls-cert-file and --tls-private-key-file arguments are
+        set as appropriate
+      description: Setup TLS connection on the Kubelets
+      checks:
+        - id: AVD-KCV-0088
+        - id: AVD-KCV-0089
+      commands:
+        - id: CMD-0041
+        - id: CMD-0042
+      severity: CRITICAL
+    - id: 4.2.11
+      name: Ensure that the --rotate-certificates argument is not set to false
+      description: Enable kubelet client certificate rotation
+      checks:
+        - id: AVD-KCV-0090
+      commands:
+        - id: CMD-0043
+      severity: CRITICAL
+    - id: 4.2.12
+      name: Verify that the RotateKubeletServerCertificate argument is set to true
+      description: Enable kubelet server certificate rotation
+      checks:
+        - id: AVD-KCV-0091
+      commands:
+        - id: CMD-0044
+      severity: CRITICAL
+    - id: 4.2.13
+      name: Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers
+      description: Ensure that the Kubelet is configured to only use strong
+        cryptographic ciphers
+      checks:
+        - id: AVD-KCV-0092
+      commands:
+        - id: CMD-0045
+      severity: CRITICAL
+    - id: 5.1.1
+      name: Ensure that the cluster-admin role is only used where required
+      description: The RBAC role cluster-admin provides wide-ranging powers over the
+        environment and should be used only where and when needed
+      checks:
+        - id: AVD-KSV-0111
+      severity: HIGH
+    - id: 5.1.2
+      name: Minimize access to secrets
+      description: The Kubernetes API stores secrets, which may be service account
+        tokens for the Kubernetes API or credentials used by workloads in the
+        cluster
+      checks:
+        - id: AVD-KSV-0041
+      severity: HIGH
+    - id: 5.1.3
+      name: Minimize wildcard use in Roles and ClusterRoles
+      description: Kubernetes Roles and ClusterRoles provide access to resources based
+        on sets of objects and actions that can be taken on those objects. It is
+        possible to set either of these to be the wildcard "*" which matches all
+        items
+      checks:
+        - id: AVD-KSV-0044
+        - id: AVD-KSV-0045
+        - id: AVD-KSV-0046
+      severity: HIGH
+    - id: 5.1.6
+      name: Ensure that Service Account Tokens are only mounted where necessary
+      description: Service accounts tokens should not be mounted in pods except where
+        the workload running in the pod explicitly needs to communicate with the
+        API server
+      checks:
+        - id: AVD-KSV-0036
+      severity: HIGH
+    - id: 5.1.8
+      name: Limit use of the Bind, Impersonate and Escalate permissions in the
+        Kubernetes cluster
+      description: Cluster roles and roles with the impersonate, bind or escalate
+        permissions should not be granted unless strictly required
+      checks:
+        - id: AVD-KSV-0043
+      severity: HIGH
+    - id: 5.2.2
+      name: Minimize the admission of privileged containers
+      description: Do not generally permit containers to be run with the
+        securityContext.privileged flag set to true
+      checks:
+        - id: AVD-KSV-0017
+      severity: HIGH
+    - id: 5.2.3
+      name: Minimize the admission of containers wishing to share the host process ID
+        namespace
+      description: Do not generally permit containers to be run with the hostPID flag
+        set to true.
+      checks:
+        - id: AVD-KSV-0010
+      severity: HIGH
+    - id: 5.2.4
+      name: Minimize the admission of containers wishing to share the host IPC
+        namespace
+      description: Do not generally permit containers to be run with the hostIPC flag
+        set to true
+      checks:
+        - id: AVD-KSV-0008
+      severity: HIGH
+    - id: 5.2.5
+      name: Minimize the admission of containers wishing to share the host network
+        namespace
+      description: Do not generally permit containers to be run with the hostNetwork
+        flag set to true
+      checks:
+        - id: AVD-KSV-0009
+      severity: HIGH
+    - id: 5.2.6
+      name: Minimize the admission of containers with allowPrivilegeEscalation
+      description: Do not generally permit containers to be run with the
+        allowPrivilegeEscalation flag set to true
+      checks:
+        - id: AVD-KSV-0001
+      severity: HIGH
+    - id: 5.2.7
+      name: Minimize the admission of root containers
+      description: Do not generally permit containers to be run as the root user
+      checks:
+        - id: AVD-KSV-0012
+      severity: MEDIUM
+    - id: 5.2.8
+      name: Minimize the admission of containers with the NET_RAW capability
+      description: Do not generally permit containers with the potentially dangerous
+        NET_RAW capability
+      checks:
+        - id: AVD-KSV-0022
+      severity: MEDIUM
+    - id: 5.2.9
+      name: Minimize the admission of containers with added capabilities
+      description: Do not generally permit containers with capabilities assigned
+        beyond the default set
+      checks:
+        - id: AVD-KSV-0004
+      severity: LOW
+    - id: 5.2.10
+      name: Minimize the admission of containers with capabilities assigned
+      description: Do not generally permit containers with capabilities
+      checks:
+        - id: AVD-KSV-0003
+      severity: LOW
+    - id: 5.2.11
+      name: Minimize the admission of containers with capabilities assigned
+      description: Do not generally permit containers with capabilities
+      checks:
+        - id: AVD-KSV-0103
+      severity: MEDIUM
+    - id: 5.2.12
+      name: Minimize the admission of HostPath volumes
+      description: Do not generally admit containers which make use of hostPath volumes
+      checks:
+        - id: AVD-KSV-0023
+      severity: MEDIUM
+    - id: 5.2.13
+      name: Minimize the admission of containers which use HostPorts
+      description: Do not generally permit containers which require the use of HostPorts
+      checks:
+        - id: AVD-KSV-0024
+      severity: MEDIUM
+    - id: 5.3.1
+      name: Ensure that the CNI in use supports Network Policies (Manual)
+      description: There are a variety of CNI plugins available for Kubernetes. If the
+        CNI in use does not support Network Policies it may not be possible to
+        effectively restrict traffic in the cluster
+      severity: MEDIUM
+    - id: 5.3.2
+      name: Ensure that all Namespaces have Network Policies defined
+      description: Use network policies to isolate traffic in your cluster network
+      checks:
+        - id: AVD-KSV-0038
+      severity: MEDIUM
+    - id: 5.4.1
+      name: Prefer using secrets as files over secrets as environment variables
+        (Manual)
+      description: Kubernetes supports mounting secrets as data volumes or as
+        environment variables. Minimize the use of environment variable secrets
+      severity: MEDIUM
+    - id: 5.4.2
+      name: Consider external secret storage (Manual)
+      description: Consider the use of an external secrets storage and management
+        system, instead of using Kubernetes Secrets directly, if you have more
+        complex secret management needs
+      severity: MEDIUM
+    - id: 5.5.1
+      name: Configure Image Provenance using ImagePolicyWebhook admission controller
+        (Manual)
+      description: Configure Image Provenance for your deployment
+      severity: MEDIUM
+    - id: 5.7.1
+      name: Create administrative boundaries between resources using namespaces
+        (Manual)
+      description: Use namespaces to isolate your Kubernetes objects
+      severity: MEDIUM
+    - id: 5.7.2
+      name: Ensure that the seccomp profile is set to docker/default in your pod
+        definitions
+      description: Enable docker/default seccomp profile in your pod definitions
+      checks:
+        - id: AVD-KSV-0104
+      severity: MEDIUM
+    - id: 5.7.3
+      name: Apply Security Context to Your Pods and Containers
+      description: Apply Security Context to Your Pods and Containers
+      checks:
+        - id: AVD-KSV-0021
+        - id: AVD-KSV-0020
+        - id: AVD-KSV-0005
+        - id: AVD-KSV-0025
+        - id: AVD-KSV-0104
+        - id: AVD-KSV-0030
+      severity: HIGH
+    - id: 5.7.4
+      name: The default namespace should not be used
+      description: Kubernetes provides a default namespace, where objects are placed
+        if no namespace is specified for them
+      checks:
+        - id: AVD-KSV-0110
+      severity: MEDIUM
+---
+# Source: trivy-operator/templates/specs/k8s-nsa-1.0.yaml
+apiVersion: aquasecurity.github.io/v1alpha1
+kind: ClusterComplianceReport
+metadata:
+  name: k8s-nsa-1.0
+  labels:
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy-operator
+    app.kubernetes.io/version: 0.29.0
+    app.kubernetes.io/managed-by: kubectl
+spec:
+  cron: "0 */6 * * *"
+  reportType: "summary"
+  compliance:
+    id: k8s-nsa-1.0
+    platform: k8s
+    type: nsa
+    title: National Security Agency - Kubernetes Hardening Guidance v1.0
+    description: National Security Agency - Kubernetes Hardening Guidance
+    relatedResources:
+      - https://www.nsa.gov/Press-Room/News-Highlights/Article/Article/2716980/nsa-cisa-release-kubernetes-hardening-guidance/
+    version: "1.0"
+    controls:
+      - name: Non-root containers
+        description: Check that container is not running as root
+        id: "1.0"
+        checks:
+          - id: AVD-KSV-0012
+        severity: MEDIUM
+      - name: Immutable container file systems
+        description: Check that container root file system is immutable
+        id: "1.1"
+        checks:
+          - id: AVD-KSV-0014
+        severity: LOW
+      - name: Preventing privileged containers
+        description: Controls whether Pods can run privileged containers
+        id: "1.2"
+        checks:
+          - id: AVD-KSV-0017
+        severity: HIGH
+      - name: Share containers process namespaces
+        description: Controls whether containers can share process namespaces
+        id: "1.3"
+        checks:
+          - id: AVD-KSV-0008
+        severity: HIGH
+      - name: Share host process namespaces
+        description: Controls whether share host process namespaces
+        id: "1.4"
+        checks:
+          - id: AVD-KSV-0009
+        severity: HIGH
+      - name: Use the host network
+        description: Controls whether containers can use the host network
+        id: "1.5"
+        checks:
+          - id: AVD-KSV-0010
+        severity: HIGH
+      - name: Run with root privileges or with root group membership
+        description: Controls whether container applications can run with root
+          privileges or with root group membership
+        id: "1.6"
+        checks:
+          - id: AVD-KSV-0029
+        severity: LOW
+      - name: Restricts escalation to root privileges
+        description: Control check restrictions escalation to root privileges
+        id: "1.7"
+        checks:
+          - id: AVD-KSV-0001
+        severity: MEDIUM
+      - name: Sets the SELinux context of the container
+        description: Control checks if pod sets the SELinux context of the container
+        id: "1.8"
+        checks:
+          - id: AVD-KSV-0002
+        severity: MEDIUM
+      - name: Restrict a container's access to resources with AppArmor
+        description: Control checks the restriction of containers access to resources
+          with AppArmor
+        id: "1.9"
+        checks:
+          - id: AVD-KSV-0030
+        severity: MEDIUM
+      - name: Sets the seccomp profile used to sandbox containers.
+        description: Control checks the sets the seccomp profile used to sandbox containers
+        id: "1.10"
+        checks:
+          - id: AVD-KSV-0030
+        severity: LOW
+      - name: Protecting Pod service account tokens
+        description: "Control check whether disable secret token been mount
+          ,automountServiceAccountToken: false"
+        id: "1.11"
+        checks:
+          - id: AVD-KSV-0036
+        severity: MEDIUM
+      - name: Namespace kube-system should not be used by users
+        description: Control check whether Namespace kube-system is not be used by users
+        id: "1.12"
+        defaultStatus: FAIL
+        checks:
+          - id: AVD-KSV-0037
+        severity: MEDIUM
+      - name: Pod and/or namespace Selectors usage
+        description: Control check validate the pod and/or namespace Selectors usage
+        id: "2.0"
+        defaultStatus: FAIL
+        checks:
+          - id: AVD-KSV-0038
+        severity: MEDIUM
+      - name: Use CNI plugin that supports NetworkPolicy API (Manual)
+        description: Control check whether check cni plugin installed
+        id: "3.0"
+        defaultStatus: FAIL
+        severity: CRITICAL
+      - name: Use ResourceQuota policies to limit resources
+        description: Control check the use of ResourceQuota policy to limit aggregate
+          resource usage within namespace
+        id: "4.0"
+        defaultStatus: FAIL
+        checks:
+          - id: AVD-KSV-0040
+        severity: MEDIUM
+      - name: Use LimitRange policies to limit resources
+        description: Control check the use of LimitRange policy limit resource usage for
+          namespaces or nodes
+        id: "4.1"
+        defaultStatus: FAIL
+        checks:
+          - id: AVD-KSV-0039
+        severity: MEDIUM
+      - name: Control plan disable insecure port (Manual)
+        description: Control check whether control plan disable insecure port
+        id: "5.0"
+        defaultStatus: FAIL
+        severity: CRITICAL
+      - name: Encrypt etcd communication
+        description: Control check whether etcd communication is encrypted
+        id: "5.1"
+        checks:
+          - id: AVD-KCV-0030
+        severity: CRITICAL
+      - name: Ensure kube config file permission (Manual)
+        description: Control check whether kube config file permissions
+        id: "6.0"
+        defaultStatus: FAIL
+        severity: CRITICAL
+      - name: Check that encryption resource has been set
+        description: Control checks whether encryption resource has been set
+        id: "6.1"
+        checks:
+          - id: AVD-KCV-0029
+        severity: CRITICAL
+      - name: Check encryption provider
+        description: Control checks whether encryption provider has been set
+        id: "6.2"
+        checks:
+          - id: AVD-KCV-0004
+        severity: CRITICAL
+      - name: Make sure anonymous-auth is unset
+        description: Control checks whether anonymous-auth is unset
+        id: "7.0"
+        checks:
+          - id: AVD-KCV-0001
+        severity: CRITICAL
+      - name: Make sure -authorization-mode=RBAC
+        description: Control check whether RBAC permission is in use
+        id: "7.1"
+        checks:
+          - id: AVD-KCV-0008
+        severity: CRITICAL
+      - name: Audit policy is configure (Manual)
+        description: Control check whether audit policy is configure
+        id: "8.0"
+        defaultStatus: FAIL
+        severity: HIGH
+      - name: Audit log path is configure
+        description: Control check whether audit log path is configure
+        id: "8.1"
+        checks:
+          - id: AVD-KCV-0019
+        severity: MEDIUM
+      - name: Audit log aging
+        description: Control check whether audit log aging is configure
+        id: "8.2"
+        checks:
+          - id: AVD-KCV-0020
+        severity: MEDIUM
+---
+# Source: trivy-operator/templates/specs/k8s-pss-baseline-0.1.yaml
+apiVersion: aquasecurity.github.io/v1alpha1
+kind: ClusterComplianceReport
+metadata:
+  name: k8s-pss-baseline-0.1
+  labels:
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy-operator
+    app.kubernetes.io/version: 0.29.0
+    app.kubernetes.io/managed-by: kubectl
+spec:
+  cron: "0 */6 * * *"
+  reportType: "summary"
+  compliance:
+    id: k8s-pss-baseline-0.1
+    platform: eks
+    type: pss-baseline
+    title: Kubernetes Pod Security Standards - Baseline
+    description: Kubernetes Pod Security Standards - Baseline
+    relatedResources:
+      - https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline
+    version: "0.1"
+    controls:
+      - name: HostProcess
+        description: Windows pods offer the ability to run HostProcess containers which
+          enables privileged access to the Windows node. Privileged access to
+          the host is disallowed in the baseline policy
+        id: "1"
+        checks:
+          - id: AVD-KSV-0103
+        severity: HIGH
+      - name: Host Namespaces
+        description: Sharing the host namespaces must be disallowed.
+        id: "2"
+        checks:
+          - id: AVD-KSV-0008
+        severity: HIGH
+      - name: Privileged Containers
+        description: Privileged Pods disable most security mechanisms and must be
+          disallowed.
+        id: "3"
+        checks:
+          - id: AVD-KSV-0017
+        severity: HIGH
+      - name: Capabilities
+        description: Adding additional capabilities beyond those listed below must be
+          disallowed.
+        id: "4"
+        checks:
+          - id: AVD-KSV-0022
+        severity: MEDIUM
+      - name: HostPath Volumes
+        description: HostPath volumes must be forbidden.
+        id: "5"
+        checks:
+          - id: AVD-KSV-0023
+        severity: MEDIUM
+      - name: host ports
+        description: hostports should be disallowed, or at minimum restricted to a known
+          list.
+        id: "6"
+        checks:
+          - id: avd-ksv-0024
+        severity: HIGH
+      - name: AppArmor
+        description: On supported hosts, the runtime/default AppArmor profile is applied
+          by default. The baseline policy should prevent overriding or disabling
+          the default AppArmor profile, or restrict overrides to an allowed set
+          of profiles.
+        id: "7"
+        checks:
+          - id: avd-ksv-0002
+        severity: HIGH
+      - name: SELinux
+        description: Setting the SELinux type is restricted, and setting a custom
+          SELinux user or role option is forbidden.
+        id: "8"
+        checks:
+          - id: avd-ksv-0025
+        severity: MEDIUM
+      - name: /proc Mount Type
+        description: The default /proc masks are set up to reduce attack surface, and
+          should be required.
+        id: "9"
+        checks:
+          - id: avd-ksv-0027
+        severity: MEDIUM
+      - name: Seccomp
+        description: Seccomp profile must not be explicitly set to Unconfined.
+        id: "10"
+        checks:
+          - id: avd-ksv-0104
+        severity: MEDIUM
+      - name: Sysctls
+        description: Sysctls can disable security mechanisms or affect all containers on
+          a host, and should be disallowed except for an allowed 'safe' subset.
+          A sysctl is considered safe if it is namespaced in the container or
+          the Pod, and it is isolated from other Pods or processes on the same
+          Node.
+        id: "11"
+        checks:
+          - id: avd-ksv-0026
+        severity: MEDIUM
+---
+# Source: trivy-operator/templates/specs/k8s-pss-restricted-0.1.yaml
+apiVersion: aquasecurity.github.io/v1alpha1
+kind: ClusterComplianceReport
+metadata:
+  name: k8s-pss-restricted-0.1
+  labels:
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy-operator
+    app.kubernetes.io/version: 0.29.0
+    app.kubernetes.io/managed-by: kubectl
+spec:
+  cron: "0 */6 * * *"
+  reportType: "summary"
+  compliance:
+    id: k8s-pss-restricted-0.1
+    platform: k8s
+    type: pss-restricted
+    title: Kubernetes Pod Security Standards - Restricted
+    description: Kubernetes Pod Security Standards - Restricted
+    relatedResources:
+      - https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
+    version: "0.1"
+    controls:
+      - name: HostProcess
+        description: Windows pods offer the ability to run HostProcess containers which
+          enables privileged access to the Windows node. Privileged access to
+          the host is disallowed in the baseline policy
+        id: "1"
+        checks:
+          - id: AVD-KSV-0103
+        severity: HIGH
+      - name: Host Namespaces
+        description: Sharing the host namespaces must be disallowed.
+        id: "2"
+        checks:
+          - id: AVD-KSV-0008
+        severity: HIGH
+      - name: Privileged Containers
+        description: Privileged Pods disable most security mechanisms and must be
+          disallowed.
+        id: "3"
+        checks:
+          - id: AVD-KSV-0017
+        severity: HIGH
+      - name: Capabilities
+        description: Adding additional capabilities beyond those listed below must be
+          disallowed.
+        id: "4"
+        checks:
+          - id: AVD-KSV-0022
+        severity: MEDIUM
+      - name: HostPath Volumes
+        description: HostPath volumes must be forbidden.
+        id: "5"
+        checks:
+          - id: AVD-KSV-0023
+        severity: MEDIUM
+      - name: host ports
+        description: hostports should be disallowed, or at minimum restricted to a known
+          list.
+        id: "6"
+        checks:
+          - id: avd-ksv-0024
+        severity: HIGH
+      - name: AppArmor
+        description: On supported hosts, the runtime/default AppArmor profile is applied
+          by default. The baseline policy should prevent overriding or disabling
+          the default AppArmor profile, or restrict overrides to an allowed set
+          of profiles.
+        id: "7"
+        checks:
+          - id: avd-ksv-0002
+        severity: HIGH
+      - name: SELinux
+        description: Setting the SELinux type is restricted, and setting a custom
+          SELinux user or role option is forbidden.
+        id: "8"
+        checks:
+          - id: avd-ksv-0025
+        severity: MEDIUM
+      - name: /proc Mount Type
+        description: The default /proc masks are set up to reduce attack surface, and
+          should be required.
+        id: "9"
+        checks:
+          - id: avd-ksv-0027
+        severity: MEDIUM
+      - name: Seccomp
+        description: Seccomp profile must not be explicitly set to Unconfined.
+        id: "10"
+        checks:
+          - id: avd-ksv-0104
+        severity: MEDIUM
+      - name: Sysctls
+        description: Sysctls can disable security mechanisms or affect all containers on
+          a host, and should be disallowed except for an allowed 'safe' subset.
+          A sysctl is considered safe if it is namespaced in the container or
+          the Pod, and it is isolated from other Pods or processes on the same
+          Node.
+        id: "11"
+        checks:
+          - id: avd-ksv-0026
+        severity: MEDIUM
+      - name: Volume Types
+        description: The restricted policy only permits specific volume types.
+        id: "12"
+        checks:
+          - id: avd-ksv-0028
+        severity: LOW
+      - name: Privilege Escalation
+        description: Privilege escalation (such as via set-user-ID or set-group-ID file
+          mode) should not be allowed.
+        id: "13"
+        checks:
+          - id: avd-ksv-0001
+        severity: MEDIUM
+      - name: Running as Non-root
+        description: Containers must be required to run as non-root users.
+        id: "14"
+        checks:
+          - id: avd-ksv-0012
+        severity: MEDIUM
+      - name: Running as Non-root user
+        description: Containers must not set runAsUser to 0
+        id: "15"
+        checks:
+          - id: avd-ksv-0105
+        severity: LOW
+      - name: Seccomp
+        description: Seccomp profile must be explicitly set to one of the allowed
+          values. Both the Unconfined profile and the absence of a profile are
+          prohibited
+        id: "16"
+        checks:
+          - id: avd-ksv-0030
+        severity: LOW
+      - name: Capabilities
+        description: Containers must drop ALL capabilities, and are only permitted to
+          add back the NET_BIND_SERVICE capability.
+        id: "17"
+        checks:
+          - id: avd-ksv-0106
+        severity: LOW
+---
+# Source: trivy-operator/templates/monitor/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: trivy-trivy-operator
+  namespace: security
+  labels:
+    helm.sh/chart: trivy-operator-0.31.0
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/instance: trivy
+    app.kubernetes.io/version: "0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: trivy-operator
+      app.kubernetes.io/instance: trivy
+  endpoints:
+  - honorLabels: true
+    port: metrics
+    scheme: http

--- a/apps/03-security/trivy/overlays/dev/kustomization.yaml
+++ b/apps/03-security/trivy/overlays/dev/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+
+components:
+  - ../../../../_shared/components/revision-history-limit
+
+patches:
+  - path: resources-patch.yaml

--- a/apps/03-security/trivy/overlays/dev/resources-patch.yaml
+++ b/apps/03-security/trivy/overlays/dev/resources-patch.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trivy-trivy-operator
+  namespace: security
+spec:
+  template:
+    spec:
+      priorityClassName: vixens-medium
+      containers:
+        - name: trivy-operator
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 100m
+              memory: 256Mi

--- a/apps/03-security/trivy/overlays/prod/kustomization.yaml
+++ b/apps/03-security/trivy/overlays/prod/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+
+components:
+  - ../../../../_shared/components/revision-history-limit
+
+patches:
+  - path: resources-patch.yaml

--- a/apps/03-security/trivy/overlays/prod/resources-patch.yaml
+++ b/apps/03-security/trivy/overlays/prod/resources-patch.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trivy-trivy-operator
+  namespace: security
+spec:
+  template:
+    spec:
+      priorityClassName: vixens-medium
+      containers:
+        - name: trivy-operator
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 100m
+              memory: 256Mi

--- a/apps/_shared/namespaces/kustomization.yaml
+++ b/apps/_shared/namespaces/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - services/base
   - downloads/base
   - velero/base
+  - security/base

--- a/apps/_shared/namespaces/security/base/kustomization.yaml
+++ b/apps/_shared/namespaces/security/base/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/apps/_shared/namespaces/security/base/namespace.yaml
+++ b/apps/_shared/namespaces/security/base/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: security
+  labels:
+    pod-security.kubernetes.io/enforce: baseline

--- a/argocd/overlays/dev/apps/trivy.yaml
+++ b/argocd/overlays/dev/apps/trivy.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: trivy
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: main
+    path: apps/03-security/trivy/overlays/dev
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: security
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/overlays/prod/apps/trivy.yaml
+++ b/argocd/overlays/prod/apps/trivy.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: trivy
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: prod-stable
+    path: apps/03-security/trivy/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: security
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
Deploying Trivy Operator in 'security' namespace with all scanners enabled (CVE, Misconfig, RBAC, Secrets). Includes Prometheus ServiceMonitor and a Grafana Dashboard placeholder (ID 17813).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Trivy Operator for continuous vulnerability and compliance scanning across Kubernetes resources.
  * Integrated security compliance monitoring with support for CIS Kubernetes Benchmarks and NSA hardening policies.
  * Added Grafana dashboard for visualizing security scan results and compliance status.
  * Established automated security namespace management with pod security baseline enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->