### PR TITLE
fix(firefly-iii): add sizing label + CP toleration to CronJob for scheduling

### DIFF
--- a/apps/60-services/firefly-iii/base/cronjob.yaml
+++ b/apps/60-services/firefly-iii/base/cronjob.yaml
@@ -11,8 +11,15 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            vixens.io/sizing: micro
         spec:
           restartPolicy: OnFailure
+          tolerations:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+              effect: NoSchedule
           containers:
             - name: firefly-iii-cron
               image: fireflyiii/core:version-6.4.16


### PR DESCRIPTION
## Problem
firefly-iii ArgoCD app is Degraded because CronJob `firefly-iii-cron` health is Degraded: 'CronJob has not completed its last execution successfully'.

The March 3 3am UTC scheduled run never completed — the cluster was recovering from a control-plane node reboot at that time.

When manually triggering the CronJob to run, the pod was Pending because:
1. No `vixens.io/sizing` label → Kyverno mutates to micro sizing (128Mi) but workers have only 19-43Mi free
2. No control-plane toleration → cannot schedule on CP nodes (poison/powder with 200-400Mi free)

## Fix
- Add `vixens.io/sizing: micro` label to make Kyverno mutation explicit
- Add CP toleration so job can schedule on CP nodes

## Result
After ArgoCD syncs the new CronJob spec, a manual job trigger (or the next scheduled run at 3am) will complete successfully and clear the Degraded status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment configuration to enhance service stability and resource efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->