### PR TITLE
fix(whoami): add allowPrivilegeEscalation: false for Diamond tier

### DIFF
--- a/apps/99-test/whoami/base/deployment.yaml
+++ b/apps/99-test/whoami/base/deployment.yaml
@@ -48,6 +48,8 @@ spec:
             limits:
               cpu: 50m
               memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/apps/_shared/components/default/kustomization.yaml
+++ b/apps/_shared/components/default/kustomization.yaml
@@ -31,7 +31,3 @@ patches:
             securityContext:
               fsGroup: 1000
               fsGroupChangePolicy: OnRootMismatch
-            containers:
-              - name: "*"
-                securityContext:
-                  allowPrivilegeEscalation: false


### PR DESCRIPTION
This PR adds the required container-level securityContext to whoami for Diamond tier compliance.

## Changes
- Add `allowPrivilegeEscalation: false` to whoami container
- Revert default component change (`name: *` is invalid in K8s)

## Verification
- [x] kustomize build passes
- [x] yamllint passes
- [ ] ArgoCD sync pending

Fixes Diamond tier SecurityContext hardened requirement (`runAsNonRoot`, `seccompProfile: RuntimeDefault`, `allowPrivilegeEscalation: false`)