### PR TITLE
hotfix: fix networkpolicy mutation for pods without app label

### DIFF
--- a/apps/00-infra/kyverno/base/policies/check-networkpolicy.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-networkpolicy.yaml
@@ -46,11 +46,16 @@ spec:
           - resources:
               kinds:
                 - Pod
+      preconditions:
+        all:
+          - key: "{{ request.object.metadata.labels.app || '' }}"
+            operator: NotEquals
+            value: ""
       context:
         - name: has_netpol
           apiCall:
             urlPath: "/apis/networking.k8s.io/v1/namespaces/{{request.namespace}}/networkpolicies"
-            jmesPath: "items[?spec.podSelector.matchLabels.app == '{{request.object.metadata.labels.app}}'] | length(@)"
+            jmesPath: "items[?spec.podSelector.matchLabels.app == '{{request.object.metadata.labels.app || 'NO_APP_LABEL'}}'] | length(@)"
       mutate:
         patchStrategicMerge:
           metadata:


### PR DESCRIPTION
## URGENT HOTFIX

Fixes critical bug that blocks Traefik pod creation.

## Problem
The  rule in check-networkpolicy.yaml was failing for pods without the  label, blocking pod creation with error:
```
JMESPath query failed: Unknown key "app" in path
```

This prevented Traefik from scaling up, making ArgoCD and all ingresses inaccessible.

## Solution
- Added precondition to only mutate pods with  label
- Fixed JMESPath to use fallback value when app label is missing

## Testing
✅ Manually applied to cluster - Traefik pods now create successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network policy validation by adding checks for non-empty pod app labels.
  * Enhanced policy evaluation with fallback label support for missing app labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->