### PR TITLE
fix(robusta): change runner sizing small→G-small (128Mi) matching 124Mi actual usage

### DIFF
--- a/apps/02-monitoring/robusta/overlays/prod/values.yaml
+++ b/apps/02-monitoring/robusta/overlays/prod/values.yaml
@@ -21,9 +21,9 @@ sinksConfig:
       url: "{{ env.DISCORD_WEBHOOK_URL }}"
 
 runner:
-  # resources managed by Kyverno sizing (small tier: 512Mi/512Mi)
+  # resources managed by Kyverno sizing (G-small tier: 128Mi/128Mi - matches actual 124Mi usage)
   labels:
-    vixens.io/sizing.runner: small
+    vixens.io/sizing.runner: G-small
   sendAdditionalTelemetry: true
   additional_env_froms:
     - secretRef:


### PR DESCRIPTION
## Problem

robusta-runner with `small` (512Mi request) still cannot schedule on workers due to memory pressure. Workers have only ~700Mi free in requests.

Actual observed usage: **124Mi** (stable for 6+ hours at micro/128Mi sizing).

## Fix

Change `small` → `G-small` (128Mi/128Mi Guaranteed QoS) which:
- Matches actual usage (124Mi)
- Has 4Mi headroom before OOM
- Will schedule on workers (128Mi << 700Mi free)

This is consistent with the old micro-sized pod that has been running stably.

## Expected Result

robusta-runner: schedules and starts, robusta: Synced/Healthy