### PR TITLE
fix(argocd): add Replace=true to priority-classes to fix app-of-apps OutOfSync

### DIFF
--- a/argocd/overlays/prod/apps/priority-classes.yaml
+++ b/argocd/overlays/prod/apps/priority-classes.yaml
@@ -21,3 +21,5 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    syncOptions:
+      - Replace=true


### PR DESCRIPTION
## Problem

`vixens-app-of-apps` is stuck OutOfSync with error:

```
error when patching: applications.argoproj.io "priority-classes" is invalid: 
metadata.resourceVersion: Invalid value: 0: must be specified for an update
```

ArgoCD tries to PATCH the `priority-classes` Application but the Kubernetes API
requires `resourceVersion` for PATCHes of existing resources.

## Fix

Add `syncOptions: [Replace=true]` to force `kubectl replace` instead of patch.
This bypasses the resourceVersion requirement.