### PR TITLE
feat(evaluate_maturity): metrics exemption via annotation

### DIFF
--- a/apps/99-test/whoami/base/deployment.yaml
+++ b/apps/99-test/whoami/base/deployment.yaml
@@ -14,8 +14,7 @@ spec:
       labels:
         app: whoami
       annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "80"
+        vixens.io/nometrics: "true"
         goldilocks.fairwinds.com/enabled: "true"
         autoscaling.k8s.io/vpa: "true"
     spec:

--- a/scripts/reports/evaluate_maturity.py
+++ b/scripts/reports/evaluate_maturity.py
@@ -371,6 +371,29 @@ def check_pvc(ns, app):
     return None  # N/A - no persistent storage needed
 
 def check_metrics(pod):
+    """Check if metrics are exposed (prometheus annotations)
+    
+    Returns:
+        True - metrics annotations present
+        False - no metrics (will fail Gold)
+        None - exempted via vixens.io/nometrics annotation
+    """
+    if not pod:
+        return False
+    
+    annotations = pod.get("metadata", {}).get("annotations", {})
+    
+    # Check for exemption: vixens.io/nometrics: "true"
+    if annotations.get("vixens.io/nometrics") == "true":
+        return None  # N/A - app exempted from metrics requirement
+    
+    # Check for prometheus annotations
+    has_metrics = (
+        "prometheus.io/scrape" in annotations
+        or "prometheus.io/port" in annotations
+    )
+    
+    return has_metrics
     """Check if metrics are exposed (prometheus annotations)"""
     annotations = pod.get("metadata", {}).get("annotations", {})
     return (


### PR DESCRIPTION
Add vixens.io/nometrics annotation support for apps that don't need metrics.

## Changes

### Script
- check_metrics() now supports exemption via annotation
- Returns None (N/A) when vixens.io/nometrics: "true"

### whoami
- Replaced fake prometheus annotations with vixens.io/nometrics: "true"
- App is now honest about not exposing metrics

## Logic

| Annotation | Result | Gold Status |
|------------|--------|-------------|
| prometheus.io/scrape | True | ✅ Pass |
| vixens.io/nometrics: "true" | None | ✅ N/A (exempted) |
| None | False | ❌ Fail |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced metrics validation and exemption handling system.
  * Deployments can now be explicitly exempted from metrics collection.
  * Improved monitoring validation logic for finer-grained operational control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->