### PR TITLE
fix(frigate): bump sizing to G-large to fix OOMKill (2Gi RAM)

### DIFF
--- a/apps/20-media/frigate/overlays/prod/kustomization.yaml
+++ b/apps/20-media/frigate/overlays/prod/kustomization.yaml
@@ -44,7 +44,7 @@ patches:
         template:
           metadata:
             labels:
-              vixens.io/sizing.frigate: medium
+              vixens.io/sizing.frigate: G-large
               vixens.io/sizing.litestream: micro
               vixens.io/sizing.config-syncer: micro
             annotations:


### PR DESCRIPTION
Frigate container OOMKilled at 1Gi limit (medium tier). Camera NVR with ML inference requires more RAM. G-large gives 2Gi request+limit.