### PR TITLE
fix(argocd): fix vixens-app-of-apps OutOfSync - normalize Application ignoreDifferences

### DIFF
--- a/argocd/overlays/prod/apps/hydrus-client.yaml
+++ b/argocd/overlays/prod/apps/hydrus-client.yaml
@@ -16,12 +16,12 @@ spec:
     repoURL: https://github.com/charchess/vixens.git
     targetRevision: prod-stable
   ignoreDifferences:
-    - group: ""
+    - kind: Secret
       kind: Secret
       name: litestream-shared-secrets
       jsonPointers:
         - /data
-    - group: ""
+    - kind: Secret
       kind: Secret
       name: hydrus-client-secrets
       jsonPointers:

--- a/argocd/overlays/prod/apps/kyverno.yaml
+++ b/argocd/overlays/prod/apps/kyverno.yaml
@@ -129,9 +129,9 @@ spec:
         - .spec.admission
         - .spec.emitWarning
         - .spec.rules[].skipBackgroundRequests
-        - ".spec.rules[].validate.allowExistingViolations"
-        - ".spec.rules[].context[].apiCall.method"
-        - ".spec.rules[].validate.foreach[].context[].apiCall.method"
+        - .spec.rules[].validate.allowExistingViolations
+        - .spec.rules[].context[].apiCall.method
+        - .spec.rules[].validate.foreach[].context[].apiCall.method
       jsonPointers:
         - /status
   syncPolicy:


### PR DESCRIPTION
## Problem

`vixens-app-of-apps` is OutOfSync on two Application resources: hydrus-client and kyverno.

## Root cause

ArgoCD normalizes Application spec fields:
1. `hydrus-client`: `group: ""` in git → ArgoCD drops empty group → diff detected
2. `kyverno`: mixed quoting in `jqPathExpressions` → ArgoCD stores without wrapping YAML quotes → diff detected

## Fix

- Remove `group: ""` from hydrus-client's ignoreDifferences entries
- Normalize kyverno's jqPathExpressions to consistent unquoted format