### PR TITLE
fix(openclaw): REALLY restore bind command

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -74,6 +74,13 @@ spec:
         - name: openclaw
           image: ghcr.io/openclaw/openclaw:latest
           imagePullPolicy: Always
+          command:
+            - node
+            - /app/openclaw.mjs
+            - gateway
+            - start
+            - --bind
+            - lan
           ports:
             - containerPort: 18789
               name: http
@@ -86,8 +93,6 @@ spec:
               value: discord,github,telegram
             - name: OPENCLAW_LOG_LEVEL
               value: info
-            - name: OPENCLAW_GATEWAY_BIND
-              value: lan
           livenessProbe:
             tcpSocket:
               port: 18789
@@ -158,9 +163,6 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
-            - name: config
-              mountPath: /data/openclaw.json
-              subPath: openclaw.json
       volumes:
         - name: data
           persistentVolumeClaim:


### PR DESCRIPTION
Restauration de la commande explicite avec --bind lan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated openclaw container deployment configuration to specify the gateway startup command directly with LAN binding.
  * Simplified configuration management by removing environment variables and config volume mounts from openclaw and data-syncer containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->