### PR TITLE
feat(openclaw): add NodePort service

### DIFF
--- a/apps/60-services/openclaw/base/service.yaml
+++ b/apps/60-services/openclaw/base/service.yaml
@@ -7,9 +7,12 @@ metadata:
   labels:
     app: openclaw
 spec:
+  type: NodePort
   ports:
     - port: 18789
-      targetPort: http
+      targetPort: 18789
+      nodePort: 18789
+      protocol: TCP
       name: http
   selector:
     app: openclaw


### PR DESCRIPTION
Change service to NodePort for direct access without reverse proxy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenClaw service is now accessible externally via NodePort on dedicated port 18789 with explicit TCP protocol configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->