### PR TITLE
fix(argocd): explicit resources for repo-server to reduce memory pressure

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
+++ b/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
@@ -34,6 +34,15 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      containers:
+        - name: argocd-repo-server
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
argocd-repo-server actual RAM usage is ~50Mi but Kyverno small tier enforces 512Mi request. Adding explicit container resources (128Mi req/1Gi limit) to free cluster memory.