### PR TITLE
fix(openclaw): align config mount naming

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -158,6 +158,9 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+            - name: config
+              mountPath: /data/openclaw.json
+              subPath: openclaw.json
       volumes:
         - name: data
           persistentVolumeClaim:


### PR DESCRIPTION
Correction de l'erreur de montage ConfigMap (subPath vs path mismatch) empêchant le démarrage du conteneur.