### PR TITLE
fix(birdnet-go): fix resources-patch - remove dangling spec.template.spec

### DIFF
--- a/apps/20-media/birdnet-go/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/birdnet-go/overlays/prod/resources-patch.yaml
@@ -10,4 +10,3 @@ spec:
         vixens.io/sizing.birdnet-go: G-medium
         vixens.io/sizing.litestream: G-small
         vixens.io/sizing.data-syncer: G-small
-    spec:


### PR DESCRIPTION
## Problem

PR #1689 fixed the birdnet-go sizing (G-large → G-medium) but left a dangling `spec.template.spec:` line with no content. This made the Deployment patch invalid when applied by ArgoCD:

```
Deployment.apps "birdnet-go" is invalid: spec.template.spec.containers: Required value
```

## Fix

Remove the dangling `spec.template.spec:` key. The patch only needs to set pod template labels — Kyverno's `sizing-mutate` policy handles the actual resource allocation via those labels.

## Result

- `kustomize build` succeeds with all 3 containers present
- Sizing labels correctly on pod template:
  - `vixens.io/sizing.birdnet-go: G-medium` (512Mi/200m)
  - `vixens.io/sizing.litestream: G-small` (128Mi/50m)
  - `vixens.io/sizing.data-syncer: G-small` (128Mi/50m)
- ArgoCD sync will succeed, birdnet-go pods will restart with reduced memory
- phoebe will free ~1.5Gi, allowing synology-csi-node to schedule there