### PR TITLE
fix(argocd): restore repo-server with correct probe config

### DIFF
--- a/apps/00-infra/argocd/base/deployments.yaml
+++ b/apps/00-infra/argocd/base/deployments.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: repo-server
+    app.kubernetes.io/name: argocd-repo-server
+    app.kubernetes.io/part-of: argocd
+    vixens.io/sizing: medium
+  name: argocd-repo-server
+  namespace: argocd
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-repo-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: argocd-repo-server
+        app.kubernetes.io/part-of: argocd
+        vixens.io/sizing: medium
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-repo-server
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - name: repo-server
+        image: quay.io/argoproj/argocd:v2.13.1
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8081
+        - containerPort: 8084
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 20
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 20
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 999
+      serviceAccountName: argocd-repo-server

--- a/apps/00-infra/argocd/base/kustomization.yaml
+++ b/apps/00-infra/argocd/base/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - argocd-install.yaml
+  - deployments.yaml


### PR DESCRIPTION
## Summary
- Restore deployments.yaml with correct image version v2.13.1
- Fix probes: use httpGet instead of tcpSocket (fixes validation error)
- This fixes the CrashLoopBackOff caused by version mismatch

ArgoCD is currently broken because:
1. The old deployments.yaml had wrong probe config (tcpSocket)
2. When ArgoCD synced, it failed with validation error
3. Resources got deleted and couldn't be recreated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Argo CD infrastructure deployment configuration with improved health monitoring, security controls, and pod scheduling resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->