### PR TITLE
fix(robusta): add control-plane toleration to runner for scheduling on CP nodes

### DIFF
--- a/apps/02-monitoring/robusta/overlays/prod/values.yaml
+++ b/apps/02-monitoring/robusta/overlays/prod/values.yaml
@@ -24,6 +24,10 @@ runner:
   # resources managed by Kyverno sizing (small tier: 512Mi/512Mi - needed due to OOMKills at 128Mi)
   labels:
     vixens.io/sizing.runner: small
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
   sendAdditionalTelemetry: true
   additional_env_froms:
     - secretRef:


### PR DESCRIPTION
## Summary

- `robusta-runner` (512Mi) is Pending for 40+ minutes
- All worker nodes (peach/pearl) are at 99% memory — no room for 512Mi
- CP nodes have free capacity (powder: 464Mi free after #1725)
- Adding `node-role.kubernetes.io/control-plane` toleration allows runner to schedule on CP nodes

## Context

Workers at 99% memory. CP toleration pattern already used by ArgoCD components (PR #1716).