### PR TITLE
fix(openclaw): exclude large dirs from sync

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -381,7 +381,7 @@ spec:
               echo "DEBUG: RCLONE_BUCKET=$RCLONE_BUCKET"
               
               sync_s3() {
-                rclone sync /data s3:$RCLONE_BUCKET --s3-access-key-id=admin --s3-secret-access-key='S0d0m!e69' --s3-endpoint=$RCLONE_ENDPOINT --exclude "lost+found/**" || echo "Sync failed"
+                rclone sync /data s3:$RCLONE_BUCKET --s3-access-key-id=admin --s3-secret-access-key='S0d0m!e69' --s3-endpoint=$RCLONE_ENDPOINT --exclude "lost+found/**" --exclude "node_modules/**" --exclude "tools/**" --exclude "gemini-cli/**" --exclude "browser/**" --exclude "canvas/**" --exclude "extensions/**" --exclude ".openclaw/**" --exclude "media/**" --exclude "netbox-mcp-server/**" || echo "Sync failed"
               }
               while true; do
                 sync_s3;


### PR DESCRIPTION
Exclut node_modules, tools, gemini-cli du sync pour accéléré

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized data synchronization operations by refining excluded files and directories, improving sync efficiency and reducing unnecessary data transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->