### PR TITLE
fix: final emerald stabilization

### DIFF
--- a/apps/40-network/adguard-home/base/adguard-ss.yaml
+++ b/apps/40-network/adguard-home/base/adguard-ss.yaml
@@ -28,7 +28,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: restore-config
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 0
             runAsGroup: 0
@@ -143,7 +143,7 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: config-syncer
-          image: rclone/rclone:1.65
+          image: rclone/rclone:1.73
           securityContext:
             runAsUser: 0
             runAsGroup: 0


### PR DESCRIPTION
Consolidated fix for rclone 1.73, Velero backup namespaces, and burstable resource limits.