### PR TITLE
fix(kyverno): add foreach context apiCall.method to ignoreDifferences

### DIFF
--- a/argocd/overlays/prod/apps/kyverno.yaml
+++ b/argocd/overlays/prod/apps/kyverno.yaml
@@ -131,6 +131,7 @@ spec:
         - .spec.rules[].skipBackgroundRequests
         - ".spec.rules[].validate.allowExistingViolations"
         - ".spec.rules[].context[].apiCall.method"
+        - ".spec.rules[].validate.foreach[].context[].apiCall.method"
       jsonPointers:
         - /status
   syncPolicy:


### PR DESCRIPTION
## Problem

`check-infisical-secrets` ClusterPolicy has a `validate.foreach[].context[].apiCall.method: GET` field defaulted by Kyverno, but this path wasn't covered by the jqPathExpressions added in #1697 (only `rules[].context[]` was covered, not `rules[].validate.foreach[].context[]`).

## Fix

Add `.spec.rules[].validate.foreach[].context[].apiCall.method` to jqPathExpressions.

## Expected Result

kyverno: Synced/Healthy, vixens-app-of-apps: Synced/Healthy