### PR TITLE
feat(homeassistant): augmenter PVC à 250Gi en prod

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
@@ -26,6 +26,5 @@ patches:
       name: homeassistant-config
     patch: |
       - op: replace
-        path: /spec/resources/requests/storage
-        value: 150Gi
+        value: 250Gi
   - path: resources-patch.yaml


### PR DESCRIPTION
Extension du PVC homeassistant de 150Gi à 250Gi en production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased storage allocation capacity to 250Gi, providing additional space for system operations and data retention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->