### PR TITLE
fix(argocd): remove duplicate kind key in hydrus-client ignoreDifferences

### DIFF
--- a/argocd/overlays/prod/apps/hydrus-client.yaml
+++ b/argocd/overlays/prod/apps/hydrus-client.yaml
@@ -17,12 +17,10 @@ spec:
     targetRevision: prod-stable
   ignoreDifferences:
     - kind: Secret
-      kind: Secret
       name: litestream-shared-secrets
       jsonPointers:
         - /data
     - kind: Secret
-      kind: Secret
       name: hydrus-client-secrets
       jsonPointers:
         - /data


### PR DESCRIPTION
## Problem

PR #1705 introduced a regression: each `ignoreDifferences` entry in `hydrus-client.yaml` has a duplicate `kind: Secret` key. This causes:

```
Error: yaml: unmarshal errors:
  line 19: mapping key "kind" already defined at line 18
```

ArgoCD can't build the app-of-apps manifest, causing `vixens-app-of-apps` to be `Unknown`.

## Fix

Remove the duplicate `kind:` field from each `ignoreDifferences` entry.