### PR TITLE
fix: remove /mail/ redirect for mail-gateway

### DIFF
--- a/apps/40-network/mail-gateway/overlays/prod/ingress.yaml
+++ b/apps/40-network/mail-gateway/overlays/prod/ingress.yaml
@@ -32,7 +32,6 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
-    traefik.ingress.kubernetes.io/router.middlewares: mail-gateway-redirect-webmail@kubernetescrd
     traefik.ingress.kubernetes.io/router.tls: "true"
     external-dns.alpha.kubernetes.io/target: truxonline.com
     external-dns.alpha.kubernetes.io/public: "true"


### PR DESCRIPTION
## Summary
- Remove middleware redirect from mail-gateway ingress
- Synology Application Portal configured for root path `/`, not `/mail/`

## Problem
The middleware was redirecting `mail.truxonline.com` → `mail.truxonline.com/mail/`, but Synology expects requests on root path.

## Test plan
- [ ] Verify `https://mail.truxonline.com` loads Synology webmail directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)