### PR TITLE
feat(argocd): Prepare for v3.3 self-management

### DIFF
--- a/apps/00-infra/argocd/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/argocd/overlays/dev/kustomization.yaml
@@ -5,6 +5,7 @@ components:
   - ../../../../_shared/components/revision-history-limit
 patches:
   - path: patches/repo-server-resources.yaml
+  - path: patches/argocd-params.yaml
 resources:
   - ../../base
   - ingress.yaml

--- a/apps/00-infra/argocd/overlays/dev/patches/argocd-params.yaml
+++ b/apps/00-infra/argocd/overlays/dev/patches/argocd-params.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmd-params-cm
+data:
+  server.insecure: "true"
+  server.disable.auth: "true"


### PR DESCRIPTION
This PR prepares the `vixens` repository for the transition to a self-managed ArgoCD v3.3.0. It adds a Kustomize patch to ensure the `insecure` and `no-auth` settings are preserved during the bootstrap process initiated by Terraform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration to enable insecure server mode and disable authentication for deployment management system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->