### PR TITLE
fix(renovate): correct JSON syntax in prBodyTemplate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -161,25 +161,5 @@
   "commitMessageAction": "update",
   "commitMessageTopic": "{{depName}}",
   "commitMessageExtra": "to {{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}",
-  "prBodyTemplate": "{{{header}}}
-
-{{{table}}}
-
-{{{notes}}}
-
-{{{changelogs}}}
-
----
-
-### 🚀 Deployment Strategy
-
-{{#if isMajor}}⚠️ **Major update** - Manual review required{{else}}✅ **Auto-merge enabled** - Will merge automatically after approval{{/if}}
-
-- [ ] Reviewed changes
-- [ ] Ready to deploy to main branch (dev cluster)
-- [ ] Notify on Discord: `@everyone New dependency update ready for approval`
-
----
-
-{{{footer}}}"
+  "prBodyTemplate": "{{{header}}}\n\n{{{table}}}\n\n{{{notes}}}\n\n{{{changelogs}}}\n\n---\n\n### 🚀 Deployment Strategy\n\n{{#if isMajor}}⚠️ **Major update** - Manual review required{{else}}✅ **Auto-merge enabled** - Will merge automatically after approval{{/if}}\n\n- [ ] Reviewed changes\n- [ ] Ready to deploy to main branch (dev cluster)\n- [ ] Notify on Discord: `@everyone New dependency update ready for approval`\n\n---\n\n{{{footer}}}"
 }


### PR DESCRIPTION
Fix invalid control characters in prBodyTemplate field that caused Renovate configuration parsing error.

## Problem
The \prBodyTemplate\ field contained literal newlines (control characters U+0000 through U+001F) instead of escaped \\n sequences, causing JSON parsing to fail.

## Solution
- Convert literal newlines to escaped \\n in template string
- Validate JSON with jq

## Changes
- renovat.json: Fixed template formatting

Fixes #1308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration file formatting for consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->