### PR TITLE
fix(sizing): right-size tiers based on VPA recommendations

### DIFF
--- a/apps/03-security/authentik/overlays/prod/worker-resources.yaml
+++ b/apps/03-security/authentik/overlays/prod/worker-resources.yaml
@@ -7,6 +7,6 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.authentik-worker: G-large
+        vixens.io/sizing.authentik-worker: G-controller
     spec:
       priorityClassName: vixens-critical

--- a/apps/20-media/hydrus-client/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/resources-patch.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.hydrus-client: G-xl
+        vixens.io/sizing.hydrus-client: small
         vixens.io/sizing.litestream: micro

--- a/apps/60-services/docspell/overlays/prod/patch-resources.yaml
+++ b/apps/60-services/docspell/overlays/prod/patch-resources.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.joex: G-large
+        vixens.io/sizing.joex: medium
     spec:
       priorityClassName: vixens-medium
 ---
@@ -19,6 +19,6 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.restserver: G-large
+        vixens.io/sizing.restserver: small
     spec:
       priorityClassName: vixens-medium


### PR DESCRIPTION
## Problem

After PR #1701 fixed label format issues, newly scheduled pods are **Pending** due to insufficient cluster memory. Workers (peach/pearl) are at 95-97% memory requests post-reboot.

## Changes based on Goldilocks VPA data

| App | Old tier | Actual usage | New tier |
|-----|----------|-------------|----------|
| hydrus-client | G-xl (4Gi, 2 CPU req) | 300Mi | small (512Mi) |
| docspell-restserver | G-large (2Gi) | 476Mi | small (512Mi) |
| docspell-joex | G-large (2Gi) | 672Mi | medium (512Mi req / 1Gi limit) |
| authentik-worker | G-large (2Gi) | 1.7Gi | G-controller (2Gi, 500m CPU) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resource allocation configurations for backend services (Authentik, Hydrus Client, and Docspell) to optimize infrastructure performance and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->