### PR TITLE
fix(music-assistant): correct slimproto redirection

### DIFF
--- a/apps/00-infra/traefik/values/common.yaml
+++ b/apps/00-infra/traefik/values/common.yaml
@@ -69,6 +69,16 @@ ports:
     exposedPort: 53
     expose: true
     protocol: UDP
+  slimproto-tcp: # MusicAssistant SlimProto TCP
+    port: 3483
+    exposedPort: 3483
+    expose: true
+    protocol: TCP
+  slimproto-udp: # MusicAssistant SlimProto UDP
+    port: 3483
+    exposedPort: 3483
+    expose: true
+    protocol: UDP
   frigate-api: # Frigate HTTP API (Home Assistant integration)
     port: 5000
     exposedPort: 5000

--- a/apps/20-media/music-assistant/base/deployment.yaml
+++ b/apps/20-media/music-assistant/base/deployment.yaml
@@ -29,6 +29,13 @@ spec:
           image: ghcr.io/music-assistant/server:2.8.0b9
           ports:
             - containerPort: 8095
+              name: web
+            - containerPort: 3483
+              name: slimproto-tcp
+              protocol: TCP
+            - containerPort: 3483
+              name: slimproto-udp
+              protocol: UDP
           env:
             - name: PUID
               value: "1000"

--- a/apps/20-media/music-assistant/base/ingressroute-slimproto.yaml
+++ b/apps/20-media/music-assistant/base/ingressroute-slimproto.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: music-assistant-slimproto-tcp
+  namespace: media
+spec:
+  entryPoints:
+    - slimproto-tcp
+  routes:
+    - match: HostSNI(`*`)
+      services:
+        - name: music-assistant
+          port: 3483
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteUDP
+metadata:
+  name: music-assistant-slimproto-udp
+  namespace: media
+spec:
+  entryPoints:
+    - slimproto-udp
+  routes:
+    - services:
+        - name: music-assistant
+          port: 3483

--- a/apps/20-media/music-assistant/base/kustomization.yaml
+++ b/apps/20-media/music-assistant/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - pvc.yaml
+  - ingressroute-slimproto.yaml

--- a/apps/20-media/music-assistant/base/service.yaml
+++ b/apps/20-media/music-assistant/base/service.yaml
@@ -7,6 +7,15 @@ spec:
   selector:
     app: music-assistant
   ports:
-    - protocol: TCP
+    - name: web
+      protocol: TCP
       port: 8095
       targetPort: 8095
+    - name: slimproto-tcp
+      protocol: TCP
+      port: 3483
+      targetPort: 3483
+    - name: slimproto-udp
+      protocol: UDP
+      port: 3483
+      targetPort: 3483

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -108,6 +108,7 @@ Last Updated: 2026-02-05 (Stabilization Milestone v3.1.536)
 | radarr | ⏳ | ✅ | Silver tier (2026-02-24)
 | sonarr | ⏳ | ✅ | Prod fixed 
 | prowlarr | ⏳ | ✅ | Prod fixed 
+| music-assistant | 💤 | ✅ | SlimProto 3483 redirected |
 | frigate | ✅ | ✅ | Elite Status + 50Gi PVC fixed |
 | jellyseerr | ⏳ | 💤 | Media request management (planned) |
 | hydrus-client | ✅ | ✅ | Elite Status + Authentik SSO |

--- a/docs/applications/20-media/music-assistant.md
+++ b/docs/applications/20-media/music-assistant.md
@@ -28,6 +28,7 @@ curl -L -k https://music-assistant.dev.truxonline.com | grep "Music Assistant"
 - **Namespace :** `media-stack`
 - **Dépendances :** `Home Assistant` (Optionnel mais recommandé)
 - **Particularités :** Agrégateur de sources musicales.
+- **Ports supplémentaires :** Le port 3483 (TCP/UDP) est redirigé via Traefik pour le protocole SlimProto (SlimServer).
 ---
 > ⚠️ **HIBERNATION DEV**
 > Cette application est désactivée dans l'environnement `dev` pour économiser les ressources.


### PR DESCRIPTION
Correction de la redirection SlimProto (port 3483) et de la génération des ressources IngressRouteTCP/UDP pour Music Assistant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SlimProto protocol support to Music Assistant, enabling SlimServer client connectivity on port 3483 (TCP/UDP).

* **Documentation**
  * Updated application documentation to reflect new SlimProto port routing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->