### PR TITLE
fix: correct Infisical path for velero-repo-credentials

### DIFF
--- a/apps/00-infra/velero/infisical/base/velero-repo-secret.yaml
+++ b/apps/00-infra/velero/infisical/base/velero-repo-secret.yaml
@@ -15,7 +15,7 @@ spec:
       secretsScope:
         projectSlug: vixens
         envSlug: dev
-        secretsPath: /00-infra/velero
+        secretsPath: /apps/00-infra/velero
   managedSecretReference:
     secretName: velero-repo-credentials
     creationPolicy: Owner


### PR DESCRIPTION
## Summary
- Fix InfisicalSecret `secretsPath` from `/00-infra/velero` to `/apps/00-infra/velero`
- This typo caused `velero-repo-credentials` K8s secret to have 0 data (empty)
- Without `repository-password`, Kopia cannot encrypt/init the backup repo → all PodVolumeBackups fail with `error getting repository password`

## Root Cause
The Infisical project stores the secret at path `/apps/00-infra/velero` but the InfisicalSecret resource was configured with `/00-infra/velero` (missing the `apps/` prefix).

## Test plan
- [ ] Verify `velero-repo-credentials` secret in namespace `velero` now has `repository-password` data
- [ ] Run test Velero backup and confirm PodVolumeBackup succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated the credential retrieval path for backup and restore operations to reference the correct secrets location, ensuring proper access to authentication credentials during backup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->