### PR TITLE
fix(firefly-iii): bump health-bump 5 to clear ArgoCD Degraded cache

### DIFF
--- a/apps/60-services/firefly-iii/base/deployment.yaml
+++ b/apps/60-services/firefly-iii/base/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         app.kubernetes.io/name: firefly-iii
       annotations:
         reloader.stakater.com/auto: "true"
-        vixens.io/health-bump: "4"
+        vixens.io/health-bump: "5"
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
         prometheus.io/path: "/metrics"


### PR DESCRIPTION
ArgoCD app-controller caches Degraded status despite firefly-iii pods Running 2/2. Bumping annotation forces fresh reconcile. Recurring ArgoCD cache bug (#1724, #1730).