### PR TITLE
feat(whoami): migrate to new granular Kustomize components

### DIFF
--- a/apps/99-test/whoami/overlays/dev/kustomization.yaml
+++ b/apps/99-test/whoami/overlays/dev/kustomization.yaml
@@ -1,18 +1,22 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
-components:
-  - ../../../../_shared/components/revision-history-limit
 kind: Kustomization
-patches:
-  - patch: "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: any\nspec:\n \
-      \ replicas: 0"
-    target:
-      kind: Deployment
-  - patch: "apiVersion: apps/v1\nkind: StatefulSet\nmetadata:\n  name: any\nspec:\n\
-      \  replicas: 0"
-    target:
-      kind: StatefulSet
+
 resources:
   - ../../base
   - middleware.yaml
   - ingress.yaml
+
+components:
+  - ../../../../_shared/components/default
+  - ../../../../_shared/components/sizing/micro
+  - ../../../../_shared/components/priority/low
+  - ../../../../_shared/components/probes/basic
+
+patches:
+  - patch: "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: any\nspec:\n  replicas: 0"
+    target:
+      kind: Deployment
+  - patch: "apiVersion: apps/v1\nkind: StatefulSet\nmetadata:\n  name: any\nspec:\n  replicas: 0"
+    target:
+      kind: StatefulSet


### PR DESCRIPTION
## Summary
- Migrate whoami dev and prod overlays to use new granular components
- Replace revision-history-limit with default + sizing + priority + probes components
- Follows the new composable component pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration structure for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->