### PR TITLE
fix(whoami): remove priority component to preserve base priorityClassName

### DIFF
--- a/apps/99-test/whoami/overlays/prod/kustomization.yaml
+++ b/apps/99-test/whoami/overlays/prod/kustomization.yaml
@@ -8,5 +8,4 @@ resources:
 
 components:
   - ../../../../_shared/components/default
-  - ../../../../_shared/components/priority/low
   - ../../../../_shared/components/probes/basic


### PR DESCRIPTION
Remove priority/low component that was overwriting the base priorityClassName. Now uses vixens-medium as defined in base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a low-priority shared component from the production deployment configuration to streamline the environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->