### PR TITLE
fix(argocd): use container-specific sizing label for application-controller

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
+++ b/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
@@ -37,3 +37,4 @@ spec:
       labels:
         app: argocd-application-controller
         vixens.io/sizing: G-large
+        vixens.io/sizing.argocd-application-controller: G-large


### PR DESCRIPTION
## Problem

`argocd-application-controller-0` gets 128Mi from Kyverno despite `vixens.io/sizing: G-large` label.

Root cause: Kyverno sizing-mutate generic fallback only supports `large/medium/small` tiers when using `vixens.io/sizing` generic label. `G-*` tiers require container-specific label format: `vixens.io/sizing.{container-name}`.

## Fix

Add container-specific label: `vixens.io/sizing.argocd-application-controller: G-large`

This maps directly to the `vixens.io/sizing.{{element.name}}` JMESPath expression in Kyverno policy, ensuring 2Gi memory allocation.