### PR TITLE
fix(frigate): reduce sizing from G-xl to G-small

### DIFF
--- a/apps/20-media/frigate/overlays/prod/kustomization.yaml
+++ b/apps/20-media/frigate/overlays/prod/kustomization.yaml
@@ -44,7 +44,7 @@ patches:
         template:
           metadata:
             labels:
-              vixens.io/sizing.frigate: G-xl
+              vixens.io/sizing.frigate: G-small
               vixens.io/sizing.litestream: micro
               vixens.io/sizing.config-syncer: micro
             annotations:


### PR DESCRIPTION
## Problem

frigate prod uses `G-xl` sizing (4Gi memory / 2 CPU requests). Due to current cluster memory/CPU pressure, this pod cannot schedule on its required nodes (powder/poison).

VPA (Goldilocks) shows actual usage: ~64Mi memory, minimal CPU.

## Fix

Change `vixens.io/sizing.frigate` from `G-xl` → `G-small` (128Mi/50m CPU).

This is sufficient for actual frigate usage and will allow the pod to schedule on production nodes.

## Impact

- frigate will schedule and run instead of being perpetually Pending
- Frees ~3.9Gi memory and ~1.95 CPU on prod nodes
- Unblocks ArgoCD application-controller scheduling (critical)