### PR TITLE
fix(firefly-iii): bump health annotation to clear ArgoCD Degraded cache

### DIFF
--- a/apps/60-services/firefly-iii/base/deployment.yaml
+++ b/apps/60-services/firefly-iii/base/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         app.kubernetes.io/name: firefly-iii
       annotations:
         reloader.stakater.com/auto: "true"
-        vixens.io/health-bump: "2"
+        vixens.io/health-bump: "3"
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
         prometheus.io/path: "/metrics"


### PR DESCRIPTION
## Summary

- `firefly-iii` pod is 2/2 Running, deployment rollout successful for 3+ hours
- ArgoCD health stuck on `Degraded` since 20:53 UTC (over 2h ago)
- Hard refresh did not clear the cached status
- Bumping `vixens.io/health-bump` annotation from `"2"` → `"3"` forces a new rollout
- ArgoCD will detect the new ReplicaSet as Healthy and update its cached state