### PR TITLE
fix(lidarr): bump to G-medium (512Mi) to fix OOMKill - was 128Mi too small

### DIFF
--- a/apps/20-media/lidarr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/lidarr/overlays/prod/resources-patch.yaml
@@ -4,13 +4,13 @@ kind: Deployment
 metadata:
   name: lidarr
   labels:
-    vixens.io/sizing.lidarr: G-small
+    vixens.io/sizing.lidarr: G-medium
     vixens.io/sizing.litestream: micro
     vixens.io/sizing.config-syncer: micro
 spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.lidarr: G-small
+        vixens.io/sizing.lidarr: G-medium
         vixens.io/sizing.litestream: micro
         vixens.io/sizing.config-syncer: micro


### PR DESCRIPTION
## Summary

- Lidarr OOMKilled (exit 137) with `G-small` sizing (128Mi limit)
- Actual memory usage: 193Mi — exceeds 128Mi limit
- Bump main container to `G-medium` (512Mi request/limit)
- `litestream` and `config-syncer` remain at `micro` (128Mi)
- Net memory: 768Mi requests (was 1.5Gi before #1725, now safer at 768Mi)