### PR TITLE
fix(sonarr): add resources-patch.yaml to kustomization, remove duplicate components

### DIFF
--- a/apps/20-media/sonarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/sonarr/overlays/prod/kustomization.yaml
@@ -13,9 +13,6 @@ components:
   - ../../../../_shared/components/resources
   - ../../../../_shared/components/metrics
   - ../../../../_shared/components/poddisruptionbudget/0
-  - ../../../../_shared/components/base
-  - ../../../../_shared/components/resources
-  - ../../../../_shared/components/metrics
 
 patches:
   - target:
@@ -25,3 +22,7 @@ patches:
       - op: replace
         path: /spec/authentication/universalAuth/secretsScope/envSlug
         value: prod
+  - target:
+      kind: Deployment
+      name: sonarr
+    path: resources-patch.yaml


### PR DESCRIPTION
## Problem

PR #1704 created `apps/20-media/sonarr/overlays/prod/resources-patch.yaml` with per-container sizing labels but **never added it to `kustomization.yaml`**.

Additionally, the kustomization has duplicate component entries (base, resources, metrics listed twice).

Result: sonarr pods get Kyverno micro fallback (128Mi limit), OOMKill because sonarr needs ~300Mi.

## Fix

1. Add `resources-patch.yaml` to patches section of `kustomization.yaml`
2. Remove duplicate component entries

## Impact

sonarr will now use `small` tier (512Mi) instead of `micro` (128Mi), preventing OOMKills.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production deployment configuration to refine component structure and resource patch application for improved deployment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->