### PR TITLE
fix(openclaw): add configmap and OPENCLAW_GATEWAY_TOKEN reference

### DIFF
--- a/apps/60-services/openclaw/base/configmap.yaml
+++ b/apps/60-services/openclaw/base/configmap.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-config
+  namespace: services
+data:
+  openclaw.json: |
+    {
+      "identity": {
+        "name": "Clawd",
+        "emoji": "🦞"
+      },
+      "gateway": {
+        "mode": "local",
+        "bind": "lan",
+        "port": 18789
+      },
+      "agent": {
+        "model": {
+          "primary": "anthropic/claude-sonnet-4-5"
+        }
+      },
+      "logging": {
+        "level": "info"
+      }
+    }

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -88,7 +88,7 @@ spec:
           env:
             - name: TZ
               value: Europe/Paris
-            - name: OPENCLAW_DATA_DIR
+            - name: OPENCLAW_HOME
               value: /data
             - name: OPENCLAW_PLUGINS
               value: discord,github,telegram
@@ -96,6 +96,11 @@ spec:
               value: info
             - name: OPENCLAW_GATEWAY_MODE
               value: local
+            - name: OPENCLAW_GATEWAY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw-secrets
+                  key: OPENCLAW_GATEWAY_TOKEN
           livenessProbe:
             tcpSocket:
               port: 18789

--- a/apps/60-services/openclaw/base/infisical-secret.yaml
+++ b/apps/60-services/openclaw/base/infisical-secret.yaml
@@ -14,7 +14,7 @@ spec:
         secretNamespace: argocd
       secretsScope:
         projectSlug: vixens
-        envSlug: dev
+        envSlug: prod
         secretsPath: /apps/60-services/openclaw
   managedSecretReference:
     secretName: openclaw-secrets

--- a/apps/60-services/openclaw/base/kustomization.yaml
+++ b/apps/60-services/openclaw/base/kustomization.yaml
@@ -6,8 +6,4 @@ resources:
   - service.yaml
   - pvc.yaml
   - infisical-secret.yaml
-
-configMapGenerator:
-  - name: openclaw-config
-    literals:
-      - openclaw.json={"gateway":{"bind":"lan"}}
+  - configmap.yaml


### PR DESCRIPTION
## Résumé

Corrections de la configuration OpenClaw pour le mode gateway lan.

## Changes

- Ajout ConfigMap `openclaw-config` avec configuration de base
- Ajout `OPENCLAW_HOME=/data` pour le chemin de config
- Ajout référence `OPENCLAW_GATEWAY_TOKEN` depuis Infisical
- Correction `envSlug: prod` dans InfisicalSecret

## Infisical

Secret `OPENCLAW_GATEWAY_TOKEN` ajouté dans `/apps/60-services/openclaw` (prod)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated OpenClaw service configuration structure and reorganized deployment settings
  * Migrated service environment configuration from development to production
  * Enhanced security with secret-based token management for service gateway authentication
  * Refactored configuration management for improved maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->