### PR TITLE
fix(lidarr): reduce sizing G-small/micro to free RAM on powder

### DIFF
--- a/apps/20-media/lidarr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/lidarr/overlays/prod/resources-patch.yaml
@@ -4,13 +4,13 @@ kind: Deployment
 metadata:
   name: lidarr
   labels:
-    vixens.io/sizing.lidarr: medium
-    vixens.io/sizing.litestream: small
-    vixens.io/sizing.config-syncer: small
+    vixens.io/sizing.lidarr: G-small
+    vixens.io/sizing.litestream: micro
+    vixens.io/sizing.config-syncer: micro
 spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.lidarr: medium
-        vixens.io/sizing.litestream: small
-        vixens.io/sizing.config-syncer: small
+        vixens.io/sizing.lidarr: G-small
+        vixens.io/sizing.litestream: micro
+        vixens.io/sizing.config-syncer: micro


### PR DESCRIPTION
## Summary

- Lidarr actual memory usage is only 193Mi total across all 3 containers
- Current sizing: `medium`(512Mi) + `small`(512Mi) + `small`(512Mi) = **1.5Gi requests**  
- New sizing: `G-small`(128Mi) + `micro`(128Mi) + `micro`(128Mi) = **384Mi requests**
- Frees ~1.1Gi on `powder` node

## Context

Cluster is fully saturated (all nodes at 99% memory). `synology-csi-controller-0` is Pending with `Insufficient memory` on all nodes, blocking all PVC mounts for frigate, mealie, whisparr.
Lidarr uses only 193Mi real memory but holds 1.5Gi in requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resource sizing labels in deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->