### PR TITLE
fix(stirling-pdf): apply seccompProfile:Unconfined via Kustomize patch (correct approach)

### DIFF
--- a/apps/70-tools/stirling-pdf/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/stirling-pdf/overlays/prod/kustomization.yaml
@@ -9,5 +9,5 @@ resources:
 components:
   - ../../../../_shared/components/revision-history-limit
 
-# patches:
-#   - path: probes-patch.yaml # Disabled: blocks ingress generation as Deployment is managed by Helm app
+patches:
+  - path: seccomp-patch.yaml

--- a/apps/70-tools/stirling-pdf/overlays/prod/seccomp-patch.yaml
+++ b/apps/70-tools/stirling-pdf/overlays/prod/seccomp-patch.yaml
@@ -1,0 +1,19 @@
+---
+# Patch to set seccompProfile: Unconfined on stirling-pdf pod
+# Required because LibreOffice (unoserver) needs syscalls blocked by RuntimeDefault
+# The Helm chart (2.2.0) doesn't support seccompProfile in its securityContext values
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stirling-pdf-stirling-pdf-chart
+  namespace: tools
+spec:
+  template:
+    metadata:
+      labels:
+        vixens.io/sizing.stirling-pdf-chart: G-medium
+    spec:
+      securityContext:
+        fsGroup: 1000
+        seccompProfile:
+          type: Unconfined

--- a/argocd/overlays/prod/apps/stirling-pdf.yaml
+++ b/argocd/overlays/prod/apps/stirling-pdf.yaml
@@ -21,6 +21,9 @@ spec:
     - repoURL: https://github.com/charchess/vixens.git
       targetRevision: prod-stable
       ref: values
+    - repoURL: https://github.com/charchess/vixens.git
+      targetRevision: prod-stable
+      path: apps/70-tools/stirling-pdf/overlays/prod
   destination:
     server: https://kubernetes.default.svc
     namespace: tools


### PR DESCRIPTION
## Problem

Previous fix (PR #1672) tried to set `seccompProfile: Unconfined` via Helm values, but the chart (2.2.0) only maps `fsGroup/runAsNonRoot/supplementalGroups` in its pod securityContext template. The `seccompProfile` key is silently ignored.

LibreOffice/unoserver fails to start with `RuntimeDefault` seccomp because it uses restricted syscalls.

## Root cause

The `_shared/components/base` injects `seccompProfile: RuntimeDefault` via Kyverno mutate on all pods. For stirling-pdf, this blocks LibreOffice startup.

## Fix

1. Add a 3rd source to the ArgoCD app pointing to `apps/70-tools/stirling-pdf/overlays/prod`
2. The Kustomize overlay patch directly sets `seccompProfile: Unconfined` on the Deployment pod template (overriding the RuntimeDefault from shared component)
3. Also adds sizing label `vixens.io/sizing.stirling-pdf-chart: G-medium` to prevent Kyverno 128Mi override