### PR TITLE
fix(sizing): replace generic sizing labels with per-container labels (hydrus, docspell, frigate, authentik)

### DIFF
--- a/apps/03-security/authentik/overlays/prod/worker-resources.yaml
+++ b/apps/03-security/authentik/overlays/prod/worker-resources.yaml
@@ -7,6 +7,6 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.authentik-worker: G-medium
+        vixens.io/sizing.authentik-worker: G-large
     spec:
       priorityClassName: vixens-critical

--- a/apps/20-media/frigate/overlays/prod/kustomization.yaml
+++ b/apps/20-media/frigate/overlays/prod/kustomization.yaml
@@ -44,7 +44,9 @@ patches:
         template:
           metadata:
             labels:
-              vixens.io/sizing: custom
+              vixens.io/sizing.frigate: G-xl
+              vixens.io/sizing.litestream: micro
+              vixens.io/sizing.config-syncer: micro
             annotations:
               vixens.io/explicitly-allow-root: "true"
           spec:
@@ -76,4 +78,3 @@ patches:
                   runAsUser: 0
                   runAsGroup: 0
   - path: pvc-patch.yaml
-  - path: resources-patch.yaml

--- a/apps/20-media/hydrus-client/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/resources-patch.yaml
@@ -3,20 +3,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hydrus-client
-  labels:
-    vixens.io/sizing: G-xl
 spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing: G-xl
-    spec:
-      containers:
-        - name: hydrus-client
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 4Gi
-            requests:
-              cpu: 100m
-              memory: 1Gi
+        vixens.io/sizing.hydrus-client: G-xl
+        vixens.io/sizing.litestream: micro

--- a/apps/60-services/docspell/overlays/prod/patch-resources.yaml
+++ b/apps/60-services/docspell/overlays/prod/patch-resources.yaml
@@ -3,44 +3,22 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: docspell-joex
-  labels:
-    vixens.io/sizing: G-large
 spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing: G-large
+        vixens.io/sizing.joex: G-large
     spec:
       priorityClassName: vixens-medium
-      containers:
-        - name: joex
-          resources:
-            requests:
-              cpu: 200m
-              memory: 1Gi
-            limits:
-              cpu: 1000m
-              memory: 2Gi
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: docspell-restserver
-  labels:
-    vixens.io/sizing: G-large
 spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing: G-large
+        vixens.io/sizing.restserver: G-large
     spec:
       priorityClassName: vixens-medium
-      containers:
-        - name: restserver
-          resources:
-            requests:
-              cpu: 200m
-              memory: 1Gi
-            limits:
-              cpu: 1000m
-              memory: 2Gi


### PR DESCRIPTION
## Problem

Kyverno `sizing-mutate` policy reads `vixens.io/sizing.<container-name>` labels only. When pods use the generic `vixens.io/sizing: <tier>` label without a container name, Kyverno cannot match and falls back to **micro (128Mi)** — overwriting any explicit resources in manifests.

This caused OOMKills on multiple apps after the cluster reboot (all apps starting simultaneously, sizing errors exposed under load).

## Changes

| App | Was | Fix |
|-----|-----|-----|
| `hydrus-client` | `vixens.io/sizing: G-xl` → 128Mi OOMKill | `vixens.io/sizing.hydrus-client: G-xl` + `vixens.io/sizing.litestream: micro` |
| `docspell-restserver` | `vixens.io/sizing: G-large` → 128Mi OOMKill | `vixens.io/sizing.restserver: G-large` |
| `docspell-joex` | `vixens.io/sizing: G-large` → 128Mi OOMKill | `vixens.io/sizing.joex: G-large` |
| `frigate` | `vixens.io/sizing: custom` → 128Mi fallback | `vixens.io/sizing.frigate: G-xl` + per-container labels; removed `resources-patch.yaml` (Kyverno manages resources) |
| `authentik-worker` | `vixens.io/sizing.authentik-worker: G-medium` (512Mi) → OOMKill | Bumped to `G-large` (2Gi) |

## Testing

All `kustomize build overlays/prod` succeed. Cluster fix verified after prod-stable promotion.