### PR TITLE
fix(loki): reduce memory request 512Mi->256Mi to free RAM for robusta scheduling

### DIFF
--- a/apps/00-infra/kyverno/base/policies/policy-exception-loki.yaml
+++ b/apps/00-infra/kyverno/base/policies/policy-exception-loki.yaml
@@ -1,0 +1,25 @@
+---
+# PolicyException for loki to bypass Kyverno sizing mutation.
+# Allows explicit resource overrides (256Mi request / 512Mi limit) since:
+# - Kyverno 'G-medium' sizing forces 512Mi request/limit
+# - Actual usage ~162Mi, comfortably within 512Mi limit
+# - 256Mi request frees 256Mi on powder node to allow robusta scheduling
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: loki-sizing-exception
+  namespace: kyverno
+spec:
+  exceptions:
+    - policyName: sizing-mutate
+      ruleNames:
+        - granular-container-sizing
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+          namespaces:
+            - monitoring
+          names:
+            - "loki-*"

--- a/apps/02-monitoring/loki/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/loki/overlays/prod/kustomization.yaml
@@ -24,3 +24,4 @@ patches:
           metadata:
             labels:
               vixens.io/sizing.loki: G-medium
+  - path: resources-patch.yaml

--- a/apps/02-monitoring/loki/overlays/prod/resources-patch.yaml
+++ b/apps/02-monitoring/loki/overlays/prod/resources-patch.yaml
@@ -1,0 +1,24 @@
+---
+# Explicit resource override for loki prod.
+# Bypasses Kyverno 'G-medium' sizing (512Mi req/limit) via PolicyException.
+# Actual usage: ~162Mi. Using 256Mi request / 512Mi limit to:
+# - Reduce memory pressure on cluster (512Mi -> 256Mi request = 256Mi freed)
+# - Keep 512Mi limit to avoid OOMKill during log ingestion spikes
+# - Free 256Mi on powder node to allow robusta-runner scheduling
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      containers:
+        - name: loki
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi


### PR DESCRIPTION
## Problem
robusta-runner pod Pending (Insufficient memory). powder node has 208Mi free, robusta needs 384Mi.

loki-0 uses Kyverno 'G-medium' sizing (512Mi request/limit) but actual usage is ~162Mi.

## Solution
- PolicyException `loki-sizing-exception` to bypass sizing-mutate for `loki-*` pods in `monitoring` namespace
- resources-patch.yaml: 256Mi request / 512Mi limit

## After this change
- powder free: 208Mi + 256Mi = 464Mi → sufficient for robusta-runner (384Mi)
- loki safety margin: 512Mi limit - 162Mi usage = 350Mi buffer
- robusta-runner can schedule and start

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Loki container resource configuration in production with optimized memory and CPU allocations (256Mi memory request, 512Mi limit, 50m-1 CPU range) to improve cluster scheduling efficiency and reduce memory pressure while maintaining sufficient capacity for handling ingestion load spikes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->