### PR TITLE
fix(lidarr): add sizing labels to fix OOMKill (128Mi Kyverno fallback)

### DIFF
--- a/apps/20-media/lidarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/lidarr/overlays/prod/kustomization.yaml
@@ -30,3 +30,4 @@ patches:
         path: /spec/authentication/universalAuth/secretsScope/envSlug
         value: prod
   - path: securitycontext-patch.yaml
+  - path: resources-patch.yaml

--- a/apps/20-media/lidarr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/lidarr/overlays/prod/resources-patch.yaml
@@ -3,15 +3,14 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: lidarr
+  labels:
+    vixens.io/sizing.lidarr: medium
+    vixens.io/sizing.litestream: small
+    vixens.io/sizing.config-syncer: small
 spec:
   template:
-    spec:
-      containers:
-        - name: lidarr
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 1Gi
-            requests:
-              cpu: 100m
-              memory: 256Mi
+    metadata:
+      labels:
+        vixens.io/sizing.lidarr: medium
+        vixens.io/sizing.litestream: small
+        vixens.io/sizing.config-syncer: small


### PR DESCRIPTION
## Problem

`resources-patch.yaml` existed in the lidarr prod overlay but was **not referenced** in `kustomization.yaml`. Without sizing labels on the pod template, Kyverno's `sizing-mutate` policy applied the 128Mi fallback, which OOMKilled lidarr (exit code 137).

## Fix

- Update `resources-patch.yaml` to use sizing labels (following the whisparr pattern):
  - `vixens.io/sizing.lidarr: medium` → 512Mi/1Gi, 200m/1CPU
  - `vixens.io/sizing.litestream: small`
  - `vixens.io/sizing.config-syncer: small`
- Reference `resources-patch.yaml` from `kustomization.yaml`

The explicit `resources:` block is removed (Kyverno manages this via sizing labels).