### PR TITLE
chore(beads): add sync.remote config for beads-sync branch

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -62,3 +62,5 @@
 # - github.repo
 
 sync.branch: "beads-sync"
+
+sync.remote: "origin"


### PR DESCRIPTION
Add sync.remote config to ensure all clones use the same beads configuration for syncing to the dedicated beads-sync branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated synchronization configuration to enable active sync with remote repository settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->