### PR TITLE
fix(sizing): add Kyverno sizing labels to music-assistant/sonarr/hydrus-client/docspell

### DIFF
--- a/apps/20-media/hydrus-client/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/resources-patch.yaml
@@ -3,15 +3,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hydrus-client
+  labels:
+    vixens.io/sizing: G-xl
 spec:
   template:
+    metadata:
+      labels:
+        vixens.io/sizing: G-xl
     spec:
       containers:
         - name: hydrus-client
           resources:
             limits:
               cpu: 1000m
-              memory: 2048Mi
+              memory: 4Gi
             requests:
-              cpu: 1000m
-              memory: 2048Mi
+              cpu: 100m
+              memory: 1Gi

--- a/apps/20-media/music-assistant/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/music-assistant/overlays/prod/resources-patch.yaml
@@ -3,8 +3,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: music-assistant
+  labels:
+    vixens.io/sizing: medium
 spec:
   template:
+    metadata:
+      labels:
+        vixens.io/sizing: medium
     spec:
       containers:
         - name: music-assistant

--- a/apps/20-media/sonarr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/sonarr/overlays/prod/resources-patch.yaml
@@ -3,8 +3,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sonarr
+  labels:
+    vixens.io/sizing: medium
 spec:
   template:
+    metadata:
+      labels:
+        vixens.io/sizing: medium
     spec:
       containers:
         - name: sonarr

--- a/apps/60-services/docspell/overlays/prod/patch-resources.yaml
+++ b/apps/60-services/docspell/overlays/prod/patch-resources.yaml
@@ -3,8 +3,13 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: docspell-joex
+  labels:
+    vixens.io/sizing: G-large
 spec:
   template:
+    metadata:
+      labels:
+        vixens.io/sizing: G-large
     spec:
       priorityClassName: vixens-medium
       containers:
@@ -21,8 +26,13 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: docspell-restserver
+  labels:
+    vixens.io/sizing: G-large
 spec:
   template:
+    metadata:
+      labels:
+        vixens.io/sizing: G-large
     spec:
       priorityClassName: vixens-medium
       containers:


### PR DESCRIPTION
## Problem

4 more apps OOMKilling due to Kyverno 128Mi fallback:

| App | Container | Issue |
|-----|-----------|-------|
| music-assistant | music-assistant | 128Mi → OOMKill (needs 1Gi) |
| sonarr | sonarr | 128Mi → OOMKill (needs 1Gi) |
| hydrus-client | hydrus-client | 128Mi → OOMKill (needs 4Gi, heavy desktop app) |
| docspell-joex | joex | 128Mi → OOMKill (JVM -Xmx1024m) |
| docspell-restserver | restserver | 128Mi → OOMKill (JVM -Xmx1024m) |

All had `resources:` patches but no `vixens.io/sizing` labels on pod templates.

## Fix

Add sizing labels to pod template metadata for all affected apps:
- music-assistant/sonarr: `medium`
- hydrus-client: `G-xl`
- docspell: `G-large`