### PR TITLE
fix(birdnet-go): use litestream credentials for bucket

### DIFF
--- a/apps/20-media/birdnet-go/base/deployment.yaml
+++ b/apps/20-media/birdnet-go/base/deployment.yaml
@@ -98,7 +98,7 @@ spec:
               export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=$LITESTREAM_SECRET_ACCESS_KEY
               export RCLONE_CONFIG_S3_ENDPOINT=$LITESTREAM_ENDPOINT
               sync_s3() {
-                rclone sync /data s3:vixens-prod-birdnet-go --exclude "lost+found/**" --exclude "*.tmp"
+                rclone sync /data s3:backups-vixens-birdnet-go --exclude "lost+found/**" --exclude "*.tmp"
               }
               while true; do
                 sync_s3;

--- a/apps/20-media/birdnet-go/base/infisical-secret.yaml
+++ b/apps/20-media/birdnet-go/base/infisical-secret.yaml
@@ -9,4 +9,4 @@ stringData:
   LITESTREAM_ACCESS_KEY_ID: litestream
   LITESTREAM_SECRET_ACCESS_KEY: rn?K:p?LHRb82PF
   LITESTREAM_ENDPOINT: http://synelia.internal.truxonline.com:9000
-  LITESTREAM_BUCKET: vixens-prod-birdnet-go
+  LITESTREAM_BUCKET: backups-vixens-birdnet-go


### PR DESCRIPTION
## Résumé

Utilisation des credentials litestream existants qui ont déjà accès au bucket backups-vixens.

## Changes

- Bucket créé: `vixens-prod-birdnet-go`
- Utilisation des credentials litestream pour le backup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for secret management, transitioning to direct Kubernetes secrets.
  * Modified S3 backup synchronization target for media data storage.
  * Streamlined infrastructure configuration for improved service deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->