### PR TITLE
fix(adguard): allow Traefik to access port 3000 in NetworkPolicy

### DIFF
--- a/apps/40-network/adguard-home/base/networkpolicy.yaml
+++ b/apps/40-network/adguard-home/base/networkpolicy.yaml
@@ -10,19 +10,18 @@ spec:
     - Ingress
     - Egress
   ingress:
+    # Allow Traefik to access AdGuard web interface (port 3000) and DNS (port 53)
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: traefik
       ports:
         - protocol: TCP
-          port: 80
+          port: 3000  # AdGuard web interface
         - protocol: TCP
-          port: 443
-        - protocol: TCP
-          port: 53
+          port: 53    # DNS over TCP
         - protocol: UDP
-          port: 53
+          port: 53    # DNS over UDP
     - from:
         - namespaceSelector:
             matchLabels:


### PR DESCRIPTION
## Problem

AdGuard Home is unreachable via ingress (https://adguard.truxonline.com)

## Root Cause

Two issues were identified:

1. **Duplicate ingress in `default` namespace** - Manually deleted (emergency fix)
2. **NetworkPolicy blocking port 3000** - This PR fixes it via GitOps

The NetworkPolicy was allowing Traefik to connect on ports 80/443/53, but AdGuard's web interface runs on **port 3000**. Traefik ingress controller couldn't reach the backend.

## Changes

Updated `apps/40-network/adguard-home/base/networkpolicy.yaml`:

**Before:**
```yaml
- from:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: traefik
  ports:
    - protocol: TCP
      port: 80      # ❌ AdGuard doesn't listen on 80
    - protocol: TCP
      port: 443     # ❌ AdGuard doesn't listen on 443
    - protocol: TCP
      port: 53
    - protocol: UDP
      port: 53
```

**After:**
```yaml
# Allow Traefik to access AdGuard web interface (port 3000) and DNS (port 53)
- from:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: traefik
  ports:
    - protocol: TCP
      port: 3000  # ✅ AdGuard web interface
    - protocol: TCP
      port: 53    # DNS over TCP
    - protocol: UDP
      port: 53    # DNS over UDP
```

## Impact

- ✅ Traefik can reach AdGuard backend on port 3000
- ✅ AdGuard web interface accessible via https://adguard.truxonline.com
- ✅ DNS functionality preserved (port 53)
- ✅ No breaking changes

## Testing

After merge and ArgoCD sync, verify:
```bash
curl -I https://adguard.truxonline.com
# Should return HTTP 200 with AdGuard login page
```

## Note

A duplicate ingress in the `default` namespace was manually deleted as an emergency fix. This should be documented to prevent recurrence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated AdGuard Home web interface port from 80 to 3000. Users must access the interface via the new port.
  * Simplified network policy to explicitly enable DNS over both TCP and UDP on port 53.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->