### PR TITLE
fix(media/tools/auth): batch fix for 8 degraded apps

### DIFF
--- a/apps/03-security/authentik/overlays/prod/worker-resources.yaml
+++ b/apps/03-security/authentik/overlays/prod/worker-resources.yaml
@@ -12,7 +12,7 @@ spec:
           resources:
             requests:
               cpu: 200m
-              memory: 512Mi
+              memory: 768Mi
             limits:
               cpu: 500m
-              memory: 1Gi
+              memory: 2Gi

--- a/apps/20-media/birdnet-go/overlays/prod/kustomization.yaml
+++ b/apps/20-media/birdnet-go/overlays/prod/kustomization.yaml
@@ -10,3 +10,4 @@ components:
   - ../../../../_shared/components/revision-history-limit
 
 patches:
+  - path: resources-patch.yaml

--- a/apps/20-media/birdnet-go/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/birdnet-go/overlays/prod/resources-patch.yaml
@@ -5,6 +5,11 @@ metadata:
   name: birdnet-go
 spec:
   template:
+    metadata:
+      labels:
+        vixens.io/sizing.birdnet-go: G-large
+        vixens.io/sizing.litestream: G-small
+        vixens.io/sizing.data-syncer: G-small
     spec:
       containers:
         - name: birdnet-go

--- a/apps/20-media/hydrus-client/overlays/prod/kustomization.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/kustomization.yaml
@@ -20,3 +20,4 @@ components:
   - ../../../../_shared/components/poddisruptionbudget/0
 
 patches:
+  - path: securitycontext-patch.yaml

--- a/apps/20-media/hydrus-client/overlays/prod/securitycontext-patch.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/securitycontext-patch.yaml
@@ -1,0 +1,17 @@
+---
+# Override _shared/components/base securityContext.
+# hydrus supervisord needs to write /opt/hydrus/supervisord.log which requires root or matching uid.
+# The hydrus image uses supervisord which expects to write to the install dir.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hydrus-client
+  namespace: media
+spec:
+  template:
+    spec:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: false
+        runAsUser: 0

--- a/apps/20-media/lidarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/lidarr/overlays/prod/kustomization.yaml
@@ -29,3 +29,4 @@ patches:
       - op: replace
         path: /spec/authentication/universalAuth/secretsScope/envSlug
         value: prod
+  - path: securitycontext-patch.yaml

--- a/apps/20-media/lidarr/overlays/prod/securitycontext-patch.yaml
+++ b/apps/20-media/lidarr/overlays/prod/securitycontext-patch.yaml
@@ -1,0 +1,16 @@
+---
+# Override _shared/components/base securityContext for s6-overlay images.
+# linuxserver images need to start as root (s6-overlay runs usermod before dropping to PUID).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lidarr
+  namespace: media
+spec:
+  template:
+    spec:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: false
+        runAsUser: 0

--- a/apps/20-media/music-assistant/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/music-assistant/overlays/prod/resources-patch.yaml
@@ -11,7 +11,7 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 322Mi
+              memory: 1Gi
             requests:
-              cpu: 11m
-              memory: 214Mi
+              cpu: 50m
+              memory: 256Mi

--- a/apps/20-media/mylar/overlays/prod/kustomization.yaml
+++ b/apps/20-media/mylar/overlays/prod/kustomization.yaml
@@ -29,3 +29,4 @@ patches:
       - op: replace
         path: /spec/authentication/universalAuth/secretsScope/envSlug
         value: prod
+  - path: securitycontext-patch.yaml

--- a/apps/20-media/mylar/overlays/prod/securitycontext-patch.yaml
+++ b/apps/20-media/mylar/overlays/prod/securitycontext-patch.yaml
@@ -1,0 +1,16 @@
+---
+# Override _shared/components/base securityContext for s6-overlay images.
+# linuxserver images need to start as root (s6-overlay runs usermod before dropping to PUID).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mylar
+  namespace: media
+spec:
+  template:
+    spec:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: false
+        runAsUser: 0

--- a/apps/20-media/whisparr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/whisparr/overlays/prod/kustomization.yaml
@@ -30,3 +30,4 @@ patches:
         path: /spec/authentication/universalAuth/secretsScope/envSlug
         value: prod
   - path: resources-patch.yaml
+  - path: securitycontext-patch.yaml

--- a/apps/20-media/whisparr/overlays/prod/securitycontext-patch.yaml
+++ b/apps/20-media/whisparr/overlays/prod/securitycontext-patch.yaml
@@ -1,0 +1,16 @@
+---
+# Override _shared/components/base securityContext for s6-overlay images.
+# hotio images need to start as root (s6-overlay runs usermod before dropping to PUID/PGID).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: whisparr
+  namespace: media
+spec:
+  template:
+    spec:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: false
+        runAsUser: 0

--- a/apps/70-tools/radar/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/radar/overlays/prod/kustomization.yaml
@@ -1,6 +1,9 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: tools
 resources:
   - ../../base
   - ingress.yaml
+patches:
+  - path: resources-patch.yaml

--- a/apps/70-tools/radar/overlays/prod/resources-patch.yaml
+++ b/apps/70-tools/radar/overlays/prod/resources-patch.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: radar
+  namespace: tools
+spec:
+  template:
+    metadata:
+      labels:
+        vixens.io/sizing.radar: small

--- a/apps/70-tools/stirling-pdf/base/values.yaml
+++ b/apps/70-tools/stirling-pdf/base/values.yaml
@@ -42,3 +42,6 @@ envs:
     value: /
   - name: SECURITY_ENABLELOGIN
     value: "false"
+podSecurityContext:
+  seccompProfile:
+    type: Unconfined


### PR DESCRIPTION
## Summary

Batch fixes for 8 Degraded ArgoCD apps after node reboot recovery.

### Root Causes & Fixes

| App | Root Cause | Fix |
|-----|-----------|-----|
| **whisparr** | `_shared/components/base` injects `runAsUser: 1000` + `runAsNonRoot: true` at pod level — hotio s6-overlay needs root to run `usermod` | Add securitycontext-patch.yaml: `runAsNonRoot: false`, `runAsUser: 0` |
| **mylar** | Same as whisparr (linuxserver image) | Same fix |
| **lidarr** | Same as whisparr (linuxserver image) | Same fix |
| **hydrus-client** | supervisord tries to write `/opt/hydrus/supervisord.log` — blocked by `runAsUser: 1000` from base component | Same securityContext fix |
| **birdnet-go** | Missing `vixens.io/sizing` label → Kyverno fallback overrides 1Gi limit to 128Mi (OOMKilled) | Add sizing labels to pod template (`G-large`/`G-small`) |
| **music-assistant** | OOMKilled with 322Mi limit | Increase memory limit to 1Gi |
| **authentik-worker** | OOMKilled with 1Gi limit | Increase memory limit to 2Gi, request to 768Mi |
| **stirling-pdf** | LibreOffice unoserver crashes — `seccompProfile: RuntimeDefault` blocks required syscalls | Add `podSecurityContext.seccompProfile.type: Unconfined` |
| **radar** | Missing `vixens.io/sizing` label → Kyverno fallback 128Mi | Add sizing label to prod overlay |

### Files Changed
- `apps/20-media/whisparr/overlays/prod/securitycontext-patch.yaml` (new)
- `apps/20-media/mylar/overlays/prod/securitycontext-patch.yaml` (new)
- `apps/20-media/lidarr/overlays/prod/securitycontext-patch.yaml` (new)
- `apps/20-media/hydrus-client/overlays/prod/securitycontext-patch.yaml` (new)
- `apps/20-media/birdnet-go/overlays/prod/resources-patch.yaml` (updated with sizing labels)
- `apps/20-media/music-assistant/overlays/prod/resources-patch.yaml` (1Gi limit)
- `apps/03-security/authentik/overlays/prod/worker-resources.yaml` (2Gi limit)
- `apps/70-tools/stirling-pdf/base/values.yaml` (seccompProfile: Unconfined)
- `apps/70-tools/radar/overlays/prod/{kustomization,resources-patch}.yaml` (sizing label)

### Validation
- `kustomize build` passes for all affected apps
- `yamllint` clean on all new/changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Increased memory allocation for authentik worker and music-assistant services to improve stability.
  * Applied security configuration updates across multiple media applications.
  * Added resource tracking and sizing labels to deployments for improved infrastructure management.
  * Updated CPU and memory resource requests for optimized performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->