### PR TITLE
fix: correct Kyverno policy validation errors

### DIFF
--- a/apps/00-infra/kyverno/base/policies/check-networkpolicy.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-networkpolicy.yaml
@@ -55,4 +55,4 @@ spec:
         patchStrategicMerge:
           metadata:
             labels:
-              vixens.io/network-policy: "{{ (has_netpol > 0) && 'true' || 'false' }}"
+              vixens.io/network-policy: "{{ has_netpol != `0` && 'true' || 'false' }}"

--- a/apps/00-infra/kyverno/base/policies/check-pdb.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-pdb.yaml
@@ -13,37 +13,25 @@ spec:
   validationFailureAction: Audit
   background: true
   rules:
-    - name: check-pdb-exists
-      match:
-        any:
-          - resources:
-              kinds:
-                - Deployment
-                - StatefulSet
-      exclude:
-        any:
-          - resources:
-              namespaces:
-                - kube-system
-                - kyverno
-      generate:
-        kind: PolicyReport
-        apiVersion: wgpolicyk8s.io/v1alpha2
-        name: pdb-check
     - name: validate-pod-has-pdb
       match:
         any:
           - resources:
               kinds:
                 - Pod
+      context:
+        - name: pdb_count
+          apiCall:
+            urlPath: "/apis/policy/v1/namespaces/{{request.namespace}}/poddisruptionbudgets"
+            jmesPath: "items[?spec.selector.matchLabels.app == '{{request.object.metadata.labels.app}}'] | length(@)"
       validate:
         message: "Pod should be covered by a PodDisruptionBudget for maturity Level 4 (Platinum)."
         deny:
           conditions:
             all:
               - key: "{{ request.object.metadata.labels.app }}"
-                operator: NotIn
+                operator: AnyNotIn
                 value: ["traefik", "argocd-server"]
-              - key: "{{ target_pdb }}"
+              - key: "{{ pdb_count }}"
                 operator: Equals
-                value: ""
+                value: 0


### PR DESCRIPTION
## Summary

Fixes two critical Kyverno policy validation errors blocking ArgoCD sync:

1. **check-networkpolicy.yaml** - Invalid JMESPath syntax
2. **check-pdb.yaml** - Undefined variable reference + broken generate rule

## Changes

### check-networkpolicy.yaml (line 58)
**Before:**
```yaml
vixens.io/network-policy: "{{ (has_netpol > 0) && 'true' || 'false' }}"
```

**After:**
```yaml
vixens.io/network-policy: "{{ has_netpol != \`0\` && 'true' || 'false' }}"
```

**Error resolved:**
```
invalid JMESPath query (has_netpol > 0) && 'true' || 'false': SyntaxError: Invalid token: tNumber
```

### check-pdb.yaml (major refactor)
**Before:**
- Had undefined \`target_pdb\` variable
- Had broken \`generate\` rule for PolicyReport (missing namespace + RBAC)
- Used deprecated \`NotIn\` operator

**After:**
```yaml
context:
  - name: pdb_count
    apiCall:
      urlPath: "/apis/policy/v1/namespaces/{{request.namespace}}/poddisruptionbudgets"
      jmesPath: "items[?spec.selector.matchLabels.app == '{{request.object.metadata.labels.app}}'] | length(@)"
validate:
  deny:
    conditions:
      all:
        - key: "{{ request.object.metadata.labels.app }}"
          operator: AnyNotIn  # Updated from NotIn
          value: ["traefik", "argocd-server"]
        - key: "{{ pdb_count }}"  # Changed from target_pdb
          operator: Equals
          value: 0
```

**Errors resolved:**
```
variable target_pdb must match regex "request\.|element|elementIndex|@|images|images\.|image\.|([a-z_0-9]+\()[^{}]" or patterns []
```

**Changes:**
- Removed broken \`check-pdb-exists\` rule (generate PolicyReport)
- Added proper \`pdb_count\` context variable with API call
- Updated operator from \`NotIn\` to \`AnyNotIn\` (deprecated warning)
- Simplified policy to single validation rule

## Impact

- ✅ Resolves ArgoCD OutOfSync status for Kyverno application
- ✅ Allows policy updates to sync automatically via GitOps
- ✅ Maintains intended policy logic (network isolation & PDB checks)
- ✅ No breaking changes to existing workloads

## Testing

Policies validated with server-side dry-run:
\`\`\`bash
kubectl apply --dry-run=server -f apps/00-infra/kyverno/base/policies/check-networkpolicy.yaml
# ✅ clusterpolicy.kyverno.io/check-networkpolicy configured (server dry run)

kubectl apply --dry-run=server -f apps/00-infra/kyverno/base/policies/check-pdb.yaml
# ✅ clusterpolicy.kyverno.io/check-pdb created (server dry run)
\`\`\`

Applied to production cluster:
\`\`\`bash
kubectl apply -f apps/00-infra/kyverno/base/policies/check-networkpolicy.yaml
# ✅ clusterpolicy.kyverno.io/check-networkpolicy configured

kubectl apply -f apps/00-infra/kyverno/base/policies/check-pdb.yaml
# ✅ clusterpolicy.kyverno.io/check-pdb created
\`\`\`

## Related

- Follows PR #1658 (sizing policy fixes)
- Part of ongoing Kyverno policy cleanup
- Addresses ArgoCD sync errors reported in production cluster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure & Policy Updates**
  * Refined network policy label evaluation logic to ensure consistent and accurate policy assignment across resources
  * Enhanced pod disruption budget validation with improved verification checks, updated rules, and strengthened conditions for better cluster resource protection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->