### PR TITLE
fix(amule): fix secretNamespace in prod overlay patch

### DIFF
--- a/apps/20-media/amule/overlays/prod/patch-infisical-env.yaml
+++ b/apps/20-media/amule/overlays/prod/patch-infisical-env.yaml
@@ -10,4 +10,4 @@ spec:
         envSlug: prod
         secretsPath: /apps/20-media/amule
   managedSecretReference:
-    secretNamespace: media
+    secretNamespace: downloads


### PR DESCRIPTION
The prod overlay patch `patch-infisical-env.yaml` was also setting `secretNamespace: media`, overriding the base fix from PR #1668. The overlay takes precedence in Kustomize, so the ArgoCD-rendered manifest still had `media` as the target namespace.

Fix: change `secretNamespace: media` → `secretNamespace: downloads` in the prod overlay patch.