### PR TITLE
fix(argocd): enable insecure mode for TLS termination at Traefik

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/argocd/overlays/prod/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 
 patches:
   - path: resources-patch.yaml
+  - path: patches/argocd-params.yaml
 
 components:
   - ../../../../_shared/components/revision-history-limit

--- a/apps/00-infra/argocd/overlays/prod/patches/argocd-params.yaml
+++ b/apps/00-infra/argocd/overlays/prod/patches/argocd-params.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmd-params-cm
+  namespace: argocd
+data:
+  # Run server without TLS - Traefik handles TLS termination
+  server.insecure: "true"


### PR DESCRIPTION
## Problem

ArgoCD was causing infinite redirect loops when accessed via https://argocd.truxonline.com

Error: "The page isn't redirecting properly"

## Root Cause

ArgoCD was trying to redirect HTTP to HTTPS, but Traefik already handles TLS termination. This created a redirect loop:
- User → HTTPS → Traefik (terminates TLS) → HTTP → ArgoCD
- ArgoCD sees HTTP → redirects to HTTPS → loop

## Solution

Added `server.insecure: "true"` to argocd-cmd-params-cm ConfigMap.

This tells ArgoCD to run in insecure mode (no TLS), trusting that Traefik handles TLS termination.

## Testing

✅ Manually patched configmap and restarted argocd-server
✅ ArgoCD now loads correctly without redirect loops
✅ HTML page loads successfully

## Files Changed

- `apps/00-infra/argocd/overlays/prod/patches/argocd-params.yaml` (new)
- `apps/00-infra/argocd/overlays/prod/kustomization.yaml` (added patch reference)
