### PR TITLE
fix(docspell): set prod URL and Ingress

### DIFF
--- a/apps/60-services/docspell/overlays/prod/kustomization.yaml
+++ b/apps/60-services/docspell/overlays/prod/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+components:
+  - ../../../../_shared/components/revision-history-limit
+kind: Kustomization
+namespace: services
+resources:
+  - ../../base

--- a/apps/60-services/docspell/overlays/prod/values.yaml
+++ b/apps/60-services/docspell/overlays/prod/values.yaml
@@ -1,0 +1,35 @@
+---
+restserver:
+  ingress:
+    enabled: true
+    className: traefik
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
+      traefik.ingress.kubernetes.io/router.middlewares: services-docspell-http-redirect@kubernetescrd
+    host: docspell.truxonline.com
+    tlsSecretName: docspell-tls-prod
+  appName: Docspell
+  bindPort: 7880
+  publicDomain: docspell.truxonline.com
+  serverSecret: docspell-secrets # Name of the Kubernetes Secret containing the server secret
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+joex:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+jdbc:
+  host: postgresql-shared-rw.databases.svc.cluster.local # Shared PostgreSQL cluster (read-write service)
+  port: 5432
+  database: docspell
+  credentialsSecretName: docspell-db-credentials # Synced from databases namespace


### PR DESCRIPTION
## Summary

Fix Docspell configuration in PROD to use the correct domain `docspell.truxonline.com`.

## Problem

Docspell was using the DEV overlay configuration in PROD:
- `base-url = https://docspell.dev.truxonline.com`
- `Ingress host = docspell.dev.truxonline.com`
- `LetsEncrypt staging` issuer

This caused CORS errors and inability to register/login because the frontend (on PROD URL) was calling an API configured for DEV URL.
Additionally, the DEV overlay had a patch setting `replicas: 0`, which was removed for PROD.

## Solution

Created a dedicated `overlays/prod` configuration:
- Host: `docspell.truxonline.com`
- Issuer: `letsencrypt-prod`
- TLS Secret: `docspell-tls-prod`
- Removed scaling down patch

## Testing

- [ ] Verify Ingress points to `docspell.truxonline.com`
- [ ] Verify registration works without CORS errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added production configuration for Docspell service deployment
  * Configured ingress routing, TLS security, database connections, and resource allocation for production environment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->