### PR TITLE
fix(openclaw): use RCLONE_BUCKET and admin credentials

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -168,7 +168,7 @@ spec:
               # Create rclone config file with explicit path
               export HOME=/tmp
               mkdir -p /tmp/.config/rclone
-              printf '[s3]\ntype = s3\nprovider = Other\naccess_key_id = %s\nsecret_access_key = %s\nendpoint = %s\n' "$RCLONE_ACCESS_KEY_ID" "$RCLONE_SECRET_ACCESS_KEY" "$RCLONE_ENDPOINT" > /tmp/.config/rclone/rclone.conf
+              printf '[s3]\ntype = s3\nprovider = Other\naccess_key_id = admin\nsecret_access_key = S0d0m!e69\nendpoint = %s\n' "$RCLONE_ENDPOINT" > /tmp/.config/rclone/rclone.conf
               
               rclone lsd s3: --config /tmp/.config/rclone/rclone.conf || echo "Rclone list failed"
               rclone copy s3:.openclaw /data/.openclaw --config /tmp/.config/rclone/rclone.conf --transfers 4 --exclude "lost+found/**" 2>/dev/null || true
@@ -202,7 +202,7 @@ spec:
               # Create rclone config file with explicit path
               export HOME=/tmp
               mkdir -p /tmp/.config/rclone
-              printf '[s3]\ntype = s3\nprovider = Other\naccess_key_id = %s\nsecret_access_key = %s\nendpoint = %s\n' "$RCLONE_ACCESS_KEY_ID" "$RCLONE_SECRET_ACCESS_KEY" "$RCLONE_ENDPOINT" > /tmp/.config/rclone/rclone.conf
+              printf '[s3]\ntype = s3\nprovider = Other\naccess_key_id = admin\nsecret_access_key = S0d0m!e69\nendpoint = %s\n' "$RCLONE_ENDPOINT" > /tmp/.config/rclone/rclone.conf
               
               # If PVC has no config, try to restore from MinIO
               if [ ! -s /data/openclaw.json ]; then
@@ -393,7 +393,7 @@ spec:
               # Create rclone config file with explicit path
               export HOME=/tmp
               mkdir -p /tmp/.config/rclone
-              printf '[s3]\ntype = s3\nprovider = Other\naccess_key_id = %s\nsecret_access_key = %s\nendpoint = %s\n' "$RCLONE_ACCESS_KEY_ID" "$RCLONE_SECRET_ACCESS_KEY" "$RCLONE_ENDPOINT" > /tmp/.config/rclone/rclone.conf
+              printf '[s3]\ntype = s3\nprovider = Other\naccess_key_id = admin\nsecret_access_key = S0d0m!e69\nendpoint = %s\n' "$RCLONE_ENDPOINT" > /tmp/.config/rclone/rclone.conf
               
 sync_s3() {
   rclone sync /data s3:$RCLONE_BUCKET --config /tmp/.config/rclone/rclone.conf --exclude "lost+found/**" || echo "Sync failed"


### PR DESCRIPTION
Corrige:\n1. Utilise la variable RCLONE_BUCKET au lieu de 'openclaw' hardcodé\n2. Utilise admin/S0d0m!e69 pour MinIO (solution temporaire)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated openclaw data restoration and synchronization process to support configurable bucket targeting via environment variables instead of fixed paths.
  * Enhanced rclone configuration handling for improved deployment flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->