### PR TITLE
fix(penpot): add sizing label G-xl to backend to prevent Kyverno 128Mi OOMKill

### DIFF
--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         app: penpot-backend
         component: backend
+        vixens.io/sizing.backend: G-xl  # Penpot JVM needs 4Gi - prevents Kyverno 128Mi OOMKill
     spec:
       priorityClassName: vixens-medium
       tolerations:


### PR DESCRIPTION
## Problem

Penpot backend (JVM/Clojure app) was in CrashLoop because Kyverno's `sizing-mutate` policy applied the 128Mi fallback memory limit — far too low for a JVM process.

**Symptom**: Exit code 143 (SIGTERM) — killed before JVM finished initializing.

## Fix

Add `vixens.io/sizing.backend: G-xl` (4Gi) to the pod template labels in `deployment-backend.yaml`.

This propagates through Kyverno's granular sizing mutation to set:
- Memory request: 4Gi
- Memory limit: 4Gi
- CPU limit: 2000m

## Context

Part of the post-incident recovery from the prod node reboot. Multiple apps were discovered to be missing sizing labels, causing Kyverno to apply 128Mi fallback (OOMKill).

Already fixed in this sprint:
- `loki`: `G-large` (PR #1664)
- `booklore-mariadb`: `G-medium` (PR #1664)
- `postgresql-shared`: `G-large` (PR #1665)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend deployment configuration labels for operational purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->