### PR TITLE
fix(argocd): reduce application-controller sizing large→G-large

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
+++ b/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
@@ -30,10 +30,10 @@ kind: StatefulSet
 metadata:
   name: argocd-application-controller
   labels:
-    vixens.io/sizing: large
+    vixens.io/sizing: G-large
 spec:
   template:
     metadata:
       labels:
         app: argocd-application-controller
-        vixens.io/sizing: large
+        vixens.io/sizing: G-large


### PR DESCRIPTION
## Problem

`argocd-application-controller-0` is **Pending** and unable to schedule.

Kyverno `sizing-mutate` policy with `large` tier forces `request=limit=4Gi`.
All nodes are at 97-98% memory — no room for a 4Gi request pod.

## Fix

Change sizing from `large` to `G-large`:
- `large`: 4Gi request = 4Gi limit → **unschedulable**
- `G-large`: 2Gi request = 2Gi limit → **schedulable**

This is the CRITICAL blocker preventing ArgoCD from functioning.