### PR TITLE
fix(music-assistant): correct persistence mount path to /data

### DIFF
--- a/apps/20-media/music-assistant/base/deployment.yaml
+++ b/apps/20-media/music-assistant/base/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               value: Europe/Paris
           volumeMounts:
             - name: config
-              mountPath: /config
+              mountPath: /data
             - name: media
               mountPath: /media
       volumes:


### PR DESCRIPTION
Fixes critical persistence issue where PVC was mounted to /config but application uses /data. Also enables data rescue for migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration storage path for the Music Assistant service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->