### PR TITLE
fix(openclaw): pass rclone credentials via CLI flags

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -163,13 +163,10 @@ spec:
             - -c
           args:
             - |
-              export RCLONE_CONFIG_S3_TYPE=s3
-              export RCLONE_CONFIG_S3_PROVIDER=Other
-              export RCLONE_CONFIG_S3_ACCESS_KEY_ID=$RCLONE_ACCESS_KEY_ID
-              export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=$RCLONE_SECRET_ACCESS_KEY
-              export RCLONE_CONFIG_S3_ENDPOINT=$RCLONE_ENDPOINT
-              rclone copy s3:$RCLONE_BUCKET/.openclaw /data/.openclaw --transfers 4 --exclude "lost+found/**" 2>/dev/null || true
-              rclone copy s3:$RCLONE_BUCKET/extensions /data/extensions --transfers 4 --exclude "lost+found/**" 2>/dev/null || true
+              echo "DEBUG: RCLONE_BUCKET=$RCLONE_BUCKET"
+              rclone lsd s3:$RCLONE_BUCKET --access_key_id=$RCLONE_ACCESS_KEY_ID --secret_access_key=$RCLONE_SECRET_ACCESS_KEY --endpoint=$RCLONE_ENDPOINT --provider=Other || echo "Rclone list failed"
+              rclone copy s3:$RCLONE_BUCKET/.openclaw /data/.openclaw --access_key_id=$RCLONE_ACCESS_KEY_ID --secret_access_key=$RCLONE_SECRET_ACCESS_KEY --endpoint=$RCLONE_ENDPOINT --provider=Other --transfers 4 --exclude "lost+found/**" 2>/dev/null || true
+              rclone copy s3:$RCLONE_BUCKET/extensions /data/extensions --access_key_id=$RCLONE_ACCESS_KEY_ID --secret_access_key=$RCLONE_SECRET_ACCESS_KEY --endpoint=$RCLONE_ENDPOINT --provider=Other --transfers 4 --exclude "lost+found/**" 2>/dev/null || true
           envFrom:
             - secretRef:
                 name: openclaw-secrets
@@ -194,16 +191,12 @@ spec:
             - -c
           args:
             - |
-              export RCLONE_CONFIG_S3_TYPE=s3
-              export RCLONE_CONFIG_S3_PROVIDER=Other
-              export RCLONE_CONFIG_S3_ACCESS_KEY_ID=$RCLONE_ACCESS_KEY_ID
-              export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=$RCLONE_SECRET_ACCESS_KEY
-              export RCLONE_CONFIG_S3_ENDPOINT=$RCLONE_ENDPOINT
+              echo "DEBUG: RCLONE_BUCKET=$RCLONE_BUCKET"
               
               # If PVC has no config, try to restore from MinIO
               if [ ! -s /data/openclaw.json ]; then
                 echo "No config found in PVC, checking MinIO backup..."
-                rclone copy s3:$RCLONE_BUCKET/openclaw.json /data/ --transfers 4 2>/dev/null || true
+                rclone copy s3:$RCLONE_BUCKET/openclaw.json /data/ --access_key_id=$RCLONE_ACCESS_KEY_ID --secret_access_key=$RCLONE_SECRET_ACCESS_KEY --endpoint=$RCLONE_ENDPOINT --provider=Other --transfers 4 2>/dev/null || echo "MinIO restore failed"
               fi
               
               # If still no config, use default from ConfigMap
@@ -384,13 +377,9 @@ spec:
             - -c
           args:
             - |
-              export RCLONE_CONFIG_S3_TYPE=s3
-              export RCLONE_CONFIG_S3_PROVIDER=Other
-              export RCLONE_CONFIG_S3_ACCESS_KEY_ID=$RCLONE_ACCESS_KEY_ID
-              export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=$RCLONE_SECRET_ACCESS_KEY
-              export RCLONE_CONFIG_S3_ENDPOINT=$RCLONE_ENDPOINT
+              echo "DEBUG: RCLONE_BUCKET=$RCLONE_BUCKET"
               sync_s3() {
-                rclone sync /data s3:$RCLONE_BUCKET/openclaw --exclude "lost+found/**"
+                rclone sync /data s3:$RCLONE_BUCKET/openclaw --access_key_id=$RCLONE_ACCESS_KEY_ID --secret_access_key=$RCLONE_SECRET_ACCESS_KEY --endpoint=$RCLONE_ENDPOINT --provider=Other --exclude "lost+found/**" || echo "Sync failed"
               }
               while true; do
                 sync_s3;


### PR DESCRIPTION
Corrige l'authentification MinIO en passant les credentials directement via les flags CLI de rclone au lieu des variables d'environnement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup and restore error handling—operations now continue when backups are unavailable instead of failing completely.
  * Added informational logging to help troubleshoot backup and restore issues.

* **Refactor**
  * Enhanced credential and parameter handling for backup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->