### PR TITLE
fix(ingress): add redirect to /mail for synology webmail

### DIFF
--- a/apps/40-network/mail-gateway/base/kustomization.yaml
+++ b/apps/40-network/mail-gateway/base/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - namespace.yaml
   - service.yaml
   - endpoints.yaml
+  - middleware.yaml

--- a/apps/40-network/mail-gateway/base/middleware.yaml
+++ b/apps/40-network/mail-gateway/base/middleware.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-webmail
+  namespace: mail-gateway
+spec:
+  redirectRegex:
+    regex: ^(https?://[^/]+)/?$
+    replacement: ${1}/mail/
+    permanent: false

--- a/apps/40-network/mail-gateway/overlays/dev/ingress.yaml
+++ b/apps/40-network/mail-gateway/overlays/dev/ingress.yaml
@@ -35,6 +35,7 @@ metadata:
     gethomepage.dev/name: Mail Gateway
     gethomepage.dev/icon: roundcube.png
     gethomepage.dev/group: Services
+    traefik.ingress.kubernetes.io/router.middlewares: mail-gateway-redirect-webmail@kubernetescrd
     traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
   ingressClassName: traefik

--- a/apps/40-network/mail-gateway/overlays/prod/ingress.yaml
+++ b/apps/40-network/mail-gateway/overlays/prod/ingress.yaml
@@ -32,6 +32,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.middlewares: mail-gateway-redirect-webmail@kubernetescrd
     traefik.ingress.kubernetes.io/router.tls: "true"
     external-dns.alpha.kubernetes.io/target: truxonline.com
     external-dns.alpha.kubernetes.io/public: "true"


### PR DESCRIPTION
Redirects mail.truxonline.com to /mail path to access MailPlus webmail instead of DSM UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic redirect functionality for mail gateway. Root HTTP(S) requests are now automatically redirected to the `/mail/` path, improving access flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->