### PR TITLE
fix(openclaw): set gateway bind to lan

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -85,6 +85,8 @@ spec:
             - name: OPENCLAW_PLUGINS
               value: discord,github,telegram
             - name: OPENCLAW_LOG_LEVEL
+            - name: OPENCLAW_GATEWAY_BIND
+              value: lan
               value: info
             - name: OPENCLAW_HOST
               value: 0.0.0.0


### PR DESCRIPTION
Pour permettre l'accès Ingress depuis Traefik, passer OPENCLAW_GATEWAY_BIND à 'lan' au lieu de loopback.