### PR TITLE
fix(openclaw): container startup configuration

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -81,6 +81,7 @@ spec:
             - --bind
             - lan
             - run
+            - --allow-unconfigured
           ports:
             - containerPort: 18789
               name: http
@@ -93,6 +94,8 @@ spec:
               value: discord,github,telegram
             - name: OPENCLAW_LOG_LEVEL
               value: info
+            - name: OPENCLAW_GATEWAY_MODE
+              value: local
           livenessProbe:
             tcpSocket:
               port: 18789


### PR DESCRIPTION
Forcer le mode 'run' avec '--allow-unconfigured' et 'OPENCLAW_GATEWAY_MODE=local' pour le déploiement Kubernetes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gateway service now supports unconfigured operation mode
  * Gateway configured to operate in local mode

* **Chores**
  * Updated openclaw service deployment configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->