### PR TITLE
fix(whisparr): reduce sizing G-small/micro to free RAM for robusta-runner

### DIFF
--- a/apps/20-media/whisparr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/whisparr/overlays/prod/resources-patch.yaml
@@ -4,13 +4,13 @@ kind: Deployment
 metadata:
   name: whisparr
   labels:
-    vixens.io/sizing.whisparr: medium
-    vixens.io/sizing.litestream: small
-    vixens.io/sizing.config-syncer: small
+    vixens.io/sizing.whisparr: G-small
+    vixens.io/sizing.litestream: micro
+    vixens.io/sizing.config-syncer: micro
 spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.whisparr: medium
-        vixens.io/sizing.litestream: small
-        vixens.io/sizing.config-syncer: small
+        vixens.io/sizing.whisparr: G-small
+        vixens.io/sizing.litestream: micro
+        vixens.io/sizing.config-syncer: micro


### PR DESCRIPTION
## Summary

- Whisparr actual memory usage is only 97Mi total across all 3 containers
- Current sizing: `medium`(512Mi) + `small`(512Mi) + `small`(512Mi) = **1.5Gi requests**
- New sizing: `G-small`(128Mi) + `micro`(128Mi) + `micro`(128Mi) = **384Mi requests**
- Frees ~1.1Gi on `pearl` node to allow `robusta-runner` (Pending, 512Mi needed) to schedule

## Context

Cluster is at 99% memory on all 5 nodes. `robusta-runner` is Pending with `Insufficient memory`.
Whisparr uses only 97Mi real memory but holds 1.5Gi in requests — classic oversizing.