### PR TITLE
fix(amule): reduce memory request 512Mi→256Mi + PolicyException to unblock Pending

### DIFF
--- a/apps/00-infra/kyverno/base/policies/policy-exception-amule.yaml
+++ b/apps/00-infra/kyverno/base/policies/policy-exception-amule.yaml
@@ -1,0 +1,25 @@
+---
+# PolicyException for amule to bypass Kyverno sizing mutation.
+# Allows explicit resource overrides (256Mi request / 512Mi limit) since:
+# - Kyverno 'small' sizing forces 512Mi request/limit
+# - Actual usage is low; 256Mi request allows scheduling on full cluster
+# - Cluster nodes are at 99% allocation; 512Mi request causes Pending
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: amule-sizing-exception
+  namespace: kyverno
+spec:
+  exceptions:
+    - policyName: sizing-mutate
+      ruleNames:
+        - granular-container-sizing
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+          namespaces:
+            - downloads
+          names:
+            - "amule-*"

--- a/apps/20-media/amule/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/amule/overlays/prod/resources-patch.yaml
@@ -4,9 +4,18 @@ kind: Deployment
 metadata:
   name: amule
   labels:
-    vixens.io/sizing.amule: small
+    vixens.io/sizing: small
 spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.amule: small
+        vixens.io/sizing: small
+    spec:
+      containers:
+        - name: amule
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              memory: 512Mi


### PR DESCRIPTION
## Problem
amule pod stuck Pending for 10+ minutes. All 5 nodes at 99% memory allocation.

## Root Cause
- amule was requesting 512Mi (from 'small' sizing)
- No room on any node for 512Mi
- Label typo: `vixens.io/sizing.amule` not recognized by Kyverno (should be `vixens.io/sizing`)

## Fix
- Add `PolicyException` to bypass `sizing-mutate` for amule pods
- Reduce request 512Mi → 256Mi (keeps 512Mi limit for safety)
- Fix sizing label to proper `vixens.io/sizing: small`

## Expected Result
amule pod schedules on powder (336Mi free) and transitions Running → Healthy