### PR TITLE
fix(authentik): reduce server memory request 1Gi→512Mi for cluster schedulability

### DIFF
--- a/apps/03-security/authentik/overlays/prod/server-resources.yaml
+++ b/apps/03-security/authentik/overlays/prod/server-resources.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.authentik-server: G-xl
+        vixens.io/sizing.authentik-server: G-large
         vixens.io/sizing.config-syncer: G-small
     spec:
       priorityClassName: vixens-critical
@@ -15,8 +15,8 @@ spec:
         - name: authentik-server
           resources:
             requests:
-              cpu: 500m
-              memory: 1Gi
+              cpu: 200m
+              memory: 512Mi
             limits:
               cpu: 1000m
               memory: 2Gi


### PR DESCRIPTION
## Problem
Cluster worker nodes are at 96-98% memory utilization. `authentik-server` with 1Gi memory request cannot be scheduled:
```
0/5 nodes are available: 4 Insufficient cpu, 5 Insufficient memory
```

## Fix  
- Reduce memory request from 1Gi to 512Mi (keeping 2Gi limit for burst)
- Change sizing label from G-xl to G-large
- Reduce CPU request from 500m to 200m

The server can start with 512Mi and burst to 2Gi if needed.