### PR TITLE
fix(kyverno): add Replace=true + extend ignoreDifferences to fix CRD too-large error

### DIFF
--- a/argocd/overlays/prod/apps/kyverno.yaml
+++ b/argocd/overlays/prod/apps/kyverno.yaml
@@ -133,6 +133,10 @@ spec:
         - /spec/rules/0/validate/allowExistingViolations
         - /spec/rules/1/skipBackgroundRequests
         - /spec/rules/1/validate/allowExistingViolations
+        - /spec/rules/2/skipBackgroundRequests
+        - /spec/rules/2/validate/allowExistingViolations
+        - /spec/rules/3/skipBackgroundRequests
+        - /spec/rules/3/validate/allowExistingViolations
   syncPolicy:
     automated:
       prune: true
@@ -140,6 +144,7 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+      - Replace=true
     retry:
       limit: 3
       backoff:


### PR DESCRIPTION
## Problem

ArgoCD kyverno app stuck OutOfSync with error:
```
CustomResourceDefinition.apiextensions.k8s.io "clusterpolicies.kyverno.io" is invalid:
metadata.annotations: Too long: may not be more than 262144 bytes
```

The kyverno CRDs are ~2.2MB — too large for standard `kubectl apply` annotation storage. Despite `ServerSideApply=true`, ArgoCD is failing to patch these CRDs.

Additionally, ClusterPolicies with Kyverno-injected fields (`skipBackgroundRequests`, `allowExistingViolations`) on rules 2 and 3 were not covered by `ignoreDifferences`, causing them to remain OutOfSync.

## Fix

1. Add `Replace=true` to syncOptions — ArgoCD uses `kubectl replace` which bypasses the annotation size limit for large CRDs
2. Extend `ignoreDifferences` to cover rules 0-3 (up from 0-1)

## Expected Result

- kyverno: Synced/Healthy
- vixens-app-of-apps: Synced/Healthy (cascading fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to refine synchronization settings for the Kyverno policy manager, including adjustments to difference detection and server-side apply behavior in the production environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->