### PR TITLE
fix(openclaw): correct gateway run command

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -78,9 +78,9 @@ spec:
             - node
             - /app/openclaw.mjs
             - gateway
-            - start
             - --bind
             - lan
+            - run
           ports:
             - containerPort: 18789
               name: http


### PR DESCRIPTION
Utilisation de 'gateway --bind lan run' pour forcer l'écoute sur 0.0.0.0.