### PR TITLE
fix: restore rclone 1.73

### DIFF
--- a/apps/03-security/authentik/base/deployment-server.yaml
+++ b/apps/03-security/authentik/base/deployment-server.yaml
@@ -34,7 +34,7 @@ spec:
             name: authentik-config
       initContainers:
         - name: restore-config
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -122,7 +122,7 @@ spec:
               memory: 1024Mi
               cpu: 500m
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: config
               mountPath: /config
         - name: restore-config
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -201,7 +201,7 @@ spec:
               cpu: 100m
               memory: 1Gi
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/10-home/homeassistant/overlays/prod/rclone-patch.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/rclone-patch.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: restore-config
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 0
             runAsGroup: 1000
@@ -33,7 +33,7 @@ spec:
                 || true
       containers:
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 0
             runAsGroup: 1000

--- a/apps/10-home/mealie/base/deployment.yaml
+++ b/apps/10-home/mealie/base/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: restore-config
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -140,7 +140,7 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/10-home/mosquitto/base/statefulset.yaml
+++ b/apps/10-home/mosquitto/base/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       initContainers:
         - name: restore-data
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           command:
             - sh
             - -c
@@ -105,7 +105,7 @@ spec:
             timeoutSeconds: 3
             failureThreshold: 3
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           command:
             - sh
             - -c

--- a/apps/20-media/booklore/base/deployment.yaml
+++ b/apps/20-media/booklore/base/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: restore-config
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -88,7 +88,7 @@ spec:
             - name: bookdrop
               mountPath: /bookdrop
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/20-media/frigate/base/deployment.yaml
+++ b/apps/20-media/frigate/base/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: restore-config
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -129,7 +129,7 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/20-media/lazylibrarian/base/deployment.yaml
+++ b/apps/20-media/lazylibrarian/base/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - name: config
               mountPath: /config
         - name: restore-config
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -150,7 +150,7 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/20-media/lidarr/base/deployment.yaml
+++ b/apps/20-media/lidarr/base/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - name: config
               mountPath: /config
         - name: restore-config
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -168,7 +168,7 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/20-media/mylar/base/deployment.yaml
+++ b/apps/20-media/mylar/base/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - name: config
               mountPath: /config
         - name: restore-config
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -163,7 +163,7 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/20-media/prowlarr/base/deployment.yaml
+++ b/apps/20-media/prowlarr/base/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - name: config
               mountPath: /config
         - name: restore-config
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -163,7 +163,7 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/20-media/radarr/base/deployment.yaml
+++ b/apps/20-media/radarr/base/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - name: config
               mountPath: /config
         - name: restore-config
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -146,7 +146,7 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: restore-config
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -119,7 +119,7 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/20-media/sonarr/base/deployment.yaml
+++ b/apps/20-media/sonarr/base/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - name: config
               mountPath: /config
         - name: restore-config
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -178,7 +178,7 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/20-media/whisparr/base/deployment.yaml
+++ b/apps/20-media/whisparr/base/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - name: config
               mountPath: /config
         - name: restore-config
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -135,7 +135,7 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/40-network/adguard-home/base/adguard-ss.yaml
+++ b/apps/40-network/adguard-home/base/adguard-ss.yaml
@@ -28,7 +28,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: restore-config
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 0
             runAsGroup: 0
@@ -143,7 +143,7 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 0
             runAsGroup: 0

--- a/apps/60-services/firefly-iii/base/deployment.yaml
+++ b/apps/60-services/firefly-iii/base/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       initContainers:
         - name: restore-config
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -126,7 +126,7 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 15
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/60-services/vaultwarden/base/deployment.yaml
+++ b/apps/60-services/vaultwarden/base/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - name: data
               mountPath: /data
         - name: restore-config
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -137,7 +137,7 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/70-tools/changedetection/base/deployment.yaml
+++ b/apps/70-tools/changedetection/base/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: restore-config
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           command:
             - sh
             - -c
@@ -103,7 +103,7 @@ spec:
               cpu: 1000m
               memory: 1Gi
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           command:
             - sh
             - -c

--- a/apps/_shared/components/elite-syncer/kustomization.yaml
+++ b/apps/_shared/components/elite-syncer/kustomization.yaml
@@ -27,7 +27,7 @@ patches:
           spec:
             initContainers:
               - name: restore-config
-                image: rclone/rclone:1.65
+                image: rclone/rclone:1.73
                 securityContext:
                   runAsUser: 1000
                   runAsGroup: 1000
@@ -56,7 +56,7 @@ patches:
                     mountPath: /config
             containers:
               - name: config-syncer
-                image: rclone/rclone:1.65
+                image: rclone/rclone:1.73
                 securityContext:
                   runAsUser: 1000
                   runAsGroup: 1000

--- a/apps/template-app/base/deployment.yaml
+++ b/apps/template-app/base/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       initContainers:
         # 1. Optionnel: Restauration des fichiers de config plats
         - name: restore-config
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -148,7 +148,7 @@ spec:
               subPath: litestream.yml
         # 4. Optionnel: Sidecar Config-Syncer
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000


### PR DESCRIPTION
Restores the correct and existing rclone version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image version from 1.65 to 1.73 across all deployed services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->