### PR TITLE
fix(openclaw): set HOME and explicit config path for rclone

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -165,9 +165,10 @@ spec:
             - |
               echo "DEBUG: RCLONE_BUCKET=$RCLONE_BUCKET"
               
-              # Create rclone config file
-              mkdir -p ~/.config/rclone
-              cat > ~/.config/rclone/rclone.conf << EOF
+              # Create rclone config file with explicit path
+              export HOME=/tmp
+              mkdir -p /tmp/.config/rclone
+              cat > /tmp/.config/rclone/rclone.conf << EOF
 [s3]
 type = s3
 provider = Other
@@ -176,9 +177,9 @@ secret_access_key = $RCLONE_SECRET_ACCESS_KEY
 endpoint = $RCLONE_ENDPOINT
 EOF
               
-              rclone lsd s3: --config ~/.config/rclone/rclone.conf || echo "Rclone list failed"
-              rclone copy s3:.openclaw /data/.openclaw --config ~/.config/rclone/rclone.conf --transfers 4 --exclude "lost+found/**" 2>/dev/null || true
-              rclone copy s3:extensions /data/extensions --config ~/.config/rclone/rclone.conf --transfers 4 --exclude "lost+found/**" 2>/dev/null || true
+              rclone lsd s3: --config /tmp/.config/rclone/rclone.conf || echo "Rclone list failed"
+              rclone copy s3:.openclaw /data/.openclaw --config /tmp/.config/rclone/rclone.conf --transfers 4 --exclude "lost+found/**" 2>/dev/null || true
+              rclone copy s3:extensions /data/extensions --config /tmp/.config/rclone/rclone.conf --transfers 4 --exclude "lost+found/**" 2>/dev/null || true
           envFrom:
             - secretRef:
                 name: openclaw-secrets
@@ -205,9 +206,10 @@ EOF
             - |
               echo "DEBUG: RCLONE_BUCKET=$RCLONE_BUCKET"
               
-              # Create rclone config file
-              mkdir -p ~/.config/rclone
-              cat > ~/.config/rclone/rclone.conf << EOF
+              # Create rclone config file with explicit path
+              export HOME=/tmp
+              mkdir -p /tmp/.config/rclone
+              cat > /tmp/.config/rclone/rclone.conf << EOF
 [s3]
 type = s3
 provider = Other
@@ -219,7 +221,7 @@ EOF
               # If PVC has no config, try to restore from MinIO
               if [ ! -s /data/openclaw.json ]; then
                 echo "No config found in PVC, checking MinIO backup..."
-                rclone copy s3:openclaw.json /data/ --config ~/.config/rclone/rclone.conf --transfers 4 2>/dev/null || echo "MinIO restore failed"
+                rclone copy s3:openclaw.json /data/ --config /tmp/.config/rclone/rclone.conf --transfers 4 2>/dev/null || echo "MinIO restore failed"
               fi
               
               # If still no config, use default from ConfigMap
@@ -402,9 +404,10 @@ EOF
             - |
               echo "DEBUG: RCLONE_BUCKET=$RCLONE_BUCKET"
               
-              # Create rclone config file
-              mkdir -p ~/.config/rclone
-              cat > ~/.config/rclone/rclone.conf << EOF
+              # Create rclone config file with explicit path
+              export HOME=/tmp
+              mkdir -p /tmp/.config/rclone
+              cat > /tmp/.config/rclone/rclone.conf << EOF
 [s3]
 type = s3
 provider = Other
@@ -414,7 +417,7 @@ endpoint = $RCLONE_ENDPOINT
 EOF
               
               sync_s3() {
-                rclone sync /data s3:openclaw --config ~/.config/rclone/rclone.conf --exclude "lost+found/**" || echo "Sync failed"
+                rclone sync /data s3:openclaw --config /tmp/.config/rclone/rclone.conf --exclude "lost+found/**" || echo "Sync failed"
               }
               while true; do
                 sync_s3;


### PR DESCRIPTION
Définit HOME=/tmp et utilise un chemin explicite pour le fichier de config rclone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration paths for data synchronization utilities to use explicit absolute paths, ensuring consistent behavior and reliability across all data restoration and synchronization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->