### PR TITLE
fix(kyverno): use managedFieldsManagers to ignore all kyverno-defaulted fields

### DIFF
--- a/argocd/overlays/prod/apps/kyverno.yaml
+++ b/argocd/overlays/prod/apps/kyverno.yaml
@@ -125,18 +125,10 @@ spec:
   ignoreDifferences:
     - group: kyverno.io
       kind: ClusterPolicy
+      managedFieldsManagers:
+        - kyverno
       jsonPointers:
         - /status
-        - /spec/admission
-        - /spec/emitWarning
-        - /spec/rules/0/skipBackgroundRequests
-        - /spec/rules/0/validate/allowExistingViolations
-        - /spec/rules/1/skipBackgroundRequests
-        - /spec/rules/1/validate/allowExistingViolations
-        - /spec/rules/2/skipBackgroundRequests
-        - /spec/rules/2/validate/allowExistingViolations
-        - /spec/rules/3/skipBackgroundRequests
-        - /spec/rules/3/validate/allowExistingViolations
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Problem

ArgoCD kyverno ClusterPolicies remain OutOfSync even after `Replace=true` fix (#1695), because Kyverno's webhook mutates resources after ArgoCD applies them — adding fields like `method: GET`, `skipBackgroundRequests`, `allowExistingViolations`, etc. The previous `jsonPointers` list only covered a subset of defaulted fields.

## Fix

Replace the partial `jsonPointers` list with `managedFieldsManagers: [kyverno]` — this tells ArgoCD to ignore ALL fields managed by Kyverno's field manager, regardless of field path. The `/status` jsonPointer is kept as it covers non-managed-field status drift.

## Expected Result

- kyverno: Synced/Healthy (no more ClusterPolicy diff from Kyverno defaulting)
- vixens-app-of-apps: Synced/Healthy (cascading fix)