### PR TITLE
fix(homeassistant): correct Python packages path

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -68,13 +68,14 @@ spec:
               # Format: package==version
               PACKAGES="hass-web-proxy-lib==0.0.7"
               
-              pip install --no-cache-dir --target=/usr/local/lib/python3.13/site-packages $PACKAGES
+              # Install to separate directory to avoid overwriting HA packages
+              pip install --no-cache-dir --target=/opt/python-packages $PACKAGES
               
               echo "Installed packages:"
-              ls -la /usr/local/lib/python3.13/site-packages/ | grep -E "hass-web-proxy|dist-info" || echo "No packages found"
+              ls -la /opt/python-packages/ | grep -E "hass-web-proxy|dist-info" || echo "No packages found"
           volumeMounts:
             - name: python-site-packages
-              mountPath: /usr/local/lib/python3.13/site-packages
+              mountPath: /opt/python-packages
           resources:
             requests:
               cpu: 50m
@@ -170,6 +171,8 @@ spec:
           env:
             - name: TZ
               value: Europe/Paris
+            - name: PYTHONPATH
+              value: /opt/python-packages:/usr/local/lib/python3.13/site-packages
           livenessProbe:
             httpGet:
               path: /
@@ -193,7 +196,7 @@ spec:
             - name: config
               mountPath: /config
             - name: python-site-packages
-              mountPath: /usr/local/lib/python3.13/site-packages
+              mountPath: /opt/python-packages
         - name: litestream
           image: litestream/litestream:0.5.7
           securityContext:


### PR DESCRIPTION
## Problem
Previous fix mounted volume on /usr/local/lib/python3.13/site-packages which overwrote HA's own packages, causing CrashLoopBackOff with error: `No module named homeassistant`

## Solution
- Install packages to /opt/python-packages instead
- Add /opt/python-packages to PYTHONPATH
- Preserve existing site-packages from HA image

## Changes
- Changed target directory from site-packages to /opt/python-packages
- Added PYTHONPATH env var to include both paths
- Fixed volume mount path

Fixes: CrashLoopBackOff caused by missing homeassistant module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal Python package installation configuration to improve dependency management and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->