### PR TITLE
feat(sonarr): add PodDisruptionBudget for Platinum tier

### DIFF
--- a/apps/20-media/sonarr/base/kustomization.yaml
+++ b/apps/20-media/sonarr/base/kustomization.yaml
@@ -1,10 +1,13 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 namespace: media
+
 resources:
   - deployment.yaml
   - service.yaml
   - pvc.yaml
+  - pdb.yaml
   - infisical-secret.yaml
   - litestream-config.yaml

--- a/apps/20-media/sonarr/base/pdb.yaml
+++ b/apps/20-media/sonarr/base/pdb.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: sonarr
+spec:
+  # minAvailable will be set by the poddisruptionbudget component
+  selector:
+    matchLabels:
+      app: sonarr

--- a/apps/20-media/sonarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/sonarr/overlays/prod/kustomization.yaml
@@ -12,6 +12,10 @@ components:
   - ../../../../_shared/components/base
   - ../../../../_shared/components/resources
   - ../../../../_shared/components/metrics
+  - ../../../../_shared/components/poddisruptionbudget/0
+  - ../../../../_shared/components/base
+  - ../../../../_shared/components/resources
+  - ../../../../_shared/components/metrics
 
 patches:
   - target:


### PR DESCRIPTION
## Summary

- Ajoute PDB (PodDisruptionBudget) à sonarr
- Sonarr passe de Gold à Platinum tier (ADR-022)

## Changes

- `apps/20-media/sonarr/base/pdb.yaml` - nouveau fichier PDB
- `apps/20-media/sonarr/base/kustomization.yaml` - ajout pdb.yaml aux resources
- `apps/20-media/sonarr/overlays/prod/kustomization.yaml` - ajout component poddisruptionbudget/0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured Sonarr service in the media namespace
  * Added Pod Disruption Budget resource configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->