### PR TITLE
fix(homeassistant): use python 3.13 for install-python-deps

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: config
               mountPath: /config
         - name: install-python-deps
-          image: python:3.14-alpine
+          image: python:3.13-alpine
           securityContext:
             runAsUser: 0
           command:


### PR DESCRIPTION
Fix Frigate integration by using Python 3.13 instead of 3.14 in the install-python-deps init container. The package `hass-web-proxy-lib==0.0.7` requires Python 3.12-3.13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Updated container image version in deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->