### PR TITLE
fix(radar): standardize ingress and rbac

### DIFF
--- a/apps/70-tools/radar/base/kustomization.yaml
+++ b/apps/70-tools/radar/base/kustomization.yaml
@@ -49,7 +49,6 @@ patches:
               - "policies.kyverno.io"
               - "configuration.konghq.com"
               - "admissionregistration.k8s.io"
-              - "apiregistration.k8s.io"
               - "resource.k8s.io"
               - "monitoring.coreos.com"
               - "cert-manager.io"


### PR DESCRIPTION
Moving ingress configuration entirely to overlays and updating RBAC rules. This resolves the ArgoCD ComparisonError and enables production TLS.