### PR TITLE
fix(frigate): revert securityContext

### DIFF
--- a/apps/20-media/frigate/base/deployment.yaml
+++ b/apps/20-media/frigate/base/deployment.yaml
@@ -119,10 +119,6 @@ spec:
           image: ghcr.io/blakeblackshear/frigate:0.17.0-beta2
           securityContext:
             privileged: true
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
           ports:
             - containerPort: 5000
               name: http


### PR DESCRIPTION
Revert - can't have both privileged and allowPrivilegeEscalation false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Frigate container security and configuration settings in deployment specification. Reorganized port definitions and health check probes to align with standard container specification structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->