### PR TITLE
fix(prod): convert to granular per-container sizing labels

### DIFF
--- a/apps/20-media/amule/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/amule/overlays/prod/resources-patch.yaml
@@ -4,10 +4,9 @@ kind: Deployment
 metadata:
   name: amule
   labels:
-    vixens.io/sizing: small
+    vixens.io/sizing.amule: small
 spec:
   template:
     metadata:
       labels:
-        app: amule
-        vixens.io/sizing: small
+        vixens.io/sizing.amule: small

--- a/apps/20-media/booklore/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/booklore/overlays/prod/resources-patch.yaml
@@ -4,10 +4,11 @@ kind: Deployment
 metadata:
   name: booklore
   labels:
-    vixens.io/sizing: medium
+    vixens.io/sizing.booklore: medium
+    vixens.io/sizing.config-syncer: small
 spec:
   template:
     metadata:
       labels:
-        app: booklore
-        vixens.io/sizing: medium
+        vixens.io/sizing.booklore: medium
+        vixens.io/sizing.config-syncer: small

--- a/apps/20-media/prowlarr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/prowlarr/overlays/prod/resources-patch.yaml
@@ -4,10 +4,13 @@ kind: Deployment
 metadata:
   name: prowlarr
   labels:
-    vixens.io/sizing: medium
+    vixens.io/sizing.prowlarr: medium
+    vixens.io/sizing.litestream: small
+    vixens.io/sizing.config-syncer: small
 spec:
   template:
     metadata:
       labels:
-        app: prowlarr
-        vixens.io/sizing: medium
+        vixens.io/sizing.prowlarr: medium
+        vixens.io/sizing.litestream: small
+        vixens.io/sizing.config-syncer: small

--- a/apps/20-media/radarr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/radarr/overlays/prod/resources-patch.yaml
@@ -4,10 +4,13 @@ kind: Deployment
 metadata:
   name: radarr
   labels:
-    vixens.io/sizing: medium
+    vixens.io/sizing.radarr: medium
+    vixens.io/sizing.litestream: small
+    vixens.io/sizing.config-syncer: small
 spec:
   template:
     metadata:
       labels:
-        app: radarr
-        vixens.io/sizing: medium
+        vixens.io/sizing.radarr: medium
+        vixens.io/sizing.litestream: small
+        vixens.io/sizing.config-syncer: small

--- a/apps/20-media/whisparr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/whisparr/overlays/prod/resources-patch.yaml
@@ -4,10 +4,13 @@ kind: Deployment
 metadata:
   name: whisparr
   labels:
-    vixens.io/sizing: medium
+    vixens.io/sizing.whisparr: medium
+    vixens.io/sizing.litestream: small
+    vixens.io/sizing.config-syncer: small
 spec:
   template:
     metadata:
       labels:
-        app: whisparr
-        vixens.io/sizing: medium
+        vixens.io/sizing.whisparr: medium
+        vixens.io/sizing.litestream: small
+        vixens.io/sizing.config-syncer: small

--- a/apps/60-services/firefly-iii/overlays/prod/resources-patch.yaml
+++ b/apps/60-services/firefly-iii/overlays/prod/resources-patch.yaml
@@ -4,10 +4,9 @@ kind: Deployment
 metadata:
   name: firefly-iii
   labels:
-    vixens.io/sizing: medium
+    vixens.io/sizing.firefly-iii: medium
 spec:
   template:
     metadata:
       labels:
-        app: firefly-iii
-        vixens.io/sizing: medium
+        vixens.io/sizing.firefly-iii: medium

--- a/apps/60-services/openclaw/overlays/prod/resources-patch.yaml
+++ b/apps/60-services/openclaw/overlays/prod/resources-patch.yaml
@@ -4,10 +4,11 @@ kind: Deployment
 metadata:
   name: openclaw
   labels:
-    vixens.io/sizing: small
+    vixens.io/sizing.openclaw: small
+    vixens.io/sizing.data-syncer: small
 spec:
   template:
     metadata:
       labels:
-        app: openclaw
-        vixens.io/sizing: small
+        vixens.io/sizing.openclaw: small
+        vixens.io/sizing.data-syncer: small

--- a/apps/70-tools/linkwarden/overlays/prod/resources-patch.yaml
+++ b/apps/70-tools/linkwarden/overlays/prod/resources-patch.yaml
@@ -4,10 +4,9 @@ kind: Deployment
 metadata:
   name: linkwarden
   labels:
-    vixens.io/sizing: medium
+    vixens.io/sizing.linkwarden: medium
 spec:
   template:
     metadata:
       labels:
-        app: linkwarden
-        vixens.io/sizing: medium
+        vixens.io/sizing.linkwarden: medium

--- a/apps/70-tools/netbox/overlays/prod/resources-patch.yaml
+++ b/apps/70-tools/netbox/overlays/prod/resources-patch.yaml
@@ -4,10 +4,9 @@ kind: Deployment
 metadata:
   name: netbox
   labels:
-    vixens.io/sizing: medium
+    vixens.io/sizing.netbox: medium
 spec:
   template:
     metadata:
       labels:
-        app: netbox
-        vixens.io/sizing: medium
+        vixens.io/sizing.netbox: medium

--- a/apps/70-tools/nocodb/overlays/prod/resources-patch.yaml
+++ b/apps/70-tools/nocodb/overlays/prod/resources-patch.yaml
@@ -4,10 +4,9 @@ kind: Deployment
 metadata:
   name: nocodb
   labels:
-    vixens.io/sizing: medium
+    vixens.io/sizing.nocodb: medium
 spec:
   template:
     metadata:
       labels:
-        app: nocodb
-        vixens.io/sizing: medium
+        vixens.io/sizing.nocodb: medium


### PR DESCRIPTION
Replace global sizing with granular per-container sizing for precise resource control.

**Problem:** Global sizing (`app + vixens.io/sizing`) only applies to containers matching the `app` label. Sidecars get default micro (128Mi).

**Solution:** Use granular labels: `vixens.io/sizing.<container-name>`

**Sizing assignments:**
- Main containers: medium (1Gi)
- Sidecars (litestream, config-syncer): small (512Mi)

Replaces PR #1655 approach with proper Kyverno granular method.