### PR TITLE
fix(radarr): remove sizing component causing sync error

### DIFF
--- a/apps/20-media/radarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/radarr/overlays/prod/kustomization.yaml
@@ -13,7 +13,6 @@ components:
   - ../../../../_shared/components/resources
   - ../../../../_shared/components/metrics
   - ../../../../_shared/components/poddisruptionbudget/0
-  - ../../../../_shared/components/sizing/large
   - ../../../../_shared/components/priority/medium
   - ../../../../_shared/components/revision-history-limit
 


### PR DESCRIPTION
The sizing component with name: "*" causes invalid patch error. Radarr already has proper resources in base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Added medium-priority resource configuration to the production environment
  * Implemented revision history limits for improved resource management in production deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->