### PR TITLE
fix(adguard): reduce memory request 512Mi->128Mi to free cluster RAM for mealie scheduling

### DIFF
--- a/apps/00-infra/kyverno/base/policies/policy-exception-adguard.yaml
+++ b/apps/00-infra/kyverno/base/policies/policy-exception-adguard.yaml
@@ -1,0 +1,25 @@
+---
+# PolicyException for adguard-home to bypass Kyverno sizing mutation.
+# Allows explicit resource overrides (128Mi request / 512Mi limit) since:
+# - Kyverno 'medium' sizing forces 512Mi request (too large for cluster)
+# - Actual usage ~76Mi, comfortably within 512Mi limit
+# - 128Mi request frees 384Mi on powder node to allow mealie scheduling
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: adguard-sizing-exception
+  namespace: kyverno
+spec:
+  exceptions:
+    - policyName: sizing-mutate
+      ruleNames:
+        - granular-container-sizing
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+          namespaces:
+            - networking
+          names:
+            - "adguard-home-*"

--- a/apps/40-network/adguard-home/overlays/prod/kustomization.yaml
+++ b/apps/40-network/adguard-home/overlays/prod/kustomization.yaml
@@ -32,3 +32,4 @@ patches:
     target:
       kind: StatefulSet
       name: adguard-home
+  - path: resources-patch.yaml

--- a/apps/40-network/adguard-home/overlays/prod/resources-patch.yaml
+++ b/apps/40-network/adguard-home/overlays/prod/resources-patch.yaml
@@ -1,0 +1,25 @@
+---
+# Explicit resource override for adguard-home prod.
+# Bypasses Kyverno 'medium' sizing (512Mi request / 1Gi limit) via
+# PolicyException (policy-exception-adguard.yaml in kyverno namespace).
+# Actual usage: ~76Mi. Using 128Mi request / 512Mi limit to:
+# - Reduce memory pressure on cluster (512Mi -> 128Mi request = 384Mi freed)
+# - Keep 512Mi limit to avoid OOMKill during DNS traffic spikes
+# - Allow mealie pod to schedule (needs 384Mi free on powder node)
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: adguard-home
+  namespace: networking
+spec:
+  template:
+    spec:
+      containers:
+        - name: adguard-home
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi


### PR DESCRIPTION
## Problem
mealie pod cannot schedule: cluster at 99% memory allocation on all nodes.
powder node has only 80Mi free, mealie needs 384Mi (main containers total).

adguard-home uses Kyverno `medium` sizing (512Mi request / 1Gi limit) but actual usage is ~76Mi.

## Solution
- Add PolicyException `adguard-sizing-exception` to bypass sizing-mutate for `adguard-home-*` pods in `networking` namespace
- Add `resources-patch.yaml` with explicit resources: 128Mi request / 512Mi limit
- Saves 384Mi on powder node (512Mi → 128Mi request)

## After this change
- powder free: 80Mi + 384Mi = 464Mi → sufficient for mealie (384Mi needed)
- adguard safety margin: 512Mi limit - ~76Mi usage = 436Mi buffer → no OOMKill risk
- mealie will be schedulable and start Running

## Impact
- adguard-home pod: needs recreation (delete old pod after apply)
- No DNS downtime expected (StatefulSet rolling update)