### PR TITLE
fix(whoami): add vixens.io/sizing label to pod template

### DIFF
--- a/apps/99-test/whoami/overlays/prod/kustomization.yaml
+++ b/apps/99-test/whoami/overlays/prod/kustomization.yaml
@@ -10,7 +10,7 @@ components:
   - ../../../../_shared/components/default
   - ../../../../_shared/components/priority/low
 
-# Add sizing label to all resources
+# Add sizing label to all resources AND pod templates
 transformers:
   - |
     apiVersion: builtin
@@ -22,3 +22,6 @@ transformers:
     fieldSpecs:
       - path: metadata/labels
         create: true
+      - path: spec/template/metadata/labels
+        create: true
+        kind: Deployment


### PR DESCRIPTION
The label was added to the Deployment metadata but not to the pod template.
Kyverno needs the label on spec.template.metadata.labels to apply resource sizing.

Changes:
- Added fieldSpec for spec/template/metadata/labels in LabelTransformer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal infrastructure configuration for deployment labeling to improve system consistency and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->