### PR TITLE
fix(frigate): increase probe initialDelaySeconds for camera startup time

### DIFF
--- a/apps/20-media/frigate/base/deployment.yaml
+++ b/apps/20-media/frigate/base/deployment.yaml
@@ -127,12 +127,12 @@ spec:
           livenessProbe:
             tcpSocket:
               port: http
-            initialDelaySeconds: 30
+            initialDelaySeconds: 120
             periodSeconds: 20
           readinessProbe:
             tcpSocket:
               port: http
-            initialDelaySeconds: 10
+            initialDelaySeconds: 60
             periodSeconds: 10
           resources:
             requests:


### PR DESCRIPTION
Frigate takes >60s to initialize cameras and bind web UI on port 5000. Liveness: 30->120s, Readiness: 10->60s to prevent false CrashLoopBackOff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Extended service health check delay timings to provide improved stability during startup initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->