### PR TITLE
fix(homeassistant): use python 3.12 for install-python-deps initContainer

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: config
               mountPath: /config
         - name: install-python-deps
-          image: python:3.14-alpine
+          image: python:3.12-alpine
           securityContext:
             runAsUser: 0
           command:
@@ -271,4 +271,3 @@ spec:
         - name: homeassistant-litestream-config
           configMap:
             name: homeassistant-litestream-config
-


### PR DESCRIPTION
L'image python:3.14-alpine utilisait Python 3.14, mais le package hass-web-proxy-lib==0.0.7 nécessite Python >=3.12,<3.14.

Ce changement permet l'installation correcte de la librairie nécessaire pour l'intégration Frigate.