### PR TITLE
fix(frigate): G-medium -> medium sizing for go2rtc CPU burst

### DIFF
--- a/apps/20-media/frigate/overlays/prod/kustomization.yaml
+++ b/apps/20-media/frigate/overlays/prod/kustomization.yaml
@@ -44,7 +44,7 @@ patches:
         template:
           metadata:
             labels:
-              vixens.io/sizing.frigate: G-medium
+              vixens.io/sizing.frigate: medium
               vixens.io/sizing.litestream: micro
               vixens.io/sizing.config-syncer: micro
             annotations:


### PR DESCRIPTION
go2rtc fails with G-medium (200m CPU limit) due to throttling during startup. medium tier (1000m CPU limit) allows go2rtc to bind port 1984 before health check fires.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated frigate deployment resource allocation configuration to standard sizing tier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->