### PR TITLE
fix(openclaw): add trustedProxies for Traefik

### DIFF
--- a/apps/60-services/openclaw/base/configmap.yaml
+++ b/apps/60-services/openclaw/base/configmap.yaml
@@ -14,7 +14,8 @@ data:
       "gateway": {
         "mode": "local",
         "bind": "lan",
-        "port": 18789
+        "port": 18789,
+        "trustedProxies": ["10.244.0.0/16", "10.100.0.0/16"]
       },
       "agent": {
         "model": {


### PR DESCRIPTION
## Résumé

Ajout de `trustedProxies` dans la config gateway pour que OpenClaw reconnaisse les connexions venant de Traefik.

## Problème

Les logs montraient :
```
Proxy headers detected from untrusted address. Connection will not be treated as local.
```

Cela empêchait l'authentification automatique des clients via le reverse proxy.

## Solution

Ajout des ranges IP des pods Traefik dans `trustedProxies`:
- `10.244.0.0/16` - Pod network
- `10.100.0.0/16` - Service network

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated gateway configuration to include trusted proxy CIDR entries. This enhances network traffic handling and security by specifying which proxies are trusted for forwarding requests through the gateway.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->