### PR TITLE
fix(renovate): remove invalid deleteConflictingBranches option

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,6 @@
   "platformAutomerge": true,
   "automergeType": "pr",
   "automergeStrategy": "squash",
-  "deleteConflictingBranches": true,
   "enabledManagers": [
     "terraform",
     "helm-values",


### PR DESCRIPTION
Corrige l'erreur de configuration qui empêchait Renovate de fonctionner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to no longer automatically delete conflicting branches during dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->