### PR TITLE
fix(robusta): increase runner sizing from G-small to small (OOMKill fix)

### DIFF
--- a/apps/02-monitoring/robusta/overlays/prod/values.yaml
+++ b/apps/02-monitoring/robusta/overlays/prod/values.yaml
@@ -21,9 +21,9 @@ sinksConfig:
       url: "{{ env.DISCORD_WEBHOOK_URL }}"
 
 runner:
-  # resources managed by Kyverno sizing (G-small tier: 128Mi/128Mi - matches actual 124Mi usage)
+  # resources managed by Kyverno sizing (small tier: 512Mi/512Mi - needed due to OOMKills at 128Mi)
   labels:
-    vixens.io/sizing.runner: G-small
+    vixens.io/sizing.runner: small
   sendAdditionalTelemetry: true
   additional_env_froms:
     - secretRef:


### PR DESCRIPTION
## Problem

robusta-runner pods are repeatedly OOMKilling at the 128Mi limit (G-small tier).
robusta-holmes is using 126Mi/128Mi (dangerously close to limit).

## Fix

Increase `vixens.io/sizing.runner` from `G-small` (128Mi) to `small` (512Mi/512Mi).

This provides enough headroom for occasional memory spikes.