### PR TITLE
fix(frigate): bump sizing to large (4Gi) to fix OOMKill with shm

### DIFF
--- a/apps/20-media/frigate/overlays/prod/kustomization.yaml
+++ b/apps/20-media/frigate/overlays/prod/kustomization.yaml
@@ -44,7 +44,7 @@ patches:
         template:
           metadata:
             labels:
-              vixens.io/sizing.frigate: G-large
+              vixens.io/sizing.frigate: large
               vixens.io/sizing.litestream: micro
               vixens.io/sizing.config-syncer: micro
             annotations:


### PR DESCRIPTION
Frigate is OOMKilled even at G-large (2Gi). Root cause: /dev/shm (4Gi) + cache (1Gi) count toward container memory limit. 6 cameras need 4Gi+ limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated frigate deployment sizing configuration label from "G-large" to "large".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->