### PR TITLE
fix(openclaw): remove invalid TLS options annotation

### DIFF
--- a/apps/60-services/openclaw/overlays/prod/ingress.yaml
+++ b/apps/60-services/openclaw/overlays/prod/ingress.yaml
@@ -7,7 +7,6 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
-    traefik.ingress.kubernetes.io/router.tls.options: default@kubernetescrd
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: OpenClaw
     gethomepage.dev/icon: openclaw.svg


### PR DESCRIPTION
Remove traefik.ingress.kubernetes.io/router.tls.options annotation that references non-existent TLS options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TLS configuration for production ingress settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->