### PR TITLE
fix(openclaw): bind gateway to 0.0.0.0

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -86,6 +86,8 @@ spec:
               value: discord,github,telegram
             - name: OPENCLAW_LOG_LEVEL
               value: info
+            - name: OPENCLAW_HOST
+              value: 0.0.0.0
           livenessProbe:
             tcpSocket:
               port: 18789


### PR DESCRIPTION
L'agent n'écoutait que sur 127.0.0.1, bloquant l'accès via Ingress. Passage à 0.0.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service configuration to enhance network interface accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->