### PR TITLE
fix(mealie): PolicyException to use explicit 256Mi request instead of Kyverno small (512Mi)

### DIFF
--- a/apps/00-infra/kyverno/base/policies/policy-exception-mealie.yaml
+++ b/apps/00-infra/kyverno/base/policies/policy-exception-mealie.yaml
@@ -1,0 +1,26 @@
+---
+# PolicyException for mealie to bypass Kyverno sizing mutation.
+# Allows explicit resource overrides (256Mi request / 512Mi limit) since:
+# - Kyverno 'small' sizing forces 512Mi request (too large for cluster)
+# - Explicit resources in resources-patch.yaml: 256Mi req / 512Mi limit
+# - Actual usage ~314Mi, comfortably within 512Mi limit
+# - 256Mi request allows scheduling on cluster with limited free memory
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: mealie-sizing-exception
+  namespace: kyverno
+spec:
+  exceptions:
+    - policyName: sizing-mutate
+      ruleNames:
+        - granular-container-sizing
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+          namespaces:
+            - mealie
+          names:
+            - "mealie-*"


### PR DESCRIPTION
## Problem
mealie pod is Pending since cluster saturation event. Kyverno `small` sizing-mutate overrides explicit 256Mi resources to 512Mi request.

All worker nodes are at 99% memory allocation. Workers (peach/pearl/phoebe) have ~194-221Mi free — insufficient for 512Mi. Control plane nodes (poison/powder) have ~417-443Mi free — sufficient for 256Mi.

## Solution
PolicyException for `mealie-*` pods in `mealie` namespace bypasses `sizing-mutate` rule so the explicit 256Mi request/512Mi limit from resources-patch.yaml takes effect.

Actual mealie usage ~314Mi, comfortably within 512Mi limit. 256Mi request allows scheduling on poison or powder.

## Impact
- mealie-* pods: 512Mi request → 256Mi request (scheduling unblocked on CP nodes)
- No other namespaces affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added policy exception for Mealie application to bypass container sizing mutation policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->