### PR TITLE
fix(argocd): increase repo-server sizing to medium

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
+++ b/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
@@ -17,13 +17,13 @@ kind: Deployment
 metadata:
   name: argocd-repo-server
   labels:
-    vixens.io/sizing: small
+    vixens.io/sizing: medium
 spec:
   template:
     metadata:
       labels:
         app: argocd-repo-server
-        vixens.io/sizing: small
+        vixens.io/sizing: medium
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
Increase repo-server from small (512Mi) to medium (1Gi) to handle 94 applications without OOMKilled. Aligns with terravixens bootstrap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resource allocation configuration for services to better optimize performance and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->