### PR TITLE
fix(authentik): change sizing G-large→G-medium to fix Kyverno conflict and free CPU

### DIFF
--- a/apps/03-security/authentik/overlays/prod/server-resources.yaml
+++ b/apps/03-security/authentik/overlays/prod/server-resources.yaml
@@ -7,16 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.authentik-server: G-large
+        vixens.io/sizing.authentik-server: G-medium
         vixens.io/sizing.config-syncer: G-small
     spec:
       priorityClassName: vixens-critical
-      containers:
-        - name: authentik-server
-          resources:
-            requests:
-              cpu: 200m
-              memory: 512Mi
-            limits:
-              cpu: 1000m
-              memory: 2Gi

--- a/apps/03-security/authentik/overlays/prod/worker-resources.yaml
+++ b/apps/03-security/authentik/overlays/prod/worker-resources.yaml
@@ -7,15 +7,6 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.authentik-worker: G-large
+        vixens.io/sizing.authentik-worker: G-medium
     spec:
       priorityClassName: vixens-critical
-      containers:
-        - name: authentik-worker
-          resources:
-            requests:
-              cpu: 200m
-              memory: 768Mi
-            limits:
-              cpu: 500m
-              memory: 2Gi


### PR DESCRIPTION
## Problem

`authentik-server` and `authentik-worker` had `vixens.io/sizing.authentik-*: G-large` on the pod template labels **combined with** explicit resource blocks (cpu: 200m/memory: 512Mi request).

Kyverno `sizing-mutate` mutates pod resources based on the sizing label → overwrites explicit resources with G-large values (1000m CPU / 2Gi). ArgoCD sees drift (git has 200m/512Mi, cluster has 1000m/2Gi) → Degraded + OutOfSync.

Side effect: 2× authentik pods at 1000m CPU = 2000m on `powder`, which only has 3950m total → powder at 100% CPU → `synology-csi-controller` cannot schedule.

## Fix

- Remove explicit resource blocks from `server-resources.yaml` and `worker-resources.yaml`
- Change sizing label from `G-large` → `G-medium` (200m CPU / 512Mi memory)
- Kyverno applies consistently, ArgoCD sees no drift

## Result

- authentik Synced + no longer Degraded
- powder frees ~1600m CPU (from 100% to ~60%)
- synology-csi-controller can schedule on powder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Authentik service resource allocation configuration in the production environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->