### PR TITLE
fix(firefly-iii-importer): CP toleration + PolicyException to unblock Pending pod

### DIFF
--- a/apps/00-infra/kyverno/base/policies/policy-exception-firefly-iii-importer.yaml
+++ b/apps/00-infra/kyverno/base/policies/policy-exception-firefly-iii-importer.yaml
@@ -1,0 +1,25 @@
+---
+# PolicyException for firefly-iii-importer to bypass Kyverno sizing mutation.
+# Allows explicit resource overrides (128Mi request / 512Mi limit) since:
+# - Kyverno 'small' sizing forces 512Mi request/limit
+# - Actual usage ~88Mi, fits well within 512Mi limit
+# - 128Mi request allows scheduling on saturated cluster (nodes at 99%)
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: firefly-iii-importer-sizing-exception
+  namespace: kyverno
+spec:
+  exceptions:
+    - policyName: sizing-mutate
+      ruleNames:
+        - granular-container-sizing
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+          namespaces:
+            - finance
+          names:
+            - "firefly-iii-importer-*"

--- a/apps/60-services/firefly-iii-importer/base/deployment.yaml
+++ b/apps/60-services/firefly-iii-importer/base/deployment.yaml
@@ -11,9 +11,13 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: firefly-iii-importer
-        vixens.io/sizing.importer: "small"
+        vixens.io/sizing: small
     spec:
       priorityClassName: vixens-low
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
       containers:
         - name: importer
           image: fireflyiii/data-importer:latest


### PR DESCRIPTION
## Problem
firefly-iii-importer pod stuck Pending. Workers at 99% memory and no CP toleration.

## Root Cause
- Pod has no CP toleration → limited to 2 workers (peach+pearl), both at 99%
- Label typo: `vixens.io/sizing.importer` not recognized by Kyverno → overridden to micro
- 512Mi request (from small sizing) has no room on workers

## Fix
- Add CP toleration to allow scheduling on phoebe/poison/powder
- Fix sizing label: `vixens.io/sizing.importer` → `vixens.io/sizing: small`
- Add PolicyException to bypass sizing-mutate, keep explicit 128Mi request / 512Mi limit
- Actual usage ~88Mi, limit 512Mi is safe

## Expected Result
Pod schedules on a CP node and transitions Running → Healthy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated firefly-iii-importer infrastructure with refined resource allocation policies and exception handling, enabling flexible resource configurations and improved deployment across diverse cluster environments
  * Strengthened deployment scheduling capabilities with expanded cluster node compatibility support, providing greater operational flexibility, enhanced infrastructure resilience, and more reliable service distribution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->