### PR TITLE
fix(openclaw): corrected deployment config

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -85,11 +85,9 @@ spec:
             - name: OPENCLAW_PLUGINS
               value: discord,github,telegram
             - name: OPENCLAW_LOG_LEVEL
+              value: info
             - name: OPENCLAW_GATEWAY_BIND
               value: lan
-              value: info
-            - name: OPENCLAW_HOST
-              value: 0.0.0.0
           livenessProbe:
             tcpSocket:
               port: 18789


### PR DESCRIPTION
Correction de la syntaxe YAML (doublon de OPENCLAW_LOG_LEVEL) et forçage du bind gateway sur 'lan' pour l'Ingress.