### PR TITLE
feat(whoami): add PodDisruptionBudget for Platinum tier

### DIFF
--- a/apps/99-test/whoami/base/kustomization.yaml
+++ b/apps/99-test/whoami/base/kustomization.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: whoami
 resources:
   - namespace.yaml
   - deployment.yaml
   - service.yaml
+  - pdb.yaml

--- a/apps/99-test/whoami/base/pdb.yaml
+++ b/apps/99-test/whoami/base/pdb.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: whoami
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app: whoami


### PR DESCRIPTION
Add PodDisruptionBudget with minAvailable: 0 to reach Platinum maturity level.

- minAvailable: 0 allows all pods to be disrupted (acceptable for test app)
- Required for Platinum tier compliance