### PR TITLE
fix(openclaw): add auth token config for device pairing

### DIFF
--- a/apps/60-services/openclaw/base/configmap.yaml
+++ b/apps/60-services/openclaw/base/configmap.yaml
@@ -27,7 +27,11 @@ data:
         "mode": "local",
         "bind": "lan",
         "port": 18789,
-        "trustedProxies": ["10.244.0.0/16", "10.100.0.0/16"]
+        "trustedProxies": ["10.244.0.0/16", "10.100.0.0/16"],
+        "auth": {
+          "mode": "token",
+          "token": "5786a33352b9429b7f377db59d85ed062284704de747e91655c75cbb970ffff8"
+        }
       },
       "logging": {
         "level": "info"


### PR DESCRIPTION
## Résumé

Ajout de la configuration `gateway.auth` avec le token pour permettre l'authentification et le device pairing.

## Problème

Même avec `OPENCLAW_GATEWAY_TOKEN` en env var, les connexions WebSocket étaient rejetées avec "pairing required".

## Solution

Ajout explicite de `gateway.auth.mode: "token"` et `gateway.auth.token` dans la config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service configuration with restructured agent setup and explicit model defaults.
  * Configured token-based authentication for gateway access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->