### PR TITLE
fix(prod): add app labels for Kyverno sizing mutation

### DIFF
--- a/apps/20-media/amule/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/amule/overlays/prod/resources-patch.yaml
@@ -9,4 +9,5 @@ spec:
   template:
     metadata:
       labels:
+        app: amule
         vixens.io/sizing: small

--- a/apps/20-media/booklore/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/booklore/overlays/prod/resources-patch.yaml
@@ -9,4 +9,5 @@ spec:
   template:
     metadata:
       labels:
+        app: booklore
         vixens.io/sizing: medium

--- a/apps/20-media/prowlarr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/prowlarr/overlays/prod/resources-patch.yaml
@@ -9,4 +9,5 @@ spec:
   template:
     metadata:
       labels:
+        app: prowlarr
         vixens.io/sizing: medium

--- a/apps/20-media/radarr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/radarr/overlays/prod/resources-patch.yaml
@@ -9,4 +9,5 @@ spec:
   template:
     metadata:
       labels:
+        app: radarr
         vixens.io/sizing: medium

--- a/apps/20-media/whisparr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/whisparr/overlays/prod/resources-patch.yaml
@@ -9,4 +9,5 @@ spec:
   template:
     metadata:
       labels:
+        app: whisparr
         vixens.io/sizing: medium

--- a/apps/60-services/firefly-iii/overlays/prod/resources-patch.yaml
+++ b/apps/60-services/firefly-iii/overlays/prod/resources-patch.yaml
@@ -9,4 +9,5 @@ spec:
   template:
     metadata:
       labels:
+        app: firefly-iii
         vixens.io/sizing: medium

--- a/apps/60-services/openclaw/overlays/prod/resources-patch.yaml
+++ b/apps/60-services/openclaw/overlays/prod/resources-patch.yaml
@@ -9,4 +9,5 @@ spec:
   template:
     metadata:
       labels:
+        app: openclaw
         vixens.io/sizing: small

--- a/apps/70-tools/linkwarden/overlays/prod/resources-patch.yaml
+++ b/apps/70-tools/linkwarden/overlays/prod/resources-patch.yaml
@@ -9,4 +9,5 @@ spec:
   template:
     metadata:
       labels:
+        app: linkwarden
         vixens.io/sizing: medium

--- a/apps/70-tools/netbox/overlays/prod/resources-patch.yaml
+++ b/apps/70-tools/netbox/overlays/prod/resources-patch.yaml
@@ -9,4 +9,5 @@ spec:
   template:
     metadata:
       labels:
+        app: netbox
         vixens.io/sizing: medium

--- a/apps/70-tools/nocodb/overlays/prod/resources-patch.yaml
+++ b/apps/70-tools/nocodb/overlays/prod/resources-patch.yaml
@@ -9,4 +9,5 @@ spec:
   template:
     metadata:
       labels:
+        app: nocodb
         vixens.io/sizing: medium


### PR DESCRIPTION
Add missing `app:` labels required by Kyverno sizing-mutate policy.

Without these labels, Kyverno applies default micro sizing (128Mi) causing OOMKilled.

Fixes 10 applications from PR #1653.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized production deployments by adding application identification labels across all media, services, and tools applications for improved resource management, pod tracking, and operational observability. Services updated include amule, booklore, prowlarr, radarr, whisparr, firefly-iii, openclaw, linkwarden, netbox, and nocodb. These labels enable better identification and management of production workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->