### PR TITLE
fix(radarr): change namespace to media

### DIFF
--- a/apps/20-media/radarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/radarr/overlays/prod/kustomization.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: radarr
+namespace: media
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Fix radarr namespace from radarr to media (matching ArgoCD application target)