### PR TITLE
fix(openclaw): run plugin install as root

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -97,8 +97,8 @@ spec:
         - name: install-gemini-plugin
           image: node:22-bookworm
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
+            runAsUser: 0
+            runAsGroup: 0
           command:
             - sh
             - -c


### PR DESCRIPTION
Run install-gemini-plugin init container as root to avoid npm EACCES permission denied error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to adjust container privilege levels during the installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->