### PR TITLE
fix(goldilocks): kustomization empty error

### DIFF
--- a/apps/02-monitoring/goldilocks/base/kustomization.yaml
+++ b/apps/02-monitoring/goldilocks/base/kustomization.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:


### PR DESCRIPTION
Removes leading dash in kustomization.yaml.