### PR TITLE
fix(postgresql): restore working state (comment out authentik)

### DIFF
--- a/apps/04-databases/postgresql-shared/base/cluster.yaml
+++ b/apps/04-databases/postgresql-shared/base/cluster.yaml
@@ -29,11 +29,11 @@ spec:
         login: true
         passwordSecret:
           name: netbox-postgresql-credentials
-      - name: authentik
-        ensure: present
-        login: true
-        passwordSecret:
-          name: authentik-postgresql-credentials
+#      - name: authentik
+#        ensure: present
+#        login: true
+#        passwordSecret:
+#          name: authentik-postgresql-credentials
       - name: scanopy
         ensure: present
         login: true


### PR DESCRIPTION
Commenting out Authentik managed role to restore the cluster to its previously working state and resolve the operator restart loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified database cluster configuration to adjust managed roles in the infrastructure setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->