### PR TITLE
fix(robusta): add vixens.io/sizing labels to prevent Kyverno 128Mi OOMKill

### DIFF
--- a/apps/02-monitoring/robusta/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/robusta/overlays/prod/kustomization.yaml
@@ -12,3 +12,5 @@ patches:
       - op: replace
         path: /spec/authentication/universalAuth/secretsScope/envSlug
         value: prod
+
+  - path: sizing-patch.yaml

--- a/apps/02-monitoring/robusta/overlays/prod/sizing-patch.yaml
+++ b/apps/02-monitoring/robusta/overlays/prod/sizing-patch.yaml
@@ -1,0 +1,24 @@
+---
+# Patch to add Kyverno sizing labels to robusta pod templates
+# Without these labels, Kyverno sizing-mutate overrides all resources to 128Mi
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: robusta-runner
+  namespace: robusta
+spec:
+  template:
+    metadata:
+      labels:
+        vixens.io/sizing.runner: G-large
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: robusta-forwarder
+  namespace: robusta
+spec:
+  template:
+    metadata:
+      labels:
+        vixens.io/sizing.kubewatch: G-medium


### PR DESCRIPTION
## Problem
Robusta runner, forwarder, and holmes pods are OOMKilling because Kyverno sizing-mutate overrides all resources to 128Mi when pod templates lack sizing labels.

- `robusta-runner`: needs 2Gi, Kyverno gives 128Mi → OOMKilled
- `robusta-forwarder`: needs 512Mi, Kyverno gives 128Mi → OOMKilled

## Fix
Add Kyverno sizing labels to pod templates via a Kustomize patch:
- `vixens.io/sizing.runner: G-large` (4Gi limit)
- `vixens.io/sizing.kubewatch: G-medium` (512Mi)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated production environment configuration to include explicit resource sizing specifications for monitoring infrastructure components to improve resource management.
* Applied sizing patches to deployment components to ensure consistent resource allocation, preventing automatic mutations that could negatively impact system performance.
* These infrastructure enhancements help maintain stable operations and enable predictable resource utilization patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->