### PR TITLE
fix(homeassistant): exclude backups from sync

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -51,7 +51,7 @@ spec:
               export RCLONE_CONFIG_S3_ACCESS_KEY_ID=$LITESTREAM_ACCESS_KEY_ID
               export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=$LITESTREAM_SECRET_ACCESS_KEY
               export RCLONE_CONFIG_S3_ENDPOINT=$LITESTREAM_ENDPOINT
-              rclone copy s3:$LITESTREAM_BUCKET/config /config --transfers 4 --exclude "*.log" --exclude "tts/**" --exclude "tmp_backups/**" --exclude "lost+found/**" --exclude ".*-litestream" --exclude ".*-litestream/**" 2>/dev/null || true
+              rclone copy s3:$LITESTREAM_BUCKET/config /config --transfers 4 --exclude "*.log" --exclude "tts/**" --exclude "backups/**" --exclude "tmp_backups/**" --exclude "lost+found/**" --exclude ".*-litestream" --exclude ".*-litestream/**" 2>/dev/null || true
           envFrom:
             - secretRef:
                 name: homeassistant-secrets
@@ -202,7 +202,7 @@ spec:
               export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=$LITESTREAM_SECRET_ACCESS_KEY
               export RCLONE_CONFIG_S3_ENDPOINT=$LITESTREAM_ENDPOINT
               sync_s3() { 
-                rclone sync /config s3:\$LITESTREAM_BUCKET/config --exclude "*.log" --exclude "tts/**" --exclude "tmp_backups/**" --exclude "lost+found/**" --exclude ".*-litestream" --exclude ".*-litestream/**"
+                rclone sync /config s3:\$LITESTREAM_BUCKET/config --exclude "*.log" --exclude "tts/**" --exclude "backups/**" --exclude "tmp_backups/**" --exclude "lost+found/**" --exclude ".*-litestream" --exclude ".*-litestream/**"
               }
               while true; do 
                 sync_s3; 


### PR DESCRIPTION
Excluding the 'backups/' directory from rclone synchronization to save S3 space and bandwidth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated backup directory exclusion patterns in deployment operations to prevent unnecessary syncing and potential conflicts during configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->