### PR TITLE
fix(openclaw): add bind 0.0.0.0 to gateway config

### DIFF
--- a/apps/60-services/openclaw/base/configmap.yaml
+++ b/apps/60-services/openclaw/base/configmap.yaml
@@ -8,7 +8,8 @@ data:
   openclaw.json: |
     {
       "gateway": {
-        "mode": "local"
+        "mode": "local",
+        "bind": "0.0.0.0"
       },
       "agents": {
         "defaults": {


### PR DESCRIPTION
## Résumé

Le problème était que OpenClaw écoutait sur `127.0.0.1` même avec `--bind 0.0.0.0` en argument CLI.

## Solution

Ajout de `"bind": "0.0.0.0"` dans la configuration `gateway` du ConfigMap.

## Tests

- [ ] Vérifier que le pod écoute sur 0.0.0.0:18789
- [ ] Tester la connectivité via Traefik