### PR TITLE
fix(argocd): reduce repo-server sizing from medium to small

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
+++ b/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
@@ -22,13 +22,13 @@ kind: Deployment
 metadata:
   name: argocd-repo-server
   labels:
-    vixens.io/sizing: medium
+    vixens.io/sizing: small
 spec:
   template:
     metadata:
       labels:
         app: argocd-repo-server
-        vixens.io/sizing: medium
+        vixens.io/sizing: small
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
argocd-repo-server uses only ~50Mi RAM but has 512Mi request (medium). Reducing to small to free memory for critical DaemonSet pods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized production infrastructure resource allocation to enhance system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->