### PR TITLE
fix(openclaw): add ConfigMap with gateway config

### DIFF
--- a/apps/60-services/openclaw/base/configmap.yaml
+++ b/apps/60-services/openclaw/base/configmap.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-config
+  namespace: services
+data:
+  openclaw.json: |
+    {
+      "gateway": {
+        "mode": "local"
+      },
+      "agent": {
+        "model": "anthropic/claude-opus-4-6"
+      }
+    }

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -74,14 +74,6 @@ spec:
         - name: openclaw
           image: ghcr.io/openclaw/openclaw:latest
           imagePullPolicy: Always
-          command:
-            - node
-            - /app/openclaw.mjs
-            - gateway
-            - --bind
-            - lan
-            - run
-            - --allow-unconfigured
           ports:
             - containerPort: 18789
               name: http
@@ -112,7 +104,7 @@ spec:
             - name: data
               mountPath: /data
             - name: config
-              mountPath: /data/openclaw.json
+              mountPath: /home/node/.openclaw/openclaw.json
               subPath: openclaw.json
         - name: data-syncer
           image: rclone/rclone:1.73

--- a/apps/60-services/openclaw/base/kustomization.yaml
+++ b/apps/60-services/openclaw/base/kustomization.yaml
@@ -6,8 +6,4 @@ resources:
   - service.yaml
   - pvc.yaml
   - infisical-secret.yaml
-
-configMapGenerator:
-  - name: openclaw-config
-    literals:
-      - openclaw.json={"gateway":{"bind":"lan"}}
+  - configmap.yaml


### PR DESCRIPTION
Add ConfigMap with gateway.mode=local so OpenClaw can start without initial setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized openclaw service configuration management by externalizing settings to a dedicated ConfigMap manifest.
  * Streamlined deployment configuration with updated mount paths and simplified startup sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->