### PR TITLE
fix(sizing): fix generic sizing labels causing OOMKills (sonarr, music-assistant, openclaw)

### DIFF
--- a/apps/20-media/music-assistant/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/music-assistant/overlays/prod/resources-patch.yaml
@@ -3,20 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: music-assistant
-  labels:
-    vixens.io/sizing: medium
 spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing: medium
-    spec:
-      containers:
-        - name: music-assistant
-          resources:
-            limits:
-              cpu: 500m
-              memory: 1Gi
-            requests:
-              cpu: 50m
-              memory: 256Mi
+        vixens.io/sizing.music-assistant: small

--- a/apps/20-media/sonarr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/sonarr/overlays/prod/resources-patch.yaml
@@ -3,20 +3,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sonarr
-  labels:
-    vixens.io/sizing: medium
 spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing: medium
-    spec:
-      containers:
-        - name: sonarr
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 1Gi
-            requests:
-              cpu: 100m
-              memory: 256Mi
+        vixens.io/sizing.sonarr: small
+        vixens.io/sizing.litestream: micro
+        vixens.io/sizing.config-syncer: micro

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -24,6 +24,8 @@ spec:
         vixens.io/sizing.install-gemini-cli: "medium"
         vixens.io/sizing.restore-data: "small"
         vixens.io/sizing.restore-config: "small"
+        vixens.io/sizing.openclaw: G-controller
+        vixens.io/sizing.data-syncer: small
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "18789"


### PR DESCRIPTION
## Problem

Multiple apps OOMKilling due to generic `vixens.io/sizing: <tier>` labels — Kyverno falls back to micro (128Mi) for containers when no per-container label matches.

## Changes

| App | Container | Was | Fix | VPA actual |
|-----|-----------|-----|-----|------------|
| sonarr | sonarr | generic medium → 128Mi | small (512Mi) | 300Mi |
| sonarr | litestream | generic medium → 128Mi | micro (128Mi) | 110Mi |
| sonarr | config-syncer | generic medium → 128Mi | micro (128Mi) | 45Mi |
| music-assistant | music-assistant | generic medium → 128Mi | small (512Mi) | 380Mi |
| openclaw | openclaw | medium (512Mi) | G-controller (2Gi) | 1.7Gi |
| openclaw | data-syncer | (missing) | small (512Mi) | 64Mi |