### PR TITLE
fix(argocd): increase application-controller sizing from small to large

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
+++ b/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
@@ -30,10 +30,10 @@ kind: StatefulSet
 metadata:
   name: argocd-application-controller
   labels:
-    vixens.io/sizing: small
+    vixens.io/sizing: large
 spec:
   template:
     metadata:
       labels:
         app: argocd-application-controller
-        vixens.io/sizing: small
+        vixens.io/sizing: large


### PR DESCRIPTION
## Summary

- Increases ArgoCD application-controller sizing from `small` to `large` (128Mi → 4Gi memory limit)
- Resolves CrashLoopBackOff caused by OOMKilled (exit code 137) in production cluster

## Problem

The ArgoCD application-controller in production was experiencing continuous restarts due to Out of Memory errors. With 93 applications to manage, the controller was using `vixens.io/sizing: small` which provides only 128Mi memory limit.

The controller was being OOMKilled within 11 seconds of startup when attempting to reconcile all 93 applications.

## Solution

Changed `vixens.io/sizing` label from `small` to `large` which provides:
- CPU request: 1000m (1 core)
- Memory request: 4Gi
- CPU limit: 2000m (2 cores)
- Memory limit: 4Gi

## Files Changed

- `apps/00-infra/argocd/overlays/prod/resources-patch.yaml`: Updated sizing label for application-controller StatefulSet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application controller resource allocation from small to large for improved performance and stability in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->