### PR TITLE
fix(frigate): use custom sizing

### DIFF
--- a/apps/20-media/frigate/overlays/prod/kustomization.yaml
+++ b/apps/20-media/frigate/overlays/prod/kustomization.yaml
@@ -44,7 +44,7 @@ patches:
         template:
           metadata:
             labels:
-              vixens.io/sizing: large
+              vixens.io/sizing: custom
             annotations:
               vixens.io/explicitly-allow-root: "true"
           spec:

--- a/apps/20-media/frigate/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/frigate/overlays/prod/resources-patch.yaml
@@ -13,7 +13,7 @@ spec:
               cpu: 8000m
               memory: 8Gi
             requests:
-              cpu: 500m
+              cpu: 200m
               memory: 4Gi
         - name: litestream
           resources:


### PR DESCRIPTION
Setting sizing to 'custom' bypasses Kyverno resource mutation, allowing our Kustomize resources-patch.yaml to take effect.