### PR TITLE
fix(openclaw): increase sizing small→medium to prevent Node.js OOM

### DIFF
--- a/apps/60-services/openclaw/overlays/prod/resources-patch.yaml
+++ b/apps/60-services/openclaw/overlays/prod/resources-patch.yaml
@@ -5,11 +5,11 @@ metadata:
   name: openclaw
   namespace: services
   labels:
-    vixens.io/sizing.openclaw: small
+    vixens.io/sizing.openclaw: medium
     vixens.io/sizing.data-syncer: small
 spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.openclaw: small
+        vixens.io/sizing.openclaw: medium
         vixens.io/sizing.data-syncer: small


### PR DESCRIPTION
## Problem
openclaw-gateway CrashLoopBackOff with `FATAL ERROR: Reached heap limit - JavaScript heap out of memory` at 250MB usage. The Kyverno sizing label `small` caps memory at 512Mi which is insufficient.

## Fix
Increase `vixens.io/sizing.openclaw` from `small` (512Mi) to `medium` (1Gi) to give Node.js enough memory headroom.