### PR TITLE
fix(openclaw): use gateway run mode

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -78,10 +78,9 @@ spec:
             - node
             - /app/openclaw.mjs
             - gateway
-            - start
             - --bind
             - lan
-            - --allow-unconfigured
+            - run
           ports:
             - containerPort: 18789
               name: http
@@ -164,9 +163,6 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
-            - name: config
-              mountPath: /data/openclaw.json
-              subPath: openclaw.json
       volumes:
         - name: data
           persistentVolumeClaim:


### PR DESCRIPTION
Le mode 'start' tente d'utiliser systemd, ce qui échoue en container. Passage en mode 'run'.