### PR TITLE
fix(openclaw): fix PYTHONPATH for pip modules

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -331,11 +331,11 @@ spec:
             - name: TZ
               value: Europe/Paris
             - name: PATH
-              value: /data/tools/local/bin:/data/tools/bin:/data/tools/lib:/data/gemini-cli:/data/gemini-cli/@google/gemini-cli/node_modules/.bin:/usr/local/bin:/usr/local/lib/node_modules/.bin:/usr/bin:/bin
+              value: /data/tools/usr/local/bin:/data/tools/local/bin:/data/tools/bin:/data/tools/lib:/data/gemini-cli:/data/gemini-cli/@google/gemini-cli/node_modules/.bin:/usr/local/bin:/usr/local/lib/node_modules/.bin:/usr/bin:/bin
             - name: LD_LIBRARY_PATH
               value: /data/tools/lib:/data/tools/lib/blas:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/lib:/usr/lib
             - name: PYTHONPATH
-              value: /data/tools/lib/python3.11/site-packages:/data/tools/local/lib/python3.11/site-packages
+              value: /data/tools/usr/local/lib/python3.11/dist-packages:/data/tools/local/lib/python3.11/dist-packages
             - name: GEMINI_CLI_AUTH_DIR
               value: /data/.gemini
             - name: OPENCLAW_HOME


### PR DESCRIPTION
Ajoute les chemins corrects pour les modules pip dans PYTHONPATH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service container environment configuration to optimize tool and Python library paths for improved service performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->