### PR TITLE
feat(mosquitto): add MQTT_USERS support for dynamic user creation

### DIFF
--- a/apps/10-home/mosquitto/base/statefulset.yaml
+++ b/apps/10-home/mosquitto/base/statefulset.yaml
@@ -51,19 +51,47 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /mosquitto/data
-        - name: copy-mosquitto-password
-          image: busybox:1.37.0 # A small image with basic utilities
+        - name: create-mosquitto-users
+          image: eclipse-mosquitto:2.0.22
           command:
             - sh
             - -c
           args:
-            - cp /secrets/MOSQUITTO_PASSWD_FILE /mnt/mosquitto-auth-writable/mosquitto.passwd && chmod 0700 /mnt/mosquitto-auth-writable/mosquitto.passwd && chown 1883:1883 /mnt/mosquitto-auth-writable/mosquitto.passwd # Assuming mosquitto user ID is 1883
+            - |
+              set -e
+              touch /auth/mosquitto.passwd
+              chmod 0600 /auth/mosquitto.passwd
+              if [ -n "$MQTT_USERS" ]; then
+                echo "Creating MQTT users from MQTT_USERS..."
+                IFS=',' read -ra USERS <<< "$MQTT_USERS"
+                for USER in "${USERS[@]}"; do
+                  NAME="${USER%%:*}"
+                  PASS="${USER##*:}"
+                  if [ -n "$NAME" ] && [ -n "$PASS" ]; then
+                    mosquitto_passwd -b /auth/mosquitto.passwd "$NAME" "$PASS"
+                    echo "Created user: $NAME"
+                  fi
+                done
+              else
+                echo "MQTT_USERS not set, using existing MOSQUITTO_PASSWD_FILE..."
+                if [ -f /secrets/MOSQUITTO_PASSWD_FILE ]; then
+                  cp /secrets/MOSQUITTO_PASSWD_FILE /auth/mosquitto.passwd
+                fi
+              fi
+              chown 1883:1883 /auth/mosquitto.passwd
+          env:
+            - name: MQTT_USERS
+              valueFrom:
+                secretKeyRef:
+                  name: mosquitto-password-file
+                  key: MQTT_USERS
+                  optional: true
           volumeMounts:
             - name: mosquitto-auth
               mountPath: /secrets
               readOnly: true
             - name: mosquitto-auth-writable
-              mountPath: /mnt/mosquitto-auth-writable
+              mountPath: /auth
       containers:
         - name: mosquitto
           image: eclipse-mosquitto:2.0.22


### PR DESCRIPTION
## Summary
- Add new init container `create-mosquitto-users` that generates passwd file from `MQTT_USERS` secret
- Format: `MQTT_USERS = "user1:pass1,user2:pass2"`
- Fallback to existing `MOSQUITTO_PASSWD_FILE` if `MQTT_USERS` not set

## Benefits
- Simpler user management - just add user:pass in Infisical
- No need to generate hashes manually
- Backward compatible with existing setup

## Usage
Add `MQTT_USERS` secret in Infisical:
```
MQTT_USERS = "frigate:password1,homeassistant:password2,shelly:password3"
```

## Test
- [ ] Deploy to dev
- [ ] Verify MQTT users created correctly
- [ ] Test MQTT connection from HA/Frigate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced Mosquitto authentication initialization with a multi-step user creation process for improved reliability.
  * Authentication configuration now supports environment variable-based user management from secrets.
  * Improved file ownership handling for authentication credentials to ensure proper access permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->