### PR TITLE
fix: restore rclone sync with Minio versioning protection

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/rclone-patch.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/rclone-patch.yaml
@@ -47,29 +47,13 @@ spec:
               export RCLONE_CONFIG_S3_ACCESS_KEY_ID=$LITESTREAM_ACCESS_KEY_ID
               export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=$LITESTREAM_SECRET_ACCESS_KEY
               export RCLONE_CONFIG_S3_ENDPOINT=$LITESTREAM_ENDPOINT
-              sync_config() {
-                rclone copy /config s3:$LITESTREAM_BUCKET/config \
-                  --exclude ".storage/**" \
+              while true; do
+                rclone sync /config s3:$LITESTREAM_BUCKET/config \
                   --exclude "*.db*" \
                   --exclude "*.log" \
                   --exclude "tts/**" \
                   --exclude "tmp_backups/**" \
                   --exclude ".*-litestream" \
                   --exclude ".*-litestream/**";
-              }
-              sync_storage() {
-                rclone copy /config/.storage s3:$LITESTREAM_BUCKET/config/.storage \
-                  --ignore-errors \
-                  --no-traverse \
-                  --ignore-checksum;
-              }
-              STORAGE_COUNTER=0
-              while true; do
-                sync_config;
-                STORAGE_COUNTER=$((STORAGE_COUNTER + 1))
-                if [ $STORAGE_COUNTER -ge 5 ]; then
-                  sync_storage;
-                  STORAGE_COUNTER=0
-                fi
                 sleep 60;
               done


### PR DESCRIPTION
## Summary
- Restores `rclone sync` (proper mirroring including deletions)
- Includes `.storage/` in sync (previously excluded due to lock concerns)
- Minio bucket versioning enabled with 7-day retention protects against accidental wipes

Supersedes #1345. Beads: `vixens-tblt`

## Test plan
- [ ] ArgoCD syncs successfully
- [ ] config-syncer pod runs without errors
- [ ] `.storage/` files visible in S3
- [ ] Verify Minio versioning retains old versions on overwrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the synchronization architecture by consolidating separate sync operations into a single continuous loop. Storage data is now consistently included in all synchronization cycles. The system executes synchronization every 60 seconds with streamlined configuration, improving overall efficiency and data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->