### PR TITLE
fix: replace rclone sync with copy and add .storage backup

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/rclone-patch.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/rclone-patch.yaml
@@ -47,17 +47,29 @@ spec:
               export RCLONE_CONFIG_S3_ACCESS_KEY_ID=$LITESTREAM_ACCESS_KEY_ID
               export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=$LITESTREAM_SECRET_ACCESS_KEY
               export RCLONE_CONFIG_S3_ENDPOINT=$LITESTREAM_ENDPOINT
-              sync_s3() { 
-                rclone sync /config s3:$LITESTREAM_BUCKET/config \
+              sync_config() {
+                rclone copy /config s3:$LITESTREAM_BUCKET/config \
                   --exclude ".storage/**" \
                   --exclude "*.db*" \
                   --exclude "*.log" \
                   --exclude "tts/**" \
                   --exclude "tmp_backups/**" \
                   --exclude ".*-litestream" \
-                  --exclude ".*-litestream/**"; 
+                  --exclude ".*-litestream/**";
               }
-              while true; do 
-                sync_s3; 
-                sleep 60; 
+              sync_storage() {
+                rclone copy /config/.storage s3:$LITESTREAM_BUCKET/config/.storage \
+                  --ignore-errors \
+                  --no-traverse \
+                  --ignore-checksum;
+              }
+              STORAGE_COUNTER=0
+              while true; do
+                sync_config;
+                STORAGE_COUNTER=$((STORAGE_COUNTER + 1))
+                if [ $STORAGE_COUNTER -ge 5 ]; then
+                  sync_storage;
+                  STORAGE_COUNTER=0
+                fi
+                sleep 60;
               done


### PR DESCRIPTION
## Summary
- **rclone sync → rclone copy** in prod config-syncer: prevents S3 wipe when PVC appears empty (iSCSI failure)
- **Add .storage/ soft backup** every 5 minutes with `--ignore-errors` to handle file locks gracefully

Addresses post-mortem action item from 2026-02-06 incident (section 4.1).

Beads: `vixens-tblt` (P0)

## Test plan
- [ ] ArgoCD syncs successfully after merge
- [ ] config-syncer pod starts without errors
- [ ] Config files are copied to S3 (check rclone logs)
- [ ] `.storage/` files appear in S3 after ~5 minutes
- [ ] Verify no files are deleted from S3 bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Restructured backup synchronization to separate configuration and storage data into distinct, independently-scheduled operations. Configuration data syncs frequently for continuous updates and protection, while storage data syncs less often with improved error tolerance. This tiered approach reduces resource overhead while ensuring comprehensive backup coverage and system resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->