### PR TITLE
fix(shared): correct priority class names (low/medium/high)

### DIFF
--- a/apps/_shared/components/priority/high/kustomization.yaml
+++ b/apps/_shared/components/priority/high/kustomization.yaml
@@ -21,5 +21,5 @@ patches:
       spec:
         template:
           spec:
-            priorityClassName: high-priority
+            priorityClassName: vixens-high
 

--- a/apps/_shared/components/priority/low/kustomization.yaml
+++ b/apps/_shared/components/priority/low/kustomization.yaml
@@ -21,5 +21,5 @@ patches:
       spec:
         template:
           spec:
-            priorityClassName: low-priority
+            priorityClassName: vixens-low
 

--- a/apps/_shared/components/priority/medium/kustomization.yaml
+++ b/apps/_shared/components/priority/medium/kustomization.yaml
@@ -21,5 +21,5 @@ patches:
       spec:
         template:
           spec:
-            priorityClassName: medium-priority
+            priorityClassName: vixens-medium
 


### PR DESCRIPTION
## Problem

Shared priority components reference non-existent PriorityClass names:
- `low-priority` → should be `vixens-low`
- `medium-priority` → should be `vixens-medium`  
- `high-priority` → should be `vixens-high`

This caused `whoami` Deployment to fail with:
```
pods "whoami-599d758ddf-" is forbidden: no PriorityClass with name low-priority was found
```

Leading to `ProgressDeadlineExceeded` and ArgoCD Degraded status.

## Fix

Correct all 3 shared priority components to use the actual cluster PriorityClass names (`vixens-*`).