### PR TITLE
fix(argocd): reduce app-controller memory request to 400Mi

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
+++ b/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
@@ -40,7 +40,7 @@ spec:
           resources:
             requests:
               cpu: 500m
-              memory: 1200Mi
+              memory: 400Mi
             limits:
               cpu: "1"
               memory: 2Gi


### PR DESCRIPTION
Cluster saturated (93-99% memory requests). 1200Mi cannot schedule. 400Mi fits on peach/phoebe. PolicyException preserved for 2Gi limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized infrastructure resource allocation for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->