### PR TITLE
fix(beads): add custom hooks for Dolt backend duplicate handling

### DIFF
--- a/.beads/hooks/post-merge
+++ b/.beads/hooks/post-merge
@@ -1,24 +1,49 @@
 #!/usr/bin/env sh
-# bd-shim v1
-# bd-hooks-version: 0.55.4
-#
-# bd (beads) post-merge hook - thin shim
-#
-# This shim delegates to 'bd hook post-merge' which contains
-# the actual hook logic. This pattern ensures hook behavior is always
-# in sync with the installed bd version - no manual updates needed.
-#
-# The 'bd hook' command (singular) supports:
-# - Branch-then-merge pattern for Dolt (cell-level conflict resolution)
-# - Per-worktree state tracking
-# - Hook chaining configuration
+# Custom post-merge hook for beads with Dolt backend
+# Workaround for https://github.com/steveyegge/beads/issues/1771
 
-# Check if bd is available
 if ! command -v bd >/dev/null 2>&1; then
-    echo "Warning: bd command not found in PATH, skipping post-merge hook" >&2
-    echo "  Install bd: brew install beads" >&2
-    echo "  Or add bd to your PATH" >&2
     exit 0
 fi
 
-exec bd hook post-merge "$@"
+echo "🔄 Syncing beads issues..."
+
+# Get the latest issues.jsonl from beads-sync
+LATEST_JSONL=$(mktemp)
+git show origin/beads-sync:.beads/issues.jsonl > "$LATEST_JSONL" 2>/dev/null || exit 0
+
+# Count issues in JSONL
+REMOTE_COUNT=$(wc -l < "$LATEST_JSONL" 2>/dev/null || echo 0)
+
+# Get local issue count
+LOCAL_COUNT=$(bd status 2>/dev/null | grep "Total Issues" | awk '{print $3}' || echo 0)
+
+if [ "$REMOTE_COUNT" != "$LOCAL_COUNT" ]; then
+    echo "📥 Sync needed: local=$LOCAL_COUNT, remote=$REMOTE_COUNT"
+    
+    # Get list of local issue IDs
+    LOCAL_IDS=$(bd list --limit 0 --json 2>/dev/null | grep -o '"id":"[^"]*"' | cut -d'"' -f4 | sort -u)
+    
+    # Create temp file with only new issues
+    NEW_JSONL=$(mktemp)
+    while IFS= read -r line; do
+        ISSUE_ID=$(echo "$line" | grep -o '"id":"[^"]*"' | cut -d'"' -f4)
+        if ! echo "$LOCAL_IDS" | grep -q "^${ISSUE_ID}$"; then
+            echo "$line" >> "$NEW_JSONL"
+        fi
+    done < "$LATEST_JSONL"
+    
+    NEW_COUNT=$(wc -l < "$NEW_JSONL" 2>/dev/null || echo 0)
+    
+    if [ "$NEW_COUNT" -gt 0 ]; then
+        echo "📥 Importing $NEW_COUNT new issues..."
+        bd import -i "$NEW_JSONL" 2>/dev/null || echo "⚠️ Import had issues, but continuing..."
+    fi
+    
+    rm -f "$NEW_JSONL"
+    echo "✅ Sync complete"
+else
+    echo "✅ Already in sync ($LOCAL_COUNT issues)"
+fi
+
+rm -f "$LATEST_JSONL"

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -1,25 +1,18 @@
 #!/usr/bin/env sh
-# bd-shim v2
-# bd-hooks-version: 0.55.4
-#
-# bd (beads) pre-commit hook — thin shim
-#
-# Delegates to 'bd hook pre-commit' which contains the actual hook logic.
-# This pattern ensures hook behavior is always in sync with the installed
-# bd version — no manual updates needed.
-#
-# The 'bd hook' command supports:
-# - Per-worktree export state tracking
-# - Dolt in-process export (no lock deadlocks)
-# - Sync-branch routing
-# - Hook chaining configuration
+# Pre-commit hook for beads
 
-# Check if bd is available
 if ! command -v bd >/dev/null 2>&1; then
-    echo "Warning: bd command not found in PATH, skipping pre-commit hook" >&2
-    echo "  Install bd: brew install beads" >&2
-    echo "  Or add bd to your PATH" >&2
     exit 0
+fi
+
+# Export to JSONL before commit
+bd sync -q 2>/dev/null
+
+# Stage the JSONL if it changed
+if git diff --quiet .beads/issues.jsonl 2>/dev/null; then
+    : # No changes
+else
+    git add .beads/issues.jsonl
 fi
 
 exec bd hook pre-commit "$@"


### PR DESCRIPTION
Custom post-merge hook that handles the duplicate primary key issue with Dolt backend (upstream bug https://github.com/steveyegge/beads/issues/1771).

This hook:
- Detects when remote has more issues than local
- Extracts only new issues from the JSONL  
- Imports them without triggering duplicate key errors

Also updates pre-commit hook to auto-sync JSONL before commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved post-merge hook to automatically synchronize and import new issues.
  * Enhanced pre-commit hook with automated export and staging of issue data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->