### PR TITLE
fix(whoami): correct VPA annotation to autoscaling.k8s.io/vpa

### DIFF
--- a/apps/99-test/whoami/base/deployment.yaml
+++ b/apps/99-test/whoami/base/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "80"
         goldilocks.fairwinds.com/enabled: "true"
-        vpa.recommendations.apps.kubernetes.io: "true"
+        autoscaling.k8s.io/vpa: "true"
     spec:
       priorityClassName: vixens-medium
       tolerations:


### PR DESCRIPTION
The VPA annotation was incorrect. Changed from vpa.recommendations.apps.kubernetes.io to autoscaling.k8s.io/vpa so the maturity script can detect it properly.