### PR TITLE
fix(openclaw): fix YAML syntax for rclone config

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -168,14 +168,7 @@ spec:
               # Create rclone config file with explicit path
               export HOME=/tmp
               mkdir -p /tmp/.config/rclone
-              cat > /tmp/.config/rclone/rclone.conf << EOF
-[s3]
-type = s3
-provider = Other
-access_key_id = $RCLONE_ACCESS_KEY_ID
-secret_access_key = $RCLONE_SECRET_ACCESS_KEY
-endpoint = $RCLONE_ENDPOINT
-EOF
+              printf '[s3]\ntype = s3\nprovider = Other\naccess_key_id = %s\nsecret_access_key = %s\nendpoint = %s\n' "$RCLONE_ACCESS_KEY_ID" "$RCLONE_SECRET_ACCESS_KEY" "$RCLONE_ENDPOINT" > /tmp/.config/rclone/rclone.conf
               
               rclone lsd s3: --config /tmp/.config/rclone/rclone.conf || echo "Rclone list failed"
               rclone copy s3:.openclaw /data/.openclaw --config /tmp/.config/rclone/rclone.conf --transfers 4 --exclude "lost+found/**" 2>/dev/null || true
@@ -209,14 +202,7 @@ EOF
               # Create rclone config file with explicit path
               export HOME=/tmp
               mkdir -p /tmp/.config/rclone
-              cat > /tmp/.config/rclone/rclone.conf << EOF
-[s3]
-type = s3
-provider = Other
-access_key_id = $RCLONE_ACCESS_KEY_ID
-secret_access_key = $RCLONE_SECRET_ACCESS_KEY
-endpoint = $RCLONE_ENDPOINT
-EOF
+              printf '[s3]\ntype = s3\nprovider = Other\naccess_key_id = %s\nsecret_access_key = %s\nendpoint = %s\n' "$RCLONE_ACCESS_KEY_ID" "$RCLONE_SECRET_ACCESS_KEY" "$RCLONE_ENDPOINT" > /tmp/.config/rclone/rclone.conf
               
               # If PVC has no config, try to restore from MinIO
               if [ ! -s /data/openclaw.json ]; then
@@ -407,14 +393,7 @@ EOF
               # Create rclone config file with explicit path
               export HOME=/tmp
               mkdir -p /tmp/.config/rclone
-              cat > /tmp/.config/rclone/rclone.conf << EOF
-[s3]
-type = s3
-provider = Other
-access_key_id = $RCLONE_ACCESS_KEY_ID
-secret_access_key = $RCLONE_SECRET_ACCESS_KEY
-endpoint = $RCLONE_ENDPOINT
-EOF
+              printf '[s3]\ntype = s3\nprovider = Other\naccess_key_id = %s\nsecret_access_key = %s\nendpoint = %s\n' "$RCLONE_ACCESS_KEY_ID" "$RCLONE_SECRET_ACCESS_KEY" "$RCLONE_ENDPOINT" > /tmp/.config/rclone/rclone.conf
               
               sync_s3() {
                 rclone sync /data s3:openclaw --config /tmp/.config/rclone/rclone.conf --exclude "lost+found/**" || echo "Sync failed"


### PR DESCRIPTION
Corrige la syntaxe YAML qui causait des erreurs de parsing