### PR TITLE
docs(openclaw): add deployment documentation

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -136,6 +136,7 @@ Last Updated: 2026-02-05 (Stabilization Milestone v3.1.536)
 | docspell-native | ✅ | ✅ | Fixed missing secretNamespace |
 | gluetun | ✅ | ✅ | Fixed missing secretNamespace |
 | firefly-iii | ✅ | ✅ | Elite Status + VPA + Security Hardened |
+| openclaw | ✅ | ✅ | AI Agent - open access (TODO: Authentik) |
 
 ---
 

--- a/docs/applications/60-services/openclaw.md
+++ b/docs/applications/60-services/openclaw.md
@@ -1,0 +1,41 @@
+# OpenClaw
+
+## Deployment Information
+| Environment | Deployed | Configured | Tested | Version |
+|-------------|----------|-----------|-------|---------|
+| Dev         | [x]      | [x]       | [x]   | latest  |
+| Prod        | [x]      | [x]       | [x]   | latest  |
+
+## Validation
+**URL:** https://openclaw.truxonline.com
+
+### Automatic Validation (CLI)
+```bash
+# Check pod status
+kubectl --kubeconfig=.secrets/prod/kubeconfig-prod get pods -n services -l app=openclaw
+
+# Check ingress
+kubectl --kubeconfig=.secrets/prod/kubeconfig-prod get ingress -n services openclaw-ingress
+
+# Test connectivity
+curl https://openclaw.truxonline.com/
+```
+
+### Manual Validation
+1. Open URL in browser.
+2. Verify the OpenClaw UI loads correctly.
+
+## Technical Notes
+- **Namespace:** services
+- **Category:** 60-services
+- **Dependencies:**
+    - MinIO (S3 backup)
+    - Infisical (secrets management)
+- **Specifics:**
+    - Gateway mode: local
+    - Binding: lan
+    - Control UI: allowInsecureAuth enabled (open access)
+    - Data persisted to PVC and synced to MinIO
+- **Security Note:**
+    - Currently open access (no authentication)
+    - TODO: Add Authentik middleware via Traefik


### PR DESCRIPTION
## Résumé

Ajout de la documentation de déploiement pour OpenClaw.

## Changes

- Création de `docs/applications/60-services/openclaw.md`
- Mise à jour de `docs/STATUS.md`

## Notes

- OpenClaw est actuellement en accès ouvert (allowInsecureAuth)
- TODO: Ajouter Authentik pour sécuriser l'accès

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new OpenClaw service documentation with deployment status for Dev and Prod environments, validation procedures (CLI and manual), technical configuration details, and security information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->