### PR TITLE
fix(openclaw): use rclone CLI flags instead of config file

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -165,14 +165,9 @@ spec:
             - |
               echo "DEBUG: RCLONE_BUCKET=$RCLONE_BUCKET"
               
-              # Create rclone config file with explicit path
-              export HOME=/tmp
-              mkdir -p /tmp/.config/rclone
-              printf '[s3]\ntype = s3\nprovider = Other\naccess_key_id = admin\nsecret_access_key = S0d0m!e69\nendpoint = %s\n' "$RCLONE_ENDPOINT" > /tmp/.config/rclone/rclone.conf
-              
-              rclone lsd s3: --config /tmp/.config/rclone/rclone.conf || echo "Rclone list failed"
-              rclone copy s3:.openclaw /data/.openclaw --config /tmp/.config/rclone/rclone.conf --transfers 4 --exclude "lost+found/**" 2>/dev/null || true
-              rclone copy s3:extensions /data/extensions --config /tmp/.config/rclone/rclone.conf --transfers 4 --exclude "lost+found/**" 2>/dev/null || true
+              rclone lsd s3:$RCLONE_BUCKET --s3-access-key-id=admin --s3-secret-access-key='S0d0m!e69' --s3-endpoint=$RCLONE_ENDPOINT || echo "Rclone list failed"
+              rclone copy s3:$RCLONE_BUCKET/.openclaw /data/.openclaw --s3-access-key-id=admin --s3-secret-access-key='S0d0m!e69' --s3-endpoint=$RCLONE_ENDPOINT --transfers 4 --exclude "lost+found/**" 2>/dev/null || true
+              rclone copy s3:$RCLONE_BUCKET/extensions /data/extensions --s3-access-key-id=admin --s3-secret-access-key='S0d0m!e69' --s3-endpoint=$RCLONE_ENDPOINT --transfers 4 --exclude "lost+found/**" 2>/dev/null || true
           envFrom:
             - secretRef:
                 name: openclaw-secrets
@@ -199,15 +194,10 @@ spec:
             - |
               echo "DEBUG: RCLONE_BUCKET=$RCLONE_BUCKET"
               
-              # Create rclone config file with explicit path
-              export HOME=/tmp
-              mkdir -p /tmp/.config/rclone
-              printf '[s3]\ntype = s3\nprovider = Other\naccess_key_id = admin\nsecret_access_key = S0d0m!e69\nendpoint = %s\n' "$RCLONE_ENDPOINT" > /tmp/.config/rclone/rclone.conf
-              
               # If PVC has no config, try to restore from MinIO
               if [ ! -s /data/openclaw.json ]; then
                 echo "No config found in PVC, checking MinIO backup..."
-                rclone copy s3:$RCLONE_BUCKET/openclaw.json /data/ --config /tmp/.config/rclone/rclone.conf --transfers 4 2>/dev/null || echo "MinIO restore failed"
+                rclone copy s3:$RCLONE_BUCKET/openclaw.json /data/ --s3-access-key-id=admin --s3-secret-access-key='S0d0m!e69' --s3-endpoint=$RCLONE_ENDPOINT --transfers 4 2>/dev/null || echo "MinIO restore failed"
               fi
               
               # If still no config, use default from ConfigMap
@@ -390,13 +380,8 @@ spec:
             - |
               echo "DEBUG: RCLONE_BUCKET=$RCLONE_BUCKET"
               
-              # Create rclone config file with explicit path
-              export HOME=/tmp
-              mkdir -p /tmp/.config/rclone
-              printf '[s3]\ntype = s3\nprovider = Other\naccess_key_id = admin\nsecret_access_key = S0d0m!e69\nendpoint = %s\n' "$RCLONE_ENDPOINT" > /tmp/.config/rclone/rclone.conf
-              
               sync_s3() {
-                rclone sync /data s3:$RCLONE_BUCKET --config /tmp/.config/rclone/rclone.conf --exclude "lost+found/**" || echo "Sync failed"
+                rclone sync /data s3:$RCLONE_BUCKET --s3-access-key-id=admin --s3-secret-access-key='S0d0m!e69' --s3-endpoint=$RCLONE_ENDPOINT --exclude "lost+found/**" || echo "Sync failed"
               }
               while true; do
                 sync_s3;


### PR DESCRIPTION
Le fichier de config rclone ne marchait pas, utilisation des flags CLI directement