### PR TITLE
feat(components/default): add allowPrivilegeEscalation: false

### DIFF
--- a/apps/_shared/components/default/kustomization.yaml
+++ b/apps/_shared/components/default/kustomization.yaml
@@ -1,9 +1,9 @@
-
+#
 # Kustomize Component: Default Requirements
 #
 # Enforces the Vixens minimum Kyverno requirements:
 # - revisionHistoryLimit: 3
-# - SecurityContext baseline (fsGroup 1000)
+# - SecurityContext hardened (fsGroup, allowPrivilegeEscalation)
 #
 # Resources and probes are now managed by Kyverno policies:
 # - sizing-mutate (resource sizing)
@@ -31,3 +31,7 @@ patches:
             securityContext:
               fsGroup: 1000
               fsGroupChangePolicy: OnRootMismatch
+            containers:
+              - name: "*"
+                securityContext:
+                  allowPrivilegeEscalation: false


### PR DESCRIPTION
Add security hardening to the default component for all containers.

## Change
- containers[].securityContext.allowPrivilegeEscalation: false

## Impact
- All apps using components/default get this automatically
- Helps pass Diamond tier SecurityContext hardened check
- Applied on next pod restart/redeploy

## Testing
Verified with kustomize build that the annotation is injected correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened deployment security configurations with hardened container restrictions and enhanced privilege management policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->