### PR TITLE
fix(argocd): document repo-server resources requirement

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/patches/REPO-SERVER-RESOURCES.md
+++ b/apps/00-infra/argocd/overlays/prod/patches/REPO-SERVER-RESOURCES.md
@@ -1,0 +1,35 @@
+# ArgoCD Repository Server Resources
+
+## Problem
+ArgoCD repo-server crashes with `CrashLoopBackOff` due to insufficient resources.
+
+Kyverno policies enforce "micro" sizing (128Mi memory) which is insufficient for ArgoCD repo-server.
+
+## Solution Applied (Manual)
+Direct patch applied to cluster:
+```bash
+kubectl patch deployment argocd-repo-server -n argocd --patch-file repo-server-resources.yaml
+```
+
+## Required Resources
+```yaml
+spec:
+  template:
+    metadata:
+      labels:
+        vixens.io/sizing: "large"
+        vixens.io/priority: "critical"
+    spec:
+      containers:
+        - name: repo-server
+          resources:
+            limits:
+              cpu: "2"
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+```
+
+## Long-term Fix
+Update Terraform Helm release values for ArgoCD to include these resources.


### PR DESCRIPTION
## Summary
- Document the required resources for ArgoCD repo-server to fix CrashLoopBackOff
- Note: ArgoCD is managed by Terraform, so this is a documentation-only change
- The patch has been applied manually to the cluster

## Problem
- Kyverno enforces "micro" sizing (128Mi memory) which is insufficient
- ArgoCD repo-server crashes with liveness probe timeout

## Applied Fix (Manual)
```bash
kubectl patch deployment argocd-repo-server -n argocd --patch-file repo-server-resources.yaml
```

## Long-term
Update Terraform Helm release values for ArgoCD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation describing the ArgoCD repo-server resource sizing issue, the applied manual workaround to resolve CrashLoopBackOff errors, required resource configuration adjustments, and guidance for long-term fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->