### PR TITLE
fix(frigate): use large sizing for production

### DIFF
--- a/apps/20-media/frigate/overlays/prod/kustomization.yaml
+++ b/apps/20-media/frigate/overlays/prod/kustomization.yaml
@@ -44,7 +44,7 @@ patches:
         template:
           metadata:
             labels:
-              vixens.io/sizing: xlarge
+              vixens.io/sizing: large
             annotations:
               vixens.io/explicitly-allow-root: "true"
           spec:


### PR DESCRIPTION
XLarge sizing was causing scheduling issues due to insufficient resources on poison/powder. Switching to Large to allow scheduling while still providing more than Micro.