### PR TITLE
fix(whoami): add vixens.io/sizing label using LabelTransformer

### DIFF
--- a/apps/99-test/whoami/overlays/prod/kustomization.yaml
+++ b/apps/99-test/whoami/overlays/prod/kustomization.yaml
@@ -2,10 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-metadata:
-  labels:
-    vixens.io/sizing: small
-
 resources:
   - ../../base
   - ingress.yaml
@@ -13,3 +9,16 @@ resources:
 components:
   - ../../../../_shared/components/default
   - ../../../../_shared/components/priority/low
+
+# Add sizing label to all resources
+transformers:
+  - |
+    apiVersion: builtin
+    kind: LabelTransformer
+    metadata:
+      name: add-sizing-label
+    labels:
+      vixens.io/sizing: small
+    fieldSpecs:
+      - path: metadata/labels
+        create: true


### PR DESCRIPTION
Fixes the sizing label not being applied to resources.

The metadata.labels in kustomization.yaml doesn't automatically propagate to resources.
Using a LabelTransformer ensures the label is added to all generated resources.

Changes:
- Replace metadata.labels with transformers/LabelTransformer
- Label vixens.io/sizing: small is now correctly applied to all resources