### PR TITLE
fix(firefly-iii): add health-bump annotation to clear stale Degraded health in ArgoCD

### DIFF
--- a/apps/60-services/firefly-iii/base/deployment.yaml
+++ b/apps/60-services/firefly-iii/base/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/name: firefly-iii
       annotations:
         reloader.stakater.com/auto: "true"
+        vixens.io/health-bump: "1"
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
         prometheus.io/path: "/metrics"


### PR DESCRIPTION
## Problem

ArgoCD v3.3.0 bug: `firefly-iii` app health is stuck at **Degraded** even though:
- All pods Running (1/1)
- Deployment Available=True, Progressing=True
- All ArgoCD resources show Synced with no health message
- Hard refresh + force sync do not resolve it

This is a known ArgoCD health cache issue where the status got set to Degraded during
a rollout and was never re-evaluated once the rollout completed.

## Fix

Adding a `vixens.io/health-bump: "1"` annotation to the pod template forces a new
deployment generation, triggering a fresh pod rollout → ArgoCD evaluates health
as Healthy once the new pods come up healthy.

## Impact

- 1 pod restart (Recreate strategy)
- ~30-60s downtime for firefly-iii
- App transitions: Degraded → Progressing → Healthy