### PR TITLE
feat(sonarr): add NetworkPolicy and securityContext for Diamond tier

### DIFF
--- a/apps/20-media/sonarr/base/deployment.yaml
+++ b/apps/20-media/sonarr/base/deployment.yaml
@@ -116,6 +116,12 @@ spec:
             limits:
               cpu: 1000m
               memory: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          env:
           env:
             - name: SONARR__API_KEY
               valueFrom:

--- a/apps/20-media/sonarr/base/kustomization.yaml
+++ b/apps/20-media/sonarr/base/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
   - service.yaml
   - pvc.yaml
   - pdb.yaml
+  - networkpolicy.yaml
   - infisical-secret.yaml
   - litestream-config.yaml

--- a/apps/20-media/sonarr/base/networkpolicy.yaml
+++ b/apps/20-media/sonarr/base/networkpolicy.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: sonarr
+spec:
+  podSelector:
+    matchLabels:
+      app: sonarr
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow ingress from Traefik (HTTP)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: traefik
+      ports:
+        - protocol: TCP
+          port: 8989
+  egress:
+    # Allow all egress (needed for API calls, updates, etc.)
+    - {}


### PR DESCRIPTION
## Summary

- Ajoute NetworkPolicy et securityContext durci à sonarr
- Sonarr passe de Emerald à Diamond tier (ADR-022)

## Changes

- `apps/20-media/sonarr/base/networkpolicy.yaml` - nouveau fichier NetworkPolicy
- `apps/20-media/sonarr/base/kustomization.yaml` - ajout networkpolicy.yaml
- `apps/20-media/sonarr/base/deployment.yaml` - ajout allowPrivilegeEscalation: false