### PR TITLE
fix(frigate): run sidecars as root in prod

### DIFF
--- a/apps/20-media/frigate/overlays/prod/kustomization.yaml
+++ b/apps/20-media/frigate/overlays/prod/kustomization.yaml
@@ -50,10 +50,27 @@ patches:
               runAsNonRoot: false
               runAsUser: 0
               fsGroup: 0
+            initContainers:
+              - name: restore-config
+                securityContext:
+                  runAsUser: 0
+                  runAsGroup: 0
+              - name: validate-config
+                securityContext:
+                  runAsUser: 0
+                  runAsGroup: 0
             containers:
               - name: frigate
                 securityContext:
                   privileged: true
+                  runAsUser: 0
+                  runAsGroup: 0
+              - name: litestream
+                securityContext:
+                  runAsUser: 0
+                  runAsGroup: 0
+              - name: config-syncer
+                securityContext:
                   runAsUser: 0
                   runAsGroup: 0
   - path: pvc-patch.yaml


### PR DESCRIPTION
Frigate pod runs as root and writes to /config as root. The sidecars (rclone, litestream, config-syncer) need to run as root as well to be able to chtimes and modify these files.