### PR TITLE
fix(renovate): enable automerge for major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -133,7 +133,7 @@
       "matchUpdateTypes": [
         "major"
       ],
-      "automerge": false,
+      "automerge": true,
       "labels": [
         "dependencies",
         "renovate",


### PR DESCRIPTION
Permet l'automerge pour les mises à jour majeures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automatic merging for approved major dependency updates so approved major-version changes no longer require a separate manual merge step, reducing manual overhead and accelerating delivery of dependency updates while preserving approval controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->