### PR TITLE
fix(radar): enable production TLS

### DIFF
--- a/apps/70-tools/radar/overlays/dev/ingress.yaml
+++ b/apps/70-tools/radar/overlays/dev/ingress.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: radar
+  namespace: tools
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+    traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: radar.dev.truxonline.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: radar
+                port:
+                  number: 9280
+  tls:
+    - hosts:
+        - radar.dev.truxonline.com
+      secretName: radar-tls-dev

--- a/apps/70-tools/radar/overlays/dev/kustomization.yaml
+++ b/apps/70-tools/radar/overlays/dev/kustomization.yaml
@@ -3,11 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-patches:
-  - target:
-      kind: Ingress
-      name: radar
-    patch: |-
-      - op: replace
-        path: /spec/rules/0/host
-        value: radar.dev.truxonline.com
+  - ingress.yaml

--- a/apps/70-tools/radar/overlays/prod/ingress.yaml
+++ b/apps/70-tools/radar/overlays/prod/ingress.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: radar
+  namespace: tools
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: radar.truxonline.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: radar
+                port:
+                  number: 9280
+  tls:
+    - hosts:
+        - radar.truxonline.com
+      secretName: radar-tls

--- a/apps/70-tools/radar/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/radar/overlays/prod/kustomization.yaml
@@ -3,11 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-patches:
-  - target:
-      kind: Ingress
-      name: radar
-    patch: |-
-      - op: replace
-        path: /spec/rules/0/host
-        value: radar.truxonline.com
+  - ingress.yaml


### PR DESCRIPTION
Adding the missing TLS block and correcting the cluster-issuer to letsencrypt-prod for Radar in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Enabled TLS encryption for the radar service with automatic certificate provisioning and renewal
  * Configured separate, secure endpoints for development and production environments
  * Implemented ingress routing with HTTPS enforcement and middleware support for improved traffic management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->