### PR TITLE
fix(goldilocks): final syntax fix

### DIFF
--- a/apps/02-monitoring/goldilocks/base/kustomization.yaml
+++ b/apps/02-monitoring/goldilocks/base/kustomization.yaml
@@ -1,5 +1,3 @@
----
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:


### PR DESCRIPTION
Removes double dash in kustomization.yaml once and for all.