### PR TITLE
fix(trivy): PolicyException to bypass Kyverno micro sizing causing OOMKill

### DIFF
--- a/apps/00-infra/kyverno/base/policies/policy-exception-trivy.yaml
+++ b/apps/00-infra/kyverno/base/policies/policy-exception-trivy.yaml
@@ -1,0 +1,25 @@
+---
+# PolicyException for trivy-operator to bypass Kyverno sizing mutation.
+# Allows explicit resource overrides (1Gi request/limit) since:
+# - Kyverno 'micro' sizing forces 128Mi limit (OOMKills during scans)
+# - resources-patch.yaml defines 1Gi request/limit for trivy-operator
+# - trivy-operator needs memory for vulnerability database + scan operations
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: trivy-sizing-exception
+  namespace: kyverno
+spec:
+  exceptions:
+    - policyName: sizing-mutate
+      ruleNames:
+        - granular-container-sizing
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+          namespaces:
+            - security
+          names:
+            - "trivy-trivy-operator-*"


### PR DESCRIPTION
trivy-operator OOMKills (exit 137) because Kyverno applies 'micro' (128Mi limit), overriding the explicit 1Gi from resources-patch.yaml. Pod crashes every ~4min while loading vulnerability database. PolicyException restores 1Gi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Enhanced resource management for vulnerability scanning operations to prevent out-of-memory errors during Trivy scans and database updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->