### PR TITLE
fix(stirling-pdf): fix podLabels placement and remove explicit resources to avoid Kyverno drift

### DIFF
--- a/apps/70-tools/stirling-pdf/base/values.yaml
+++ b/apps/70-tools/stirling-pdf/base/values.yaml
@@ -9,13 +9,7 @@ image:
   pullPolicy: IfNotPresent
   tag: 2.5.3
 replicaCount: 1
-resources:
-  requests:
-    cpu: 100m
-    memory: 1Gi
-  limits:
-    cpu: 2000m
-    memory: 1Gi
+# resources managed by Kyverno sizing (G-large tier)
 # Tolerations for control-plane nodes if needed
 tolerations:
   - key: node-role.kubernetes.io/control-plane
@@ -45,5 +39,5 @@ envs:
 securityContext:
   enabled: true
   fsGroup: 1000
-  podLabels:
+podLabels:
   vixens.io/sizing.stirling-pdf-chart: G-large


### PR DESCRIPTION
## Problem

`podLabels` was incorrectly nested under `securityContext` in `values.yaml`, with wrong indentation. This meant the Kyverno sizing label `vixens.io/sizing.stirling-pdf-chart: G-large` was never applied to pod templates, causing Kyverno to fall back to `micro` sizing (128Mi/100m) — way too small for a Java+LibreOffice app.

As a result, stirling-pdf pods crash immediately (OOMKill / CrashLoopBackOff).

## Fix

1. Move `podLabels` to the correct top-level position in `values.yaml`
2. Remove explicit `resources:` block to avoid Kyverno drift (Kyverno overwrites explicit resources when a sizing label is present → ArgoCD detects perpetual diff)

## Expected Result

- Kyverno applies G-large sizing: 4Gi/4Gi memory, 1000m/2000m CPU
- stirling-pdf pod starts successfully
- ArgoCD: stirling-pdf → Synced/Healthy