### PR TITLE
fix(security): stabilize trivy operator

### DIFF
--- a/apps/03-security/trivy/overlays/dev/resources-patch.yaml
+++ b/apps/03-security/trivy/overlays/dev/resources-patch.yaml
@@ -12,8 +12,8 @@ spec:
         - name: trivy-operator
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 200m
+              memory: 512Mi
             limits:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 500m
+              memory: 512Mi

--- a/apps/03-security/trivy/overlays/prod/resources-patch.yaml
+++ b/apps/03-security/trivy/overlays/prod/resources-patch.yaml
@@ -12,8 +12,8 @@ spec:
         - name: trivy-operator
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 200m
+              memory: 512Mi
             limits:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 500m
+              memory: 512Mi

--- a/apps/_shared/namespaces/security/base/namespace.yaml
+++ b/apps/_shared/namespaces/security/base/namespace.yaml
@@ -4,4 +4,4 @@ kind: Namespace
 metadata:
   name: security
   labels:
-    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce: privileged


### PR DESCRIPTION
Increasing memory and CPU limits for Trivy Operator to handle cluster-wide scans and setting 'security' namespace to 'privileged' to allow NodeCollector jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased CPU and memory allocation for trivy security scanner in development and production environments to improve performance and stability.
  * Enhanced pod security enforcement level for the security namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->