### PR TITLE
fix(kyverno): limit sidecar resources to 'micro'

### DIFF
--- a/apps/00-infra/kyverno/base/policies/sizing-mutate.yaml
+++ b/apps/00-infra/kyverno/base/policies/sizing-mutate.yaml
@@ -137,6 +137,42 @@ spec:
                     cpu: "2000m"
                     memory: "4Gi"
 
+    # Rule 11: Sidecar sizing (Always micro)
+    - name: sidecar-resources
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      mutate:
+        patchStrategicMerge:
+          spec:
+            containers:
+              - (name): "litestream"
+                resources:
+                  requests:
+                    cpu: "10m"
+                    memory: "64Mi"
+                  limits:
+                    cpu: "100m"
+                    memory: "128Mi"
+              - (name): "config-syncer"
+                resources:
+                  requests:
+                    cpu: "10m"
+                    memory: "64Mi"
+                  limits:
+                    cpu: "100m"
+                    memory: "128Mi"
+              - (name): "node-agent"
+                resources:
+                  requests:
+                    cpu: "10m"
+                    memory: "64Mi"
+                  limits:
+                    cpu: "100m"
+                    memory: "128Mi"
+
     # Rule 5: XLarge sizing
     - name: xlarge-sizing
       match:


### PR DESCRIPTION
Correction de la politique de sizing pour isoler les sidecars (litestream, config-syncer). Cela réduit la consommation globale des pods multi-containers et permet la planification de Home Assistant.