### PR TITLE
chore(dev): finalize dashboard health

### DIFF
--- a/argocd/overlays/dev/kustomization.yaml
+++ b/argocd/overlays/dev/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
   - apps/cilium-lb.yaml
   - apps/traefik.yaml
   - apps/traefik-middlewares.yaml
-  - apps/metrics-server.yaml
+  # - apps/metrics-server.yaml
   - apps/vpa.yaml
   - apps/goldilocks.yaml                        # Traefik Ingress Controller
   - apps/reloader.yaml
@@ -71,11 +71,11 @@ resources:
   - apps/changedetection.yaml
   - apps/adguard-home.yaml
   - apps/netbird.yaml
-  - apps/netvisor.yaml
+  # - apps/netvisor.yaml
   - apps/authentik.yaml
   - apps/netbox.yaml
   - apps/loki.yaml
-  - apps/promtail.yaml
+  # - apps/promtail.yaml
   - apps/renovate.yaml
   - apps/stirling-pdf.yaml
   # - apps/stirling-pdf-ingress.yaml


### PR DESCRIPTION
Cleanup of metrics-server, netvisor, and promtail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled metrics-server, netvisor, and promtail components in the development environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->