### PR TITLE
fix(argocd): disable authentication for anonymous admin access

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/patches/argocd-params.yaml
+++ b/apps/00-infra/argocd/overlays/prod/patches/argocd-params.yaml
@@ -6,3 +6,5 @@ metadata:
 data:
   # Run server without TLS - Traefik handles TLS termination
   server.insecure: "true"
+  # Disable authentication for anonymous admin access
+  server.disable.auth: "true"


### PR DESCRIPTION
## Problem

ArgoCD in prod is asking for login/password, but should be anonymous like dev.

## Solution

Added `server.disable.auth: "true"` to match dev configuration.

This enables anonymous access with admin privileges.

## Reference

Dev config: `apps/00-infra/argocd/overlays/dev/patches/argocd-params.yaml`
