### PR TITLE
fix(openclaw): add namespace to prod overlay resources-patch

### DIFF
--- a/apps/60-services/openclaw/overlays/prod/resources-patch.yaml
+++ b/apps/60-services/openclaw/overlays/prod/resources-patch.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: openclaw
+  namespace: services
   labels:
     vixens.io/sizing.openclaw: small
     vixens.io/sizing.data-syncer: small


### PR DESCRIPTION
The strategic merge patch in `overlays/prod/resources-patch.yaml` was missing `namespace: services`, causing kustomize build to fail:

```
no resource matches strategic merge patch "Deployment.v1.apps/openclaw.[noNs]";
failed to find unique target for patch Deployment.v1.apps/openclaw.[noNs]
```

This broke ArgoCD manifest generation for openclaw entirely, leaving it in `Unknown/Degraded` state. After the fix, `kustomize build` succeeds and all sizing labels (including the new init-container labels from PR #1667) render correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for services namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->