### PR TITLE
fix(stirling-pdf): correct seccompProfile Unconfined for LibreOffice

### DIFF
--- a/apps/70-tools/stirling-pdf/base/values.yaml
+++ b/apps/70-tools/stirling-pdf/base/values.yaml
@@ -42,6 +42,8 @@ envs:
     value: /
   - name: SECURITY_ENABLELOGIN
     value: "false"
-podSecurityContext:
+securityContext:
+  enabled: true
+  fsGroup: 1000
   seccompProfile:
     type: Unconfined


### PR DESCRIPTION
Use chart-native `securityContext` key instead of `podSecurityContext` for the Unconfined seccomp profile. LibreOffice/unoserver requires syscalls blocked by the RuntimeDefault seccomp profile.