### PR TITLE
fix(homeassistant): restore-config initContainer permission fix

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/resources-patch.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/resources-patch.yaml
@@ -83,7 +83,7 @@ spec:
         - name: restore-config
           image: rclone/rclone:1.73
           securityContext:
-            runAsUser: 0
+            runAsUser: 1000
             runAsGroup: 1000
           command:
             - sh


### PR DESCRIPTION
**Problème :** Le pod Home Assistant est en CrashLoopBackOff avec une erreur de permission :\n\n\n\n**Cause :** L'initContainer  dans l'overlay prod tournait avec  (root), ce qui créait les fichiers restaurés depuis S3 avec l'ownership root:root. Home Assistant (qui tourne avec uid 1000) ne pouvait alors pas écrire dans ces fichiers.\n\n**Fix :** Changement de  à  pour correspondre au déploiement de base et s'assurer que les fichiers sont créés avec les bonnes permissions.\n\n**Testé :** Le pod redémarre maintenant correctement et Home Assistant peut écrire dans /config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container security configuration to enhance system stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->