### PR TITLE
feat(radar): total visibility RBAC (SOTA)

### DIFF
--- a/apps/70-tools/radar/base/kustomization.yaml
+++ b/apps/70-tools/radar/base/kustomization.yaml
@@ -5,45 +5,45 @@ namespace: tools
 resources:
   - manifests.yaml
   - ingress.yaml
+  - rbac-view-binding.yaml
 
 patches:
   - target:
       kind: ClusterRole
       name: radar
     patch: |-
-      - op: add
-        path: /rules/-
+      - op: replace
+        path: /rules
         value:
-          apiGroups: [""]
-          resources: ["pods/portforward"]
-          verbs: ["create"]
-      - op: add
-        path: /rules/-
-        value:
-          apiGroups: ["traefik.io"]
-          resources: ["ingressroutes", "middlewares", "tlsoptions"]
-          verbs: ["get", "list", "watch"]
-      - op: add
-        path: /rules/-
-        value:
-          apiGroups: [""]
-          resources: ["persistentvolumes"]
-          verbs: ["get", "list", "watch"]
-      - op: add
-        path: /rules/-
-        value:
-          apiGroups: ["aquasecurity.github.io"]
-          resources: ["vulnerabilityreports", "configauditreports", "exposedsecretreports", "rbacassessmentreports", "sbomreports"]
-          verbs: ["get", "list", "watch"]
-      - op: add
-        path: /rules/-
-        value:
-          apiGroups: ["apiextensions.k8s.io"]
-          resources: ["customresourcedefinitions"]
-          verbs: ["get", "list", "watch"]
-      - op: add
-        path: /rules/-
-        value:
-          apiGroups: ["velero.io"]
-          resources: ["backups", "schedules", "restores", "backupstoragelocations"]
-          verbs: ["get", "list", "watch"]
+          # Custom Resource Definitions and Discovery
+          - apiGroups: ["apiextensions.k8s.io"]
+            resources: ["customresourcedefinitions"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["authorization.k8s.io"]
+            resources: ["selfsubjectaccessreviews"]
+            verbs: ["create"]
+          
+          # Pod Operations (Port-forward & Logs)
+          - apiGroups: [""]
+            resources: ["pods/portforward", "pods/log"]
+            verbs: ["create", "get"]
+
+          # Wildcard for all custom groups (SOTA Observability)
+          # This excludes the core group "" to avoid accidental secret access
+          - apiGroups: 
+              - "traefik.io"
+              - "traefik.containo.us"
+              - "cilium.io"
+              - "argoproj.io"
+              - "aquasecurity.github.io"
+              - "velero.io"
+              - "kyverno.io"
+              - "policies.kyverno.io"
+              - "configuration.konghq.com"
+              - "admissionregistration.k8s.io"
+              - "resource.k8s.io"
+              - "monitoring.coreos.com"
+              - "cert-manager.io"
+              - "postgresql.cnpg.io"
+            resources: ["*"]
+            verbs: ["get", "list", "watch"]

--- a/apps/70-tools/radar/base/rbac-view-binding.yaml
+++ b/apps/70-tools/radar/base/rbac-view-binding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: radar-view-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: radar
+    namespace: tools


### PR DESCRIPTION
Implementing a hybrid RBAC approach for Radar: binding to system 'view' role for safe core resource access and a custom role for all CRD groups (Traefik, Cilium, etc.). This resolves all 'forbidden' errors while keeping secrets safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster-level permissions for the radar tool, consolidating access rules across multiple resource types including pod operations, custom resource definitions, and authorization checks.
  * Added a view role binding to enable the radar service account to access resources across the cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->