### PR TITLE
fix(authentik): add vixens.io/sizing labels to bypass Kyverno 128Mi OOMKill

### DIFF
--- a/apps/03-security/authentik/overlays/prod/server-resources.yaml
+++ b/apps/03-security/authentik/overlays/prod/server-resources.yaml
@@ -5,6 +5,10 @@ metadata:
   name: authentik-server
 spec:
   template:
+    metadata:
+      labels:
+        vixens.io/sizing.authentik-server: G-xl
+        vixens.io/sizing.config-syncer: G-small
     spec:
       priorityClassName: vixens-critical
       containers:

--- a/apps/03-security/authentik/overlays/prod/worker-resources.yaml
+++ b/apps/03-security/authentik/overlays/prod/worker-resources.yaml
@@ -5,6 +5,9 @@ metadata:
   name: authentik-worker
 spec:
   template:
+    metadata:
+      labels:
+        vixens.io/sizing.authentik-worker: G-large
     spec:
       priorityClassName: vixens-critical
       containers:


### PR DESCRIPTION
## Problem

Authentik server and worker are OOMKilling because Kyverno `sizing-mutate` policy overrides explicit resource limits to 128Mi when pod template is missing `vixens.io/sizing.*` labels.

- `authentik-server`: OOMKilled (needed 2Gi, got 128Mi from Kyverno)
- `authentik-worker`: CrashLoopBackOff OOMKilled (needed 2Gi, got 128Mi from Kyverno)

## Fix

Add sizing labels to pod template metadata in prod overlay patches:
- `vixens.io/sizing.authentik-server: G-xl` (2Gi/4Gi)
- `vixens.io/sizing.config-syncer: G-small` (128Mi sidecar)
- `vixens.io/sizing.authentik-worker: G-large` (2Gi/4Gi)

This allows Kyverno sizing-mutate to apply the correct tier instead of falling back to 128Mi.