### PR TITLE
fix(openclaw): fix rclone flag names

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -164,9 +164,9 @@ spec:
           args:
             - |
               echo "DEBUG: RCLONE_BUCKET=$RCLONE_BUCKET"
-              rclone lsd s3:$RCLONE_BUCKET --access_key_id=$RCLONE_ACCESS_KEY_ID --secret_access_key=$RCLONE_SECRET_ACCESS_KEY --endpoint=$RCLONE_ENDPOINT --provider=Other || echo "Rclone list failed"
-              rclone copy s3:$RCLONE_BUCKET/.openclaw /data/.openclaw --access_key_id=$RCLONE_ACCESS_KEY_ID --secret_access_key=$RCLONE_SECRET_ACCESS_KEY --endpoint=$RCLONE_ENDPOINT --provider=Other --transfers 4 --exclude "lost+found/**" 2>/dev/null || true
-              rclone copy s3:$RCLONE_BUCKET/extensions /data/extensions --access_key_id=$RCLONE_ACCESS_KEY_ID --secret_access_key=$RCLONE_SECRET_ACCESS_KEY --endpoint=$RCLONE_ENDPOINT --provider=Other --transfers 4 --exclude "lost+found/**" 2>/dev/null || true
+              rclone lsd s3:$RCLONE_BUCKET --s3-access-key-id=$RCLONE_ACCESS_KEY_ID --s3-secret-access-key=$RCLONE_SECRET_ACCESS_KEY --s3-endpoint=$RCLONE_ENDPOINT --s3-provider=Other || echo "Rclone list failed"
+              rclone copy s3:$RCLONE_BUCKET/.openclaw /data/.openclaw --s3-access-key-id=$RCLONE_ACCESS_KEY_ID --s3-secret-access-key=$RCLONE_SECRET_ACCESS_KEY --s3-endpoint=$RCLONE_ENDPOINT --s3-provider=Other --transfers 4 --exclude "lost+found/**" 2>/dev/null || true
+              rclone copy s3:$RCLONE_BUCKET/extensions /data/extensions --s3-access-key-id=$RCLONE_ACCESS_KEY_ID --s3-secret-access-key=$RCLONE_SECRET_ACCESS_KEY --s3-endpoint=$RCLONE_ENDPOINT --s3-provider=Other --transfers 4 --exclude "lost+found/**" 2>/dev/null || true
           envFrom:
             - secretRef:
                 name: openclaw-secrets
@@ -196,7 +196,7 @@ spec:
               # If PVC has no config, try to restore from MinIO
               if [ ! -s /data/openclaw.json ]; then
                 echo "No config found in PVC, checking MinIO backup..."
-                rclone copy s3:$RCLONE_BUCKET/openclaw.json /data/ --access_key_id=$RCLONE_ACCESS_KEY_ID --secret_access_key=$RCLONE_SECRET_ACCESS_KEY --endpoint=$RCLONE_ENDPOINT --provider=Other --transfers 4 2>/dev/null || echo "MinIO restore failed"
+                rclone copy s3:$RCLONE_BUCKET/openclaw.json /data/ --s3-access-key-id=$RCLONE_ACCESS_KEY_ID --s3-secret-access-key=$RCLONE_SECRET_ACCESS_KEY --s3-endpoint=$RCLONE_ENDPOINT --s3-provider=Other --transfers 4 2>/dev/null || echo "MinIO restore failed"
               fi
               
               # If still no config, use default from ConfigMap
@@ -379,7 +379,7 @@ spec:
             - |
               echo "DEBUG: RCLONE_BUCKET=$RCLONE_BUCKET"
               sync_s3() {
-                rclone sync /data s3:$RCLONE_BUCKET/openclaw --access_key_id=$RCLONE_ACCESS_KEY_ID --secret_access_key=$RCLONE_SECRET_ACCESS_KEY --endpoint=$RCLONE_ENDPOINT --provider=Other --exclude "lost+found/**" || echo "Sync failed"
+                rclone sync /data s3:$RCLONE_BUCKET/openclaw --s3-access-key-id=$RCLONE_ACCESS_KEY_ID --s3-secret-access-key=$RCLONE_SECRET_ACCESS_KEY --s3-endpoint=$RCLONE_ENDPOINT --s3-provider=Other --exclude "lost+found/**" || echo "Sync failed"
               }
               while true; do
                 sync_s3;


### PR DESCRIPTION
Utilise --s3-* prefix pour les flags rclone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated storage configuration parameters for S3 compatibility across deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->