### PR TITLE
fix(kyverno/openclaw/prometheus/firefly-importer): OOMKill sizing fixes

### DIFF
--- a/apps/00-infra/kyverno/base/policies/sizing-mutate.yaml
+++ b/apps/00-infra/kyverno/base/policies/sizing-mutate.yaml
@@ -64,8 +64,8 @@ spec:
                   - (name): "{{ element.name }}"
                     resources:
                       requests:
-                        cpu: "{{ request.object.metadata.labels.\"vixens.io/sizing.{{element.name}}\" == 'small' && '50m' || '10m' }}"
-                        memory: "{{ request.object.metadata.labels.\"vixens.io/sizing.{{element.name}}\" == 'small' && '256Mi' || '64Mi' }}"
+                        cpu: "{{ request.object.metadata.labels.\"vixens.io/sizing.{{element.name}}\" == 'large' && '1000m' || request.object.metadata.labels.\"vixens.io/sizing.{{element.name}}\" == 'medium' && '200m' || request.object.metadata.labels.\"vixens.io/sizing.{{element.name}}\" == 'small' && '50m' || '10m' }}"
+                        memory: "{{ request.object.metadata.labels.\"vixens.io/sizing.{{element.name}}\" == 'large' && '2Gi' || request.object.metadata.labels.\"vixens.io/sizing.{{element.name}}\" == 'medium' && '512Mi' || request.object.metadata.labels.\"vixens.io/sizing.{{element.name}}\" == 'small' && '256Mi' || '64Mi' }}"
                       limits:
-                        cpu: "{{ request.object.metadata.labels.\"vixens.io/sizing.{{element.name}}\" == 'small' && '500m' || '100m' }}"
-                        memory: "{{ request.object.metadata.labels.\"vixens.io/sizing.{{element.name}}\" == 'small' && '512Mi' || '128Mi' }}"
+                        cpu: "{{ request.object.metadata.labels.\"vixens.io/sizing.{{element.name}}\" == 'large' && '2000m' || request.object.metadata.labels.\"vixens.io/sizing.{{element.name}}\" == 'medium' && '1000m' || request.object.metadata.labels.\"vixens.io/sizing.{{element.name}}\" == 'small' && '500m' || '100m' }}"
+                        memory: "{{ request.object.metadata.labels.\"vixens.io/sizing.{{element.name}}\" == 'large' && '4Gi' || request.object.metadata.labels.\"vixens.io/sizing.{{element.name}}\" == 'medium' && '1Gi' || request.object.metadata.labels.\"vixens.io/sizing.{{element.name}}\" == 'small' && '512Mi' || '128Mi' }}"

--- a/apps/02-monitoring/prometheus/base/values.yaml
+++ b/apps/02-monitoring/prometheus/base/values.yaml
@@ -4,6 +4,8 @@
 # Server configuration
 server:
   priorityClassName: vixens-critical
+  podLabels:
+    vixens.io/sizing.prometheus-server: "G-large"
   tolerations:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists

--- a/apps/60-services/firefly-iii-importer/base/deployment.yaml
+++ b/apps/60-services/firefly-iii-importer/base/deployment.yaml
@@ -11,6 +11,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: firefly-iii-importer
+        vixens.io/sizing.importer: "small"
     spec:
       priorityClassName: vixens-low
       containers:

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -19,6 +19,11 @@ spec:
       labels:
         app: openclaw
         vixens.io/sizing: "large"
+        vixens.io/sizing.install-tools: "large"
+        vixens.io/sizing.install-gemini-plugin: "medium"
+        vixens.io/sizing.install-gemini-cli: "medium"
+        vixens.io/sizing.restore-data: "small"
+        vixens.io/sizing.restore-config: "small"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "18789"


### PR DESCRIPTION
## Root Cause

Kyverno's \`sizing-mutate\` policy applies a **128Mi fallback** to any container/init-container without a sizing label. After the \`poison\` node reboot, three apps landed on nodes with fresh pod schedules and hit this Kyverno override:

## Fixes

### 1. \`kyverno/sizing-mutate\`: Extend init container policy

Init container rule was capped at \`small\` (512Mi). Extended to support \`medium\` (1Gi) and \`large\` (4Gi) tiers — same pattern as regular containers.

### 2. \`openclaw\`: Per-init-container sizing labels

The \`install-tools\` init container runs a full Debian apt-get + 8 CLI binary downloads (kubectl, rclone, argocd, talosctl, gh, mc, infisical, himalaya). It OOMKilled at 128Mi → needs \`large\` (4Gi).

| Init Container | Label | Memory |
|---|---|---|
| \`install-tools\` | \`large\` | 4Gi |
| \`install-gemini-plugin\` | \`medium\` | 1Gi |
| \`install-gemini-cli\` | \`medium\` | 1Gi |
| \`restore-data\` | \`small\` | 512Mi |
| \`restore-config\` | \`small\` | 512Mi |

### 3. \`prometheus\`: Add \`podLabels\` for server container

Kyverno was silently overriding the \`4Gi\` spec in \`values.yaml\` to \`128Mi\` → repeated OOMKills. Fix: add \`podLabels.vixens.io/sizing.prometheus-server: G-large\` (2Gi request, 2Gi limit).

### 4. \`firefly-iii-importer\`: Add sizing label

Kyverno was overriding the explicit \`512Mi\` resource spec to \`128Mi\` → CrashLoop. Fix: add \`vixens.io/sizing.importer: small\` (512Mi limit).

## Testing

- All files pass \`yamllint\` (warnings only, pre-existing)
- Kyverno policy syntax is additive — no breaking change to existing sizing labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced container resource sizing policy with expanded support for multiple size classifications and label variants
  * Applied sizing labels to Prometheus and application deployments for improved resource allocation management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->