### PR TITLE
fix(prod): add resources-patch.yaml to kustomization patches

### DIFF
--- a/apps/20-media/amule/overlays/prod/kustomization.yaml
+++ b/apps/20-media/amule/overlays/prod/kustomization.yaml
@@ -11,3 +11,4 @@ labels:
       environment: prod
 patches:
   - path: patch-infisical-env.yaml
+  - path: resources-patch.yaml

--- a/apps/20-media/booklore/overlays/prod/kustomization.yaml
+++ b/apps/20-media/booklore/overlays/prod/kustomization.yaml
@@ -13,3 +13,4 @@ patches:
         path: /spec/authentication/universalAuth/secretsScope/envSlug
         value: prod
   - path: mariadb-resources-patch.yaml
+  - path: resources-patch.yaml

--- a/apps/20-media/prowlarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/prowlarr/overlays/prod/kustomization.yaml
@@ -29,3 +29,4 @@ patches:
       - op: replace
         path: /spec/authentication/universalAuth/secretsScope/envSlug
         value: prod
+  - path: resources-patch.yaml

--- a/apps/20-media/radarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/radarr/overlays/prod/kustomization.yaml
@@ -29,3 +29,4 @@ patches:
       - op: replace
         path: /spec/authentication/universalAuth/secretsScope/envSlug
         value: prod
+  - path: resources-patch.yaml

--- a/apps/20-media/whisparr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/whisparr/overlays/prod/kustomization.yaml
@@ -29,3 +29,4 @@ patches:
       - op: replace
         path: /spec/authentication/universalAuth/secretsScope/envSlug
         value: prod
+  - path: resources-patch.yaml

--- a/apps/60-services/firefly-iii/overlays/prod/kustomization.yaml
+++ b/apps/60-services/firefly-iii/overlays/prod/kustomization.yaml
@@ -3,8 +3,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - resources-patch.yaml
 patches:
+  - path: resources-patch.yaml
   - target:
       kind: InfisicalSecret
       name: firefly-iii-secrets-sync

--- a/apps/60-services/openclaw/overlays/prod/kustomization.yaml
+++ b/apps/60-services/openclaw/overlays/prod/kustomization.yaml
@@ -5,8 +5,8 @@ namespace: services
 resources:
   - ../../base
   - ingress.yaml
-  - resources-patch.yaml
 patches:
+  - path: resources-patch.yaml
   - target:
       kind: InfisicalSecret
       name: openclaw-secrets

--- a/apps/70-tools/linkwarden/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/linkwarden/overlays/prod/kustomization.yaml
@@ -6,6 +6,7 @@ labels:
       environment: prod
 patches:
   - path: patch-nextauth-url.yaml
+  - path: resources-patch.yaml
 resources:
   - ../../base
   - infisical-secret.yaml

--- a/apps/70-tools/netbox/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/netbox/overlays/prod/kustomization.yaml
@@ -6,6 +6,7 @@ patches:
     target:
       kind: Deployment
       name: netbox
+  - path: resources-patch.yaml
   - patch: |-
       - op: replace
         path: /spec/authentication/universalAuth/secretsScope/envSlug

--- a/apps/70-tools/nocodb/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/nocodb/overlays/prod/kustomization.yaml
@@ -4,8 +4,8 @@ kind: Kustomization
 namespace: tools
 resources:
   - ../../base
-  - resources-patch.yaml
 patches:
+  - path: resources-patch.yaml
   - target:
       kind: InfisicalSecret
       name: nocodb-secrets-sync


### PR DESCRIPTION
## Summary
- Fix missing resources-patch.yaml reference in kustomization.yaml files
- Move misplaced resources-patch.yaml from resources to patches section

## Problem
PR #1656 created resources-patch.yaml files with granular sizing labels (`vixens.io/sizing.<container-name>`), but these patches were never referenced in the kustomization.yaml files. As a result, ArgoCD applied manifests without the sizing labels, leaving containers with default (micro = 128Mi) sizing.

## Changes
### Added patches reference to:
- linkwarden, booklore, prowlarr, radarr, whisparr
- amule, netbox

### Moved from resources to patches:
- firefly-iii, openclaw, nocodb (already had resources-patch.yaml but in wrong section)

## Impact
After this PR merges and prod-stable tag is updated:
- ArgoCD will apply manifests with granular sizing labels
- Kyverno will mutate pods with correct per-container resources
- Main containers: 1Gi memory (medium)
- Sidecars: 512Mi memory (small)
- OOMKilled issues should be resolved

## Testing
Can verify kustomize build locally:
```bash
kustomize build apps/70-tools/linkwarden/overlays/prod | grep -A 5 "vixens.io/sizing"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production deployment configurations across multiple services to standardize resource management and patch application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->