### PR TITLE
fix(argocd): add helm chart reference for kustomize overlay

### DIFF
--- a/apps/00-infra/argocd/base/kustomization.yaml
+++ b/apps/00-infra/argocd/base/kustomization.yaml
@@ -4,4 +4,13 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - argocd-install.yaml
+
+helmCharts:
+  - name: argo-cd
+    repo: https://argoproj.github.io/argo-helm
+    version: 7.7.7
+    releaseName: argocd
+    namespace: argocd
+    includeCRDs: false
+
 patches:

--- a/apps/00-infra/argocd/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/argocd/overlays/prod/kustomization.yaml
@@ -11,4 +11,10 @@ components:
 
 patches:
   - path: patches/redis-resources.yaml
+    target:
+      kind: Deployment
+      name: argocd-redis
   - path: patches/redis-probes.yaml
+    target:
+      kind: Deployment
+      name: argocd-redis


### PR DESCRIPTION
## 🔧 Fix: Enable Kustomize Overlay on Helm-deployed ArgoCD

### Problem
ArgoCD is deployed via Terraform/Helm (terravixens), but we want to override configuration via GitOps (vixens) without modifying terravixens.

Kustomize patches were failing with:
```
no resource matches strategic merge patch "Deployment.v1.apps/argocd-redis.argocd"
```

### Solution
Add `helmCharts` reference in base kustomization to generate manifests from Helm chart, enabling overlay patches to work.

### Changes
- `apps/00-infra/argocd/base/kustomization.yaml`: Add helmCharts reference to argo-cd 7.7.7
- `apps/00-infra/argocd/overlays/prod/kustomization.yaml`: Add target selectors to patches

### Impact
- Enables GitOps-based configuration override
- No changes to terravixens required
- Patches can now be applied on top of Helm deployment

### Related
- PR #1370 (Phase 1 Lot 1.1 - redis resources/probes)
- Task: vixens-gi2 (ArgoCD goldification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Argo CD deployment configuration via Helm (version 7.7.7) to the base infrastructure setup
  * Refined production environment patches to apply more precisely to specific components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->