### PR TITLE
fix(mosquitto): use bash instead of sh

### DIFF
--- a/apps/10-home/mosquitto/base/statefulset.yaml
+++ b/apps/10-home/mosquitto/base/statefulset.yaml
@@ -54,7 +54,7 @@ spec:
         - name: create-mosquitto-users
           image: eclipse-mosquitto:2.0.22
           command:
-            - sh
+            - bash
             - -c
           args:
             - |


### PR DESCRIPTION
Fix syntax error in create-mosquitto-users init container. The `<<<` operator is bash-specific.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shell configuration for internal services to improve compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->