### PR TITLE
fix(ingress): disable passHostHeader for mail-gateway

### DIFF
--- a/apps/40-network/mail-gateway/overlays/dev/ingress.yaml
+++ b/apps/40-network/mail-gateway/overlays/dev/ingress.yaml
@@ -36,6 +36,7 @@ metadata:
     gethomepage.dev/icon: roundcube.png
     gethomepage.dev/group: Services
     traefik.ingress.kubernetes.io/router.middlewares: mail-gateway-redirect-webmail@kubernetescrd
+    traefik.ingress.kubernetes.io/service.passhostheader: "false"
     traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
   ingressClassName: traefik

--- a/apps/40-network/mail-gateway/overlays/prod/ingress.yaml
+++ b/apps/40-network/mail-gateway/overlays/prod/ingress.yaml
@@ -36,6 +36,7 @@ metadata:
     traefik.ingress.kubernetes.io/router.tls: "true"
     external-dns.alpha.kubernetes.io/target: truxonline.com
     external-dns.alpha.kubernetes.io/public: "true"
+    traefik.ingress.kubernetes.io/service.passhostheader: "false"
 spec:
   ingressClassName: traefik
   rules:


### PR DESCRIPTION
Synology Nginx returns 404 for /mail/ when Host header is mail.truxonline.com. Disabling passHostHeader allows it to respond correctly by using the backend IP as Host.