### PR TITLE
fix(amule): correct InfisicalSecret managedSecretReference namespace

### DIFF
--- a/apps/20-media/amule/base/infisical-secret.yaml
+++ b/apps/20-media/amule/base/infisical-secret.yaml
@@ -18,4 +18,4 @@ spec:
   managedSecretReference:
     secretName: amule-secrets
     creationPolicy: Owner
-    secretNamespace: media
+    secretNamespace: downloads


### PR DESCRIPTION
## Problem

The `amule-secrets` InfisicalSecret CRD was deployed to the `downloads` namespace (where amule runs), but `managedSecretReference.secretNamespace` pointed to `media` — a different namespace.

Kubernetes disallows cross-namespace owner references, causing the Infisical operator to fail:

```
Error: failed to create managed secret [err=cross-namespace owner references are disallowed,
owner's namespace downloads, obj's namespace media]
```

As a result, no `amule-secrets` Kubernetes Secret was ever created, causing amule to enter `CreateContainerConfigError`.

## Fix

Change `secretNamespace: media` → `secretNamespace: downloads` in `base/infisical-secret.yaml`.