### PR TITLE
fix(openclaw): remove sed that breaks JSON

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -82,14 +82,6 @@ spec:
             - |
               echo "Applying Layer 2 config from Infisical..."
               cp /tmp/config/openclaw.json /data/openclaw.json
-              # Fix unsupported config keys
-              sed -i 's/"controlUi":.*,//g' /data/openclaw.json
-              # Ensure token auth mode uses env var token
-              sed -i 's/"mode": "password"/"mode": "token"/g' /data/openclaw.json
-              # Add trustedProxies if not present
-              if ! grep -q "trustedProxies" /data/openclaw.json; then
-                sed -i 's/"gateway": {/"gateway": {"trustedProxies": ["10.244.0.0\/16", "192.168.0.0\/16"],/' /data/openclaw.json
-              fi
               chown 1000:1000 /data/openclaw.json
               echo "Config applied successfully"
           volumeMounts:


### PR DESCRIPTION
Remove sed commands that were corrupting the JSON config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automatic configuration post-processing from the deployment layer. Configuration files now require manual adjustments where automatic transformations were previously applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->