### PR TITLE
feat(penpot): enable-access-tokens for MCP

### DIFF
--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -35,7 +35,7 @@ spec:
                 name: penpot-secrets
           env:
             - name: PENPOT_FLAGS
-              value: "enable-registration enable-login-with-password disable-secure-session-cookies disable-email-verification"
+              value: "enable-registration enable-login-with-password disable-secure-session-cookies disable-email-verification enable-access-tokens"
             - name: PENPOT_PUBLIC_URI
               value: "https://design.truxonline.com"
             - name: PENPOT_DATABASE_URI

--- a/apps/70-tools/penpot/base/deployment-frontend.yaml
+++ b/apps/70-tools/penpot/base/deployment-frontend.yaml
@@ -32,7 +32,7 @@ spec:
             - name: PENPOT_BACKEND_URI
               value: "http://penpot-backend:6060"
             - name: PENPOT_FLAGS
-              value: "enable-registration enable-login-with-password disable-secure-session-cookies enable-smtp enable-email-verification"
+              value: "enable-registration enable-login-with-password disable-secure-session-cookies enable-smtp enable-email-verification enable-access-tokens"
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
Enabling API access tokens in Penpot backend and frontend to allow MCP server connection. Applied via Lisa.