### PR TITLE
fix(velero): move repositoryMaintenanceJob under configuration key

### DIFF
--- a/apps/00-infra/velero/values/common.yaml
+++ b/apps/00-infra/velero/values/common.yaml
@@ -27,6 +27,18 @@ configuration:
       config:
         region: us-east-1
 
+  # MAINTENANCE JOB RESOURCES
+  # Template reads: .Values.configuration.repositoryMaintenanceJob.repositoryConfigData
+  repositoryMaintenanceJob:
+    repositoryConfigData:
+      global:
+        podResources:
+          cpuRequest: "100m"
+          memoryRequest: "256Mi"
+          cpuLimit: "500m"
+          memoryLimit: "1Gi"
+        keepLatestMaintenanceJobs: 3
+
 # BACKUP SCHEDULES
 schedules:
   daily-critical:
@@ -54,16 +66,7 @@ schedules:
       snapshotVolumes: true
 
 # CLEANUP SETTINGS
-repositoryMaintenanceJob:
-  repositoryConfigData:
-    global:
-      podResources:
-        cpuRequest: "100m"
-        memoryRequest: "256Mi"
-        cpuLimit: "500m"
-        memoryLimit: "1Gi"
-      keepLatestMaintenanceJobs: 3
-  maintenanceCronJob:
+maintenanceCronJob:
   enabled: false
 upgradeCRDs: false
 cleanUpCRDs: false


### PR DESCRIPTION
Helm template reads `.Values.configuration.repositoryMaintenanceJob` (not top-level `.Values.repositoryMaintenanceJob`). Previous PR placed it at the wrong level causing podResources to be silently ignored. This commit also removes the leftover top-level `repositoryMaintenanceJob` and correctly nests it under `configuration:`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated maintenance job configuration with enhanced resource management controls including CPU and memory request/limit parameters. Latest job retention configured to maintain three maintenance job records.
  * Reorganized configuration structure for improved clarity and easier management of backup cleanup and maintenance job settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->