### PR TITLE
fix(argocd): fix docspell references

### DIFF
--- a/argocd/overlays/dev/kustomization.yaml
+++ b/argocd/overlays/dev/kustomization.yaml
@@ -66,8 +66,7 @@ resources:
   - apps/cloudnative-pg.yaml # CloudNativePG Operator (databases)
   - apps/redis-shared.yaml
   - apps/postgresql-shared.yaml # Shared PostgreSQL Cluster (Docspell, ...)
-  - apps/docspell.yaml # OLD Helm-based (deprecated, use docspell-native)
-  - apps/docspell-native.yaml
+  - apps/docspell.yaml
   - apps/changedetection.yaml
   - apps/adguard-home.yaml
   - apps/netbird.yaml

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -66,7 +66,7 @@ resources:
   - apps/cloudnative-pg.yaml
   - apps/redis-shared.yaml
   - apps/postgresql-shared.yaml
-  - apps/docspell-native.yaml
+  - apps/docspell.yaml
   - apps/changedetection.yaml
   - apps/adguard-home.yaml
   - apps/netbird.yaml


### PR DESCRIPTION
Fix kustomization references after renaming docspell-native to docspell.

- Prod: remove old docspell-native.yaml reference
- Dev: use new docspell.yaml (was docspell-native)