### PR TITLE
fix(velero): fix kopia maintenance ConfigMap data format

### DIFF
--- a/apps/00-infra/velero/base/maintenance-config.yaml
+++ b/apps/00-infra/velero/base/maintenance-config.yaml
@@ -5,15 +5,13 @@ metadata:
   name: velero-repo-maintenance
   namespace: velero
 data:
-  config.json: |
+  global: |
     {
-      "global": {
-        "keepLatestMaintenanceJobs": 3,
-        "podResources": {
-          "cpuRequest": "100m",
-          "memoryRequest": "256Mi",
-          "cpuLimit": "500m",
-          "memoryLimit": "1Gi"
-        }
-      }
+      "podResources": {
+        "cpuRequest": "100m",
+        "memoryRequest": "256Mi",
+        "cpuLimit": "500m",
+        "memoryLimit": "1Gi"
+      },
+      "keepLatestMaintenanceJobs": 3
     }


### PR DESCRIPTION
## Root Cause

The ConfigMap `velero-repo-maintenance` had the wrong data key format. Velero v1.17.2 reads:
- Key `global` (= `GlobalKeyForRepoMaintenanceJobCM` const) with a flat `JobConfigs` JSON value

Our ConfigMap had:
- Key `config.json` with a `{"global": {...}}` wrapped JSON

The wrong key caused Velero to silently ignore the entire ConfigMap → kopia jobs created with default 128Mi limit → OOMKill loop.

## Fix

```yaml
# Before (ignored):
data:
  config.json: |
    {"global": {"podResources": {"memoryRequest": "256Mi", ...}}}

# After (correct):
data:
  global: |
    {"podResources": {"memoryRequest": "256Mi", ...}, "keepLatestMaintenanceJobs": 3}
```

## Verification

Source confirmed in `vmware-tanzu/velero@v1.17.2 pkg/repository/maintenance/maintenance.go`:
- `GlobalKeyForRepoMaintenanceJobCM = "global"`
- `json.Unmarshal([]byte(cm.Data[GlobalKeyForRepoMaintenanceJobCM]), globalResult)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring maintenance job retention settings.

* **Chores**
  * Updated Velero maintenance configuration structure for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->