### PR TITLE
fix(radarr): fix Bronze tier issues

### DIFF
--- a/apps/20-media/radarr/base/deployment.yaml
+++ b/apps/20-media/radarr/base/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: fix-permissions
-          image: busybox:latest
+          image: busybox:1.36
           command: ["sh", "-c", "chown -R 1000:1000 /config && rm -rf /config/*.db-litestream /config/.*-litestream"]
           volumeMounts:
             - name: config

--- a/apps/20-media/radarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/radarr/overlays/prod/kustomization.yaml
@@ -1,10 +1,13 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: media
+
+namespace: radarr
+
 resources:
   - ../../base
   - ingress.yaml
+
 patches:
   - target:
       kind: InfisicalSecret


### PR DESCRIPTION
Fix Bronze tier requirements for radarr:

## Changes

1. **busybox:latest → busybox:1.36** - Fixes :latest tag requirement
2. **namespace: media → radarr** - Correct namespace for the app
3. **Service included** - Now properly referenced via base

## Verification

Build test:
apiVersion: v1
data:
  litestream.yml: |
    dbs:
      - path: /config/radarr.db
        replicas:
          - url: s3://$LITESTREAM_BUCKET/radarr.db
            endpoint: $LITESTREAM_ENDPOINT
    addr: ":9090"
kind: ConfigMap
metadata:
  name: radarr-litestream-config
  namespace: radarr
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app: radarr
  name: radarr
  namespace: radarr
spec:
  ports:
  - port: 7878
    protocol: TCP
    targetPort: 7878
  selector:
    app: radarr
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: radarr-config-pvc
  namespace: radarr
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 2Gi
  storageClassName: synelia-iscsi-retain
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: radarr
  name: radarr
  namespace: radarr
spec:
  replicas: 1
  selector:
    matchLabels:
      app: radarr
  strategy:
    type: Recreate
  template:
    metadata:
      annotations:
        prometheus.io/path: /metrics
        prometheus.io/port: "9090"
        prometheus.io/scrape: "true"
        reloader.stakater.com/auto: "true"
      labels:
        app: radarr
    spec:
      containers:
      - env:
        - name: RADARR__API_KEY
          valueFrom:
            secretKeyRef:
              key: API_KEY
              name: radarr-secrets
        - name: PUID
          value: "1000"
        - name: PGID
          value: "1000"
        - name: TZ
          value: Europe/Paris
        envFrom:
        - secretRef:
            name: radarr-secrets
        image: ghcr.io/linuxserver/radarr:version-6.0.4.10291
        livenessProbe:
          httpGet:
            path: /ping
            port: http
          initialDelaySeconds: 30
          periodSeconds: 20
        name: radarr
        ports:
        - containerPort: 7878
          name: http
        readinessProbe:
          httpGet:
            path: /ping
            port: http
          initialDelaySeconds: 15
          periodSeconds: 10
        resources:
          limits:
            cpu: 1000m
            memory: 1Gi
          requests:
            cpu: 100m
            memory: 256Mi
        volumeMounts:
        - mountPath: /config
          name: config
        - mountPath: /downloads
          name: downloads
        - mountPath: /movies
          name: movies
          subPath: movies
      - args:
        - replicate
        - -config
        - /etc/litestream.yml
        envFrom:
        - secretRef:
            name: radarr-secrets
        image: litestream/litestream:0.5.9
        name: litestream
        ports:
        - containerPort: 9090
          name: metrics
        resources:
          limits:
            cpu: 100m
            memory: 128Mi
          requests:
            cpu: 10m
            memory: 64Mi
        securityContext:
          runAsGroup: 1000
          runAsUser: 1000
        volumeMounts:
        - mountPath: /config
          name: config
        - mountPath: /etc/litestream.yml
          name: radarr-litestream-config
          subPath: litestream.yml
      - args:
        - |
          export RCLONE_CONFIG_S3_TYPE=s3
          export RCLONE_CONFIG_S3_PROVIDER=Other
          export RCLONE_CONFIG_S3_ACCESS_KEY_ID=$LITESTREAM_ACCESS_KEY_ID
          export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=$LITESTREAM_SECRET_ACCESS_KEY
          export RCLONE_CONFIG_S3_ENDPOINT=$LITESTREAM_ENDPOINT
          sync_s3() {
            rclone sync /config s3:$LITESTREAM_BUCKET/config \
              --exclude "*.db*" \
              --exclude "*.log" \
              --exclude ".*-litestream" \
              --exclude ".*-litestream/**";
          }
          while true; do
            sync_s3;
            sleep 60;
          done
        command:
        - sh
        - -c
        envFrom:
        - secretRef:
            name: radarr-secrets
        image: rclone/rclone:1.73
        name: config-syncer
        resources:
          limits:
            cpu: 100m
            memory: 128Mi
          requests:
            cpu: 10m
            memory: 64Mi
        securityContext:
          runAsGroup: 1000
          runAsUser: 1000
        volumeMounts:
        - mountPath: /config
          name: config
      initContainers:
      - command:
        - sh
        - -c
        - chown -R 1000:1000 /config && rm -rf /config/*.db-litestream /config/.*-litestream
        image: busybox:1.36
        name: fix-permissions
        volumeMounts:
        - mountPath: /config
          name: config
      - args:
        - |
          export RCLONE_CONFIG_S3_TYPE=s3
          export RCLONE_CONFIG_S3_PROVIDER=Other
          export RCLONE_CONFIG_S3_ACCESS_KEY_ID=$LITESTREAM_ACCESS_KEY_ID
          export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=$LITESTREAM_SECRET_ACCESS_KEY
          export RCLONE_CONFIG_S3_ENDPOINT=$LITESTREAM_ENDPOINT
          rclone copy s3:$LITESTREAM_BUCKET/config /config \
            --transfers 4 \
            --exclude "*.db*" \
            --exclude "*.log" \
            --exclude ".*-litestream" \
            --exclude ".*-litestream/**" \
            || true
        command:
        - sh
        - -c
        envFrom:
        - secretRef:
            name: radarr-secrets
        image: rclone/rclone:1.73
        name: restore-config
        resources:
          limits:
            cpu: 100m
            memory: 128Mi
          requests:
            cpu: 10m
            memory: 64Mi
        securityContext:
          runAsGroup: 1000
          runAsUser: 1000
        volumeMounts:
        - mountPath: /config
          name: config
      priorityClassName: vixens-medium
      securityContext:
        fsGroup: 1000
        fsGroupChangePolicy: OnRootMismatch
      tolerations:
      - effect: NoSchedule
        key: node-role.kubernetes.io/control-plane
        operator: Exists
      volumes:
      - name: config
        persistentVolumeClaim:
          claimName: radarr-config-pvc
      - name: downloads
        nfs:
          path: /volume3/Downloads
          server: 192.168.111.69
      - name: movies
        nfs:
          path: /volume3/Content
          server: 192.168.111.69
      - configMap:
          name: radarr-litestream-config
        name: radarr-litestream-config
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt-prod
    gethomepage.dev/enabled: "true"
    gethomepage.dev/group: Media
    gethomepage.dev/icon: radarr.png
    gethomepage.dev/name: Radarr
    traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
  name: radarr-ingress
  namespace: radarr
spec:
  ingressClassName: traefik
  rules:
  - host: radarr.truxonline.com
    http:
      paths:
      - backend:
          service:
            name: radarr
            port:
              number: 7878
        path: /
        pathType: Prefix
  tls:
  - hosts:
    - radarr.truxonline.com
    secretName: radarr-tls
---
apiVersion: secrets.infisical.com/v1alpha1
kind: InfisicalSecret
metadata:
  name: radarr-secrets-sync
  namespace: radarr
spec:
  authentication:
    universalAuth:
      credentialsRef:
        secretName: infisical-universal-auth
        secretNamespace: argocd
      secretsScope:
        envSlug: prod
        projectSlug: vixens
        secretsPath: /apps/20-media/radarr
  hostAPI: http://192.168.111.69:8085
  managedSecretReference:
    creationPolicy: Owner
    secretName: radarr-secrets
    secretNamespace: media
  resyncInterval: 60

Expected: Bronze tier passes after deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container initialization image to a pinned version for improved stability.
  * Enhanced production deployment configuration with improved environment isolation and secret management settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->