### PR TITLE
chore: cleanup obsolete sizing/priority components

### DIFF
--- a/apps/99-test/whoami/overlays/dev/kustomization.yaml
+++ b/apps/99-test/whoami/overlays/dev/kustomization.yaml
@@ -2,6 +2,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+metadata:
+  labels:
+    vixens.io/sizing: small
+
 resources:
   - ../../base
   - middleware.yaml
@@ -9,8 +13,6 @@ resources:
 
 components:
   - ../../../../_shared/components/default
-  - ../../../../_shared/components/sizing/micro
-  - ../../../../_shared/components/priority/low
   - ../../../../_shared/components/probes/basic
 
 patches:

--- a/apps/_shared/components/sizing/small/kustomization.yaml
+++ b/apps/_shared/components/sizing/small/kustomization.yaml
@@ -1,4 +1,11 @@
-
+#
+# ⚠️  DEPRECATED - DO NOT USE
+#
+# This component is obsolete. Resource sizing is now handled by Kyverno
+# via the vixens.io/sizing label. See docs/guides/sizing-migration.md
+#
+# Kustomize Component: Small Sizing
+#
 # Kustomize Component: Small Sizing
 #
 # Standard resource allocation for typical applications


### PR DESCRIPTION
Cleanup deprecated sizing and priority components.

## Changes

### Documentation
- Complete rewrite of sizing-migration.md
- Current state: Kyverno sizing + base YAML priority
- Clear migration examples
- Deprecated warnings

### whoami dev overlay
- Removed sizing/micro component
- Removed priority/low component  
- Added vixens.io/sizing label

### Components
- Added deprecation warning to sizing/small component

## Current Architecture

| Aspect | Method |
|----------|---------|
| Resource Sizing | Kyverno mutate (vixens.io/sizing label) |
| Priority | Base YAML (priorityClassName) |
| Components | **DEPRECATED** |

All apps should migrate to the new approach.