### PR TITLE
fix(mealie/headlamp): add Kyverno sizing labels to prevent 128Mi OOMKill

### DIFF
--- a/apps/10-home/mealie/overlays/prod/resources-patch.yaml
+++ b/apps/10-home/mealie/overlays/prod/resources-patch.yaml
@@ -6,6 +6,11 @@ metadata:
   namespace: mealie
 spec:
   template:
+    metadata:
+      labels:
+        vixens.io/sizing.mealie: small
+        vixens.io/sizing.litestream: G-small
+        vixens.io/sizing.config-syncer: G-small
     spec:
       containers:
         - name: mealie

--- a/apps/70-tools/headlamp/overlays/prod/resources-patch.yaml
+++ b/apps/70-tools/headlamp/overlays/prod/resources-patch.yaml
@@ -5,6 +5,9 @@ metadata:
   name: headlamp
 spec:
   template:
+    metadata:
+      labels:
+        vixens.io/sizing.headlamp: G-small
     spec:
       containers:
         - name: headlamp


### PR DESCRIPTION
## Problem
- mealie: 3 containers (mealie, litestream, config-syncer) all at 128Mi → CrashLoopBackOff
- headlamp: pod at 128Mi limit

Missing `vixens.io/sizing.*` labels on pod templates → Kyverno sizing-mutate overrides.

## Fix
Add sizing labels to pod template metadata in prod overlays.