### PR TITLE
fix(whisparr): bump to G-medium (512Mi) to fix OOMKill

### DIFF
--- a/apps/20-media/whisparr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/whisparr/overlays/prod/resources-patch.yaml
@@ -4,13 +4,13 @@ kind: Deployment
 metadata:
   name: whisparr
   labels:
-    vixens.io/sizing.whisparr: G-small
+    vixens.io/sizing.whisparr: G-medium
     vixens.io/sizing.litestream: micro
     vixens.io/sizing.config-syncer: micro
 spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.whisparr: G-small
+        vixens.io/sizing.whisparr: G-medium
         vixens.io/sizing.litestream: micro
         vixens.io/sizing.config-syncer: micro


### PR DESCRIPTION
## Summary

- Whisparr OOMKilled (exit 137) with `G-small` sizing (128Mi limit)
- Stable memory: 97Mi, but startup spikes exceed 128Mi limit
- Bump main container from `G-small` to `G-medium` (512Mi request/limit)
- `litestream` and `config-syncer` remain at `micro` (128Mi)
- Total: 512Mi + 128Mi + 128Mi = 768Mi requests (was 1.5Gi before #1723)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Whisparr deployment resource sizing from small to medium for optimized performance allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->