### PR TITLE
fix(firefly-iii): bump health annotation to 4 for fresh ArgoCD health evaluation

### DIFF
--- a/apps/60-services/firefly-iii/base/deployment.yaml
+++ b/apps/60-services/firefly-iii/base/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         app.kubernetes.io/name: firefly-iii
       annotations:
         reloader.stakater.com/auto: "true"
-        vixens.io/health-bump: "3"
+        vixens.io/health-bump: "4"
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
         prometheus.io/path: "/metrics"


### PR DESCRIPTION
firefly-iii Degraded in ArgoCD since 20:53 UTC (3h+) despite pod 2/2 Running with 0 restarts. Previous health-bump to '3' triggered a rollout but ArgoCD health cache still shows Degraded. Bump to '4' for a new rollout.