### PR TITLE
fix(openclaw): bump sizing to G-controller to fix JS heap OOM

### DIFF
--- a/apps/60-services/openclaw/overlays/prod/resources-patch.yaml
+++ b/apps/60-services/openclaw/overlays/prod/resources-patch.yaml
@@ -5,11 +5,11 @@ metadata:
   name: openclaw
   namespace: services
   labels:
-    vixens.io/sizing.openclaw: medium
+    vixens.io/sizing.openclaw: G-controller
     vixens.io/sizing.data-syncer: small
 spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.openclaw: medium
+        vixens.io/sizing.openclaw: G-controller
         vixens.io/sizing.data-syncer: small


### PR DESCRIPTION
openclaw Node.js process OOMs at medium tier (512Mi req/1Gi limit). Bumping to G-controller (2Gi/2Gi) to match the base deployment default.