### PR TITLE
fix(sizing): reduce stirling-pdf G-large→medium, robusta-runner G-large→small

### DIFF
--- a/apps/02-monitoring/robusta/overlays/prod/values.yaml
+++ b/apps/02-monitoring/robusta/overlays/prod/values.yaml
@@ -21,15 +21,9 @@ sinksConfig:
       url: "{{ env.DISCORD_WEBHOOK_URL }}"
 
 runner:
-  resources:
-    requests:
-      cpu: 250m
-      memory: 2Gi
-    limits:
-      cpu: 500m
-      memory: 2Gi
+  # resources managed by Kyverno sizing (small tier: 512Mi/512Mi)
   labels:
-    vixens.io/sizing.runner: G-large
+    vixens.io/sizing.runner: small
   sendAdditionalTelemetry: true
   additional_env_froms:
     - secretRef:

--- a/apps/70-tools/stirling-pdf/base/values.yaml
+++ b/apps/70-tools/stirling-pdf/base/values.yaml
@@ -9,7 +9,7 @@ image:
   pullPolicy: IfNotPresent
   tag: 2.5.3
 replicaCount: 1
-# resources managed by Kyverno sizing (G-large tier)
+# resources managed by Kyverno sizing (medium tier: 512Mi request/1Gi limit)
 # Tolerations for control-plane nodes if needed
 tolerations:
   - key: node-role.kubernetes.io/control-plane
@@ -40,4 +40,4 @@ securityContext:
   enabled: true
   fsGroup: 1000
 podLabels:
-  vixens.io/sizing.stirling-pdf-chart: G-large
+  vixens.io/sizing.stirling-pdf-chart: medium


### PR DESCRIPTION
## Problem

Both `stirling-pdf` and `robusta-runner` pods are stuck Pending because Kyverno's `G-large` sizing (2Gi request = 2Gi limit) cannot be scheduled on the cluster — all nodes are request-saturated (workers: 93-99%, CP nodes: 82-99%).

**Root cause analysis:**
- robusta-runner actual usage: **124Mi** — G-large (2Gi request) is ~16x overprovisioned
- stirling-pdf (Java+LibreOffice): needs a limit, but request can be smaller

## Fix

1. **stirling-pdf**: `G-large` → `medium` (512Mi request / 1Gi limit, 200m/1000m CPU)
   - 512Mi request is schedulable on current cluster
   - 1Gi limit gives LibreOffice room to breathe
   
2. **robusta-runner**: `G-large` → `small` (512Mi/512Mi, 50m/500m CPU)
   - 512Mi is 4x actual usage — safe buffer
   - Equal request=limit (Guaranteed QoS) prevents OOMKill

## Expected Result

- Both pods schedule on existing nodes
- stirling-pdf: Synced/Healthy
- robusta: Synced/Healthy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resource allocation configuration for monitoring and PDF processing services
  * Simplified resource management through automated sizing controls
  * Optimized pod sizing tier labels for improved resource efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->