### PR TITLE
fix(radar): add missing API groups to RBAC

### DIFF
--- a/apps/70-tools/radar/base/kustomization.yaml
+++ b/apps/70-tools/radar/base/kustomization.yaml
@@ -45,5 +45,8 @@ patches:
               - "monitoring.coreos.com"
               - "cert-manager.io"
               - "postgresql.cnpg.io"
+              - "autoscaling.k8s.io"
+              - "secrets.infisical.com"
+              - "storage.k8s.io"
             resources: ["*"]
             verbs: ["get", "list", "watch"]


### PR DESCRIPTION
Adding autoscaling, infisical and storage groups to Radar RBAC.