### PR TITLE
perf: restore burstable limits

### DIFF
--- a/apps/00-infra/traefik/values/prod.yaml
+++ b/apps/00-infra/traefik/values/prod.yaml
@@ -18,13 +18,13 @@ logs:
     level: WARN
   access:
     enabled: true
-# Production-grade resource limits (Emerald - Guaranteed QoS)
+# Production-grade resource limits (Burstable)
 resources:
   requests:
     cpu: 250m
-    memory: 2Gi
+    memory: 256Mi
   limits:
-    cpu: 250m
+    cpu: 2000m
     memory: 2Gi
 # High availability with multiple replicas
 deployment:

--- a/apps/40-network/external-dns-gandi/values/prod.yaml
+++ b/apps/40-network/external-dns-gandi/values/prod.yaml
@@ -36,5 +36,5 @@ resources:
     cpu: 20m
     memory: 64Mi
   limits:
-    cpu: 20m
-    memory: 64Mi
+    cpu: 100m
+    memory: 128Mi

--- a/apps/40-network/external-dns-unifi/values/prod.yaml
+++ b/apps/40-network/external-dns-unifi/values/prod.yaml
@@ -8,5 +8,5 @@ resources:
     cpu: 20m
     memory: 64Mi
   limits:
-    cpu: 20m
-    memory: 64Mi
+    cpu: 100m
+    memory: 128Mi


### PR DESCRIPTION
Fixes error in previous de-escalation where limits were accidentally locked to requests.