### PR TITLE
fix(homeassistant): pin python to 3.12.9-alpine

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: config
               mountPath: /config
         - name: install-python-deps
-          image: python:3.12-alpine
+          image: python:3.12.9-alpine
           securityContext:
             runAsUser: 0
           command:


### PR DESCRIPTION
Utilise une version patchée spécifique (3.12.9) au lieu de 3.12-alpine pour l'initContainer install-python-deps.

**Problème :** La PR #1515 (Renovate) a upgradé Python vers 3.14-alpine, ce qui casserait l'intégration Frigate car hass-web-proxy-lib==0.0.7 nécessite Python >=3.12,<3.14.

**Solution :** Utiliser une version patchée spécifique (3.12.9). Renovate proposera les futures versions patch (3.12.10, 3.12.11...) mais jamais 3.13.x ou 3.14.x.

**Bénéfices :**
- ✅ Continue de recevoir les mises à jour de sécurité (patch)
- ✅ Bloque les upgrades majeures cassantes (3.13, 3.14)
- ✅ Pas besoin de configuration Renovate complexe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment container image to a newer patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->