### PR TITLE
fix(velero,radar): fix kopia maintenance ConfigMap name + remove explicit resources from radar

### DIFF
--- a/apps/00-infra/velero/base/maintenance-config.yaml
+++ b/apps/00-infra/velero/base/maintenance-config.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: velero-repo-maintenance-config
+  name: velero-repo-maintenance
   namespace: velero
 data:
   config.json: |

--- a/apps/70-tools/radar/base/manifests.yaml
+++ b/apps/70-tools/radar/base/manifests.yaml
@@ -160,6 +160,7 @@ spec:
         vixens.io/sizing.radar: small
         vixens.io/sizing: small
     spec:
+      priorityClassName: vixens-medium
       serviceAccountName: radar
       securityContext:
         fsGroup: 65532
@@ -207,10 +208,3 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
-          resources:
-            limits:
-              cpu: 500m
-              memory: 512Mi
-            requests:
-              cpu: 100m
-              memory: 128Mi


### PR DESCRIPTION
## Summary

- **velero**: rename `ConfigMap` from `velero-repo-maintenance-config` → `velero-repo-maintenance` to match the `--repo-maintenance-job-configmap` flag in the Velero deployment. The name mismatch caused kopia repository maintenance jobs to ignore the 256Mi memoryRequest and OOMKill on the default 128Mi.

- **radar**: remove explicit `resources:` block from the Deployment (Kyverno `sizing-mutate` will apply `small` sizing via `vixens.io/sizing.radar` label). Add `priorityClassName: vixens-medium` to give the pod proper scheduling priority during node pressure.

## Root Causes

| App | Bug | Effect |
|-----|-----|--------|
| velero | ConfigMap name mismatch (`velero-repo-maintenance-config` vs `velero-repo-maintenance`) | kopia maintenance OOMKills at 128Mi instead of 256Mi |
| radar | Explicit `resources:` block conflicts with Kyverno mutation | old RS pods running with micro sizing → OOMKill loop (22 restarts) |

## Changes

- `apps/00-infra/velero/base/maintenance-config.yaml`: `name: velero-repo-maintenance-config` → `name: velero-repo-maintenance`
- `apps/70-tools/radar/base/manifests.yaml`: remove `resources:` block, add `priorityClassName: vixens-medium`

## Validation

- `yamllint` clean on both files
- No prod overlay resources-patch.yaml exists for radar (verified)