### PR TITLE
fix(whoami): add namespace to prod overlay

### DIFF
--- a/apps/99-test/whoami/overlays/prod/kustomization.yaml
+++ b/apps/99-test/whoami/overlays/prod/kustomization.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
+namespace: whoami
 resources:
   - ../../base
   - ingress.yaml


### PR DESCRIPTION
Add namespace: whoami to prod overlay so PDB is created in correct namespace.