### PR TITLE
fix: homeassistant permissions

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -26,6 +26,8 @@ spec:
         prometheus.io/path: "/metrics"
     spec:
       securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
       hostNetwork: true
@@ -36,6 +38,18 @@ spec:
           operator: Exists
           effect: NoSchedule
       initContainers:
+        - name: fix-perms
+          image: busybox:latest
+          securityContext:
+            runAsUser: 0
+          command:
+            - sh
+            - -c
+          args:
+            - chown -R 1000:1000 /config
+          volumeMounts:
+            - name: config
+              mountPath: /config
         - name: restore-config
           image: rclone/rclone:1.73
           securityContext:


### PR DESCRIPTION
Adds fix-perms initContainer and sets pod-level runAsUser: 1000 to resolve database lock and permission errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Home Assistant deployment configuration and container initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->