### PR TITLE
fix(homeassistant): fix OOM by adding sizing label

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: homeassistant
   labels:
     app: homeassistant
+    vixens.io/sizing: G-xl
   annotations:
     secret.reloader.stakater.com/reload: homeassistant-config
 spec:
@@ -19,6 +20,7 @@ spec:
     metadata:
       labels:
         app: homeassistant
+        vixens.io/sizing: G-xl
       annotations:
         reloader.stakater.com/auto: "true"
         prometheus.io/scrape: "true"


### PR DESCRIPTION
Home Assistant subissait des OOMKilled car le label vixens.io/sizing était manquant, ce qui déclenchait une mutation Kyverno 'micro' (128Mi).