### PR TITLE
fix: add whoami Application for dev overlay

### DIFF
--- a/argocd/overlays/dev/apps/whoami.yaml
+++ b/argocd/overlays/dev/apps/whoami.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: whoami
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: main
+    path: apps/99-test/whoami/overlays/dev
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: whoami
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary
Fixes the `ComparisonError` in the app-of-apps by creating the missing `whoami.yaml` Application manifest for the dev environment.

## Changes
- **Created:** `argocd/overlays/dev/apps/whoami.yaml`
  - Points to `apps/99-test/whoami/overlays/dev`
  - Uses `targetRevision: main` (dev branch)
  - Enables automated sync with prune and selfHeal
  - `CreateNamespace=true` for dev environment

## Problem Fixed
The `vixens-app-of-apps` Application was failing with:
```
Failed to load target state: ... lstat .../argocd/overlays/dev/apps/whoami.yaml: no such file or directory
```

The `kustomization.yaml` referenced `apps/whoami.yaml` but the file didn't exist in the dev overlay, while it existed in staging, test, and prod overlays.

## Testing
After merge, ArgoCD should automatically:
1. Sync the app-of-apps successfully
2. Deploy the whoami test application to the `whoami` namespace
3. Resolve the ComparisonError status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added deployment configuration for the whoami application in the dev environment with automated synchronization, self-healing, and automatic namespace provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->