### PR TITLE
fix(docspell-native): patch ConfigMap for prod URL

### DIFF
--- a/apps/60-services/docspell-native/overlays/prod/kustomization.yaml
+++ b/apps/60-services/docspell-native/overlays/prod/kustomization.yaml
@@ -9,6 +9,7 @@ patches:
   - path: patch-infisical-secrets.yaml
 patchesStrategicMerge:
   - patch-resources.yaml
+  - patch-configmap.yaml
 resources:
   - ../../base
   - ingress.yaml

--- a/apps/60-services/docspell-native/overlays/prod/patch-configmap.yaml
+++ b/apps/60-services/docspell-native/overlays/prod/patch-configmap.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: docspell-restserver-config
+data:
+  config: |
+    docspell.server {
+      app-name = "Docspell"
+      app-id = ${HOSTNAME}
+      base-url = "https://docspell.truxonline.com"
+      internal-url = "http://docspell-restserver:7880"
+
+      logging {
+        minimum-level = "Info"
+
+        levels = {
+          "docspell" = "Info"
+        }
+      }
+
+      bind {
+        address = "0.0.0.0"
+        port = 7880
+      }
+
+      integration-endpoint {
+        enabled = false
+      }
+
+      full-text-search {
+        enabled = true
+        backend = "postgresql"
+
+        postgresql = {
+          use-default-connection = true
+        }
+      }
+
+      auth {
+        server-secret = "docspell-secrets"
+      }
+
+      backend {
+        jdbc {
+          url = ${JDBC_URI}
+          user = ${JDBC_USERNAME}
+          password = ${JDBC_PASSWORD}
+        }
+
+        signup {
+          mode = "open"
+        }
+
+        files {
+        }
+      }
+    }


### PR DESCRIPTION
## Summary

Fix CORS errors by patching the ConfigMap to use correct prod base-url.

## Solution

Add patch-configmap.yaml in overlays/prod to override base-url to https://docspell.truxonline.com

## Testing

- [ ] Verify registration works without CORS errors