### PR TITLE
fix(whoami): remove probes component (has invalid name: *)

### DIFF
--- a/apps/99-test/whoami/overlays/prod/kustomization.yaml
+++ b/apps/99-test/whoami/overlays/prod/kustomization.yaml
@@ -8,4 +8,3 @@ resources:
 
 components:
   - ../../../../_shared/components/default
-  - ../../../../_shared/components/probes/basic


### PR DESCRIPTION
Remove probes/basic component that was causing sync failures due to invalid container name '*'. The base deployment already has proper probes defined.