### PR TITLE
fix(argocd): add trivy to app-of-apps

### DIFF
--- a/argocd/overlays/dev/kustomization.yaml
+++ b/argocd/overlays/dev/kustomization.yaml
@@ -93,5 +93,6 @@ resources:
   - apps/mariadb-shared.yaml
   - apps/penpot.yaml
   - apps/robusta.yaml
+  - apps/trivy.yaml
   - apps/firefly-iii-importer.yaml
 

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -91,3 +91,4 @@ resources:
   - apps/penpot.yaml
   - apps/vikunja.yaml
   - apps/robusta.yaml
+  - apps/trivy.yaml


### PR DESCRIPTION
Enabling Trivy application in app-of-apps for both dev and prod.