### PR TITLE
fix(kyverno): use jqPathExpressions to ignore kyverno-defaulted fields including apiCall.method

### DIFF
--- a/argocd/overlays/prod/apps/kyverno.yaml
+++ b/argocd/overlays/prod/apps/kyverno.yaml
@@ -125,8 +125,12 @@ spec:
   ignoreDifferences:
     - group: kyverno.io
       kind: ClusterPolicy
-      managedFieldsManagers:
-        - kyverno
+      jqPathExpressions:
+        - .spec.admission
+        - .spec.emitWarning
+        - .spec.rules[].skipBackgroundRequests
+        - ".spec.rules[].validate.allowExistingViolations"
+        - ".spec.rules[].context[].apiCall.method"
       jsonPointers:
         - /status
   syncPolicy:


### PR DESCRIPTION
## Problem

After #1695 (Replace=true) and #1696 (managedFieldsManagers), ClusterPolicies still show OutOfSync because:
1. `managedFieldsManagers` requires SSA managedFields tracking, which is lost when `Replace=true` is used
2. Kyverno injects additional fields beyond what was listed in `jsonPointers`: `context[].apiCall.method: GET`

## Fix

Replace `managedFieldsManagers` approach with `jqPathExpressions` — these work with array wildcards (`[]`) and cover all positions regardless of the number of rules/contexts:
- `.spec.admission`
- `.spec.emitWarning`
- `.spec.rules[].skipBackgroundRequests`
- `.spec.rules[].validate.allowExistingViolations`
- `.spec.rules[].context[].apiCall.method`

## Expected Result

- kyverno ClusterPolicies: Synced (no more diff from Kyverno defaulting)
- kyverno: Synced/Healthy
- vixens-app-of-apps: Synced/Healthy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined Kyverno policy configuration management in production by updating how configuration differences are tracked, improving system maintainability while preserving all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->