### PR TITLE
fix(robusta): set explicit 384Mi request + PolicyException to allow scheduling

### DIFF
--- a/apps/00-infra/kyverno/base/policies/policy-exception-robusta.yaml
+++ b/apps/00-infra/kyverno/base/policies/policy-exception-robusta.yaml
@@ -1,0 +1,25 @@
+---
+# PolicyException for robusta-runner to bypass Kyverno sizing mutation.
+# Allows explicit resource overrides (384Mi) since:
+# - 128Mi (micro/G-small) causes OOMKills
+# - 512Mi (small) cannot schedule on memory-saturated cluster (all nodes at 99%)
+# - 384Mi is a safe compromise that fits on powder (CP node, 464Mi free)
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: robusta-sizing-exception
+  namespace: kyverno
+spec:
+  exceptions:
+    - policyName: sizing-mutate
+      ruleNames:
+        - granular-container-sizing
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+          namespaces:
+            - robusta
+          names:
+            - "robusta-runner-*"

--- a/apps/02-monitoring/robusta/overlays/prod/values.yaml
+++ b/apps/02-monitoring/robusta/overlays/prod/values.yaml
@@ -21,13 +21,20 @@ sinksConfig:
       url: "{{ env.DISCORD_WEBHOOK_URL }}"
 
 runner:
-  # resources managed by Kyverno sizing (small tier: 512Mi/512Mi - needed due to OOMKills at 128Mi)
+  # PolicyException bypasses Kyverno sizing-mutate. Explicit resources set here.
   labels:
     vixens.io/sizing.runner: small
   tolerations:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists
       effect: NoSchedule
+  resources:
+    requests:
+      memory: 384Mi
+      cpu: 250m
+    limits:
+      memory: 768Mi
+      cpu: 500m
   sendAdditionalTelemetry: true
   additional_env_froms:
     - secretRef:


### PR DESCRIPTION
## Summary

- `robusta-runner` has been Pending for 1h due to insufficient memory on all nodes
- Helm chart default: 1Gi request
- Kyverno `small` override: 512Mi (also too large — powder has 464Mi free)
- This PR sets 384Mi request via explicit Helm values + PolicyException to bypass Kyverno

## Changes

- `policy-exception-robusta.yaml`: bypass `sizing-mutate` for `robusta-runner-*` pods
- `values.yaml`: explicit resources (384Mi req / 768Mi limit) + already has CP toleration

## Context

CP toleration added in PR #1726. Powder has 464Mi free after lidarr fix (#1725).
384Mi fits in 464Mi with 80Mi headroom.