### PR TITLE
fix(openclaw): use explicit start command

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -78,9 +78,10 @@ spec:
             - node
             - /app/openclaw.mjs
             - gateway
+            - start
             - --bind
             - lan
-            - run
+            - --allow-unconfigured
           ports:
             - containerPort: 18789
               name: http
@@ -163,6 +164,9 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+            - name: config
+              mountPath: /data/openclaw.json
+              subPath: openclaw.json
       volumes:
         - name: data
           persistentVolumeClaim:


### PR DESCRIPTION
Forcer l'écoute sur 0.0.0.0 via la commande explicite du conteneur.