### PR TITLE
fix(homeassistant): fix prod OOM by adding sizing to patch

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/resources-patch.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/resources-patch.yaml
@@ -3,8 +3,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: homeassistant
+  labels:
+    vixens.io/sizing: G-xl
 spec:
   template:
+    metadata:
+      labels:
+        vixens.io/sizing: G-xl
     spec:
       containers:
         - name: homeassistant


### PR DESCRIPTION
Le label vixens.io/sizing manquait dans l'overlay de production (resources-patch.yaml), causant des OOMKilled via la mutation Kyverno 'micro'.