### PR TITLE
feat(booklore): add health probes to mariadb

### DIFF
--- a/apps/20-media/booklore/base/mariadb-deployment.yaml
+++ b/apps/20-media/booklore/base/mariadb-deployment.yaml
@@ -51,6 +51,20 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /config
+          readinessProbe:
+            exec:
+              command: ["mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          livenessProbe:
+            exec:
+              command: ["mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
         - name: db-backup
           image: alpine:3.23
           command:


### PR DESCRIPTION
## Summary

Add Liveness and Readiness probes to MariaDB deployment to prevent Booklore crash loops and ensure database availability.

## Problem

Booklore crashes with `Connection refused` on startup because it attempts to connect before MariaDB is fully initialized.
Kyverno also reports policy violations due to missing probes.

## Solution

Add `readinessProbe` and `livenessProbe` using `mysqladmin ping`.
- **Readiness**: Ensures Service only routes traffic when DB is answering queries.
- **Liveness**: Restarts pod if DB freezes.

## Testing

- [ ] Verify pod becomes Ready only after MySQL is up
- [ ] Verify Booklore waits (or retries) until DB is ready instead of failing hard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced MariaDB health monitoring with readiness and liveness checks to automatically detect and respond to database health issues, improving overall system reliability.
  * Fixed database backup connectivity to ensure proper backup operation in the deployment environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->