### PR TITLE
fix(argocd): add control-plane toleration to allow scheduling on CP nodes

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
+++ b/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
@@ -11,6 +11,11 @@ spec:
       labels:
         app: argocd-server
         vixens.io/sizing: small
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -24,6 +29,11 @@ spec:
       labels:
         app: argocd-repo-server
         vixens.io/sizing: medium
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -35,6 +45,10 @@ spec:
       labels:
         app: argocd-application-controller
     spec:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
       containers:
         - name: argocd-application-controller
           resources:


### PR DESCRIPTION
## Summary

- Add `node-role.kubernetes.io/control-plane` toleration to argocd-application-controller, argocd-server, and argocd-repo-server
- Workers peach/pearl are at 97% memory requests — ArgoCD pods were stuck Pending with no room to schedule
- Control-plane nodes poison/powder have 1.1-1.2Gi free memory available
- Without this fix, ArgoCD cannot bootstrap after a cluster restart when workers are saturated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Infrastructure updates to enhance system scheduling and availability capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->