### PR TITLE
fix(postgresql-shared): add sizing label to prevent Kyverno 128Mi OOMKill

### DIFF
--- a/apps/04-databases/postgresql-shared/base/cluster.yaml
+++ b/apps/04-databases/postgresql-shared/base/cluster.yaml
@@ -6,10 +6,15 @@ metadata:
   namespace: databases
   annotations:
     argocd.argoproj.io/sync-wave: "2"
+  labels:
+    environment: prod
 spec:
   instances: 1 # Single instance in dev (scalable to 3 for HA in staging/prod)
   priorityClassName: vixens-critical
   imageName: ghcr.io/cloudnative-pg/postgresql:17.6-system-trixie
+  inheritedMetadata:
+    labels:
+      vixens.io/sizing.postgres: G-large  # 2Gi memory - prevents Kyverno 128Mi fallback OOMKill
   superuserSecret:
     name: postgresql-admin-credentials
   managed:


### PR DESCRIPTION
## Problem

After the prod incident (node `poison` reboot), `postgresql-shared-1` was repeatedly OOMKilled because Kyverno's `sizing-mutate` policy was overriding the memory resources.

**Root cause**: The CNPG Cluster spec defines `512Mi` in `spec.resources`, but Kyverno mutates the **pod** (not the CRD). Since the pod template had no `vixens.io/sizing.postgres` label, Kyverno applied the fallback: **128Mi limit** — causing OOMKill during WAL recovery.

## Fix

Add `spec.inheritedMetadata.labels` to the CNPG Cluster resource:
```yaml
inheritedMetadata:
  labels:
    vixens.io/sizing.postgres: G-large  # 2Gi memory
```

This propagates the label to all CNPG-managed pods, so Kyverno correctly sets 2Gi instead of 128Mi.

## Sizing class
- `G-large` = 2Gi memory request/limit, 1000m CPU limit (matches Kyverno policy definition)
- PostgreSQL with `shared_buffers: 512MB` needs at least 1Gi to operate normally under load

## Related
- Same pattern already applied to `loki` (PR #1664) and `booklore-mariadb` (PR #1664)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database cluster configuration to designate production environment settings
  * Added sizing specifications for PostgreSQL cluster performance optimization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->