### PR TITLE
fix(frigate): add sizing label for production

### DIFF
--- a/apps/20-media/frigate/overlays/prod/kustomization.yaml
+++ b/apps/20-media/frigate/overlays/prod/kustomization.yaml
@@ -43,6 +43,8 @@ patches:
       spec:
         template:
           metadata:
+            labels:
+              vixens.io/sizing: xlarge
             annotations:
               vixens.io/explicitly-allow-root: "true"
           spec:


### PR DESCRIPTION
Kyverno overrides resources to micro if sizing label is missing. Adding xlarge to match Frigate needs.