### PR TITLE
fix(openclaw): download infisical and himalaya from correct repos

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -123,13 +123,17 @@ spec:
               curl -sSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /data/tools/bin/mc
               chmod +x /data/tools/bin/mc
               
-              # infisical CLI - download directly
-              curl -sSL -o /data/tools/bin/infisical "https://github.com/Infisical/infisical/releases/download/cli-v0.25.0/infisical-linux-amd64"
-              chmod +x /data/tools/bin/infisical 2>/dev/null || true
+              # infisical CLI - download tar.gz and extract
+              curl -sSL "https://github.com/Infisical/cli/releases/download/v0.43.57/cli_0.43.57_linux_amd64.tar.gz" -o /tmp/infisical.tar.gz
+              tar -xzf /tmp/infisical.tar.gz -C /data/tools/bin/ infisical
+              chmod +x /data/tools/bin/infisical
+              rm /tmp/infisical.tar.gz
               
-              # himalaya email CLI - download directly
-              curl -sSL -o /data/tools/bin/himalaya "https://github.com/pimalaya/himalaya/releases/download/v1.2.0/himalaya-linux-x86_64"
-              chmod +x /data/tools/bin/himalaya 2>/dev/null || true
+              # himalaya email CLI - download binary directly
+              curl -sSL "https://github.com/pimalaya/himalaya/releases/download/v1.2.0/himalaya-linux-x86_64.tar.gz" -o /tmp/himalaya.tar.gz
+              tar -xzf /tmp/himalaya.tar.gz -C /data/tools/bin/ himalaya
+              chmod +x /data/tools/bin/himalaya
+              rm /tmp/himalaya.tar.gz
               
               # Add node user to sudoers with NOPASSWD
               echo "node ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/node


### PR DESCRIPTION
## Résumé

Corrige les URLs de téléchargement pour:
- **infisical CLI**: Utilise le bon dépôt `Infisical/cli` avec le format tar.gz
- **himalaya CLI**: Utilise le bon format tar.gz

## Problème

Les fichiers téléchargés contenaient "Not Found" car les URLs étaient incorrectes.

## Solution

- Infisical: `https://github.com/Infisical/cli/releases/download/v0.43.57/cli_0.43.57_linux_amd64.tar.gz`
- Himalaya: `https://github.com/pimalaya/himalaya/releases/download/v1.2.0/himalaya-linux-x86_64.tar.gz`