### PR TITLE
fix(openclaw): use lan bind instead of 0.0.0.0

### DIFF
--- a/apps/60-services/openclaw/base/configmap.yaml
+++ b/apps/60-services/openclaw/base/configmap.yaml
@@ -9,7 +9,7 @@ data:
     {
       "gateway": {
         "mode": "local",
-        "bind": "0.0.0.0"
+        "bind": "lan"
       },
       "agents": {
         "defaults": {


### PR DESCRIPTION
## Résumé

Le bind "0.0.0.0" n'est pas valide. Utilisation de "lan" à la place.

## Tests

- [ ] Vérifier que le pod démarre correctement
- [ ] Vérifier que le pod écoute sur 0.0.0.0:18789
- [ ] Tester la connectivité via Traefik