### PR TITLE
fix(openclaw): move /data/tools/lib to end of LD_LIBRARY_PATH

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -327,7 +327,7 @@ spec:
             - name: PATH
               value: /data/tools/usr/local/bin:/data/tools/local/bin:/data/tools/bin:/data/tools/lib:/data/gemini-cli:/data/gemini-cli/@google/gemini-cli/node_modules/.bin:/usr/local/bin:/usr/local/lib/node_modules/.bin:/usr/bin:/bin
             - name: LD_LIBRARY_PATH
-              value: /data/tools/lib:/data/tools/lib/blas:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/lib:/usr/lib
+              value: /usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/lib:/usr/lib:/data/tools/lib/blas
             - name: PYTHONPATH
               value: /data/tools/usr/local/lib/python3.11/dist-packages:/data/tools/local/lib/python3.11/dist-packages
             - name: GEMINI_CLI_AUTH_DIR


### PR DESCRIPTION
Fixes libc.so.6 symbol lookup error by ensuring system libraries are loaded first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated library path configuration in deployment settings to optimize system library resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->