### PR TITLE
fix(argocd): add ServerSideApply + ignoreDifferences for CRD annotations

### DIFF
--- a/argocd/overlays/prod/apps/argocd.yaml
+++ b/argocd/overlays/prod/apps/argocd.yaml
@@ -19,3 +19,10 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+  ignoreDifferences:
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      jsonPointers:
+        - /metadata/annotations


### PR DESCRIPTION
Fixes ArgoCD sync failure due to annotation size limit on CRDs. ServerSideApply avoids client-side apply annotation limit of 256KB.