### PR TITLE
fix(synology-csi): add iscsi-lock-cleanup initContainer

### DIFF
--- a/apps/01-storage/synology-csi/base/node.yaml
+++ b/apps/01-storage/synology-csi/base/node.yaml
@@ -15,6 +15,18 @@ spec:
       hostNetwork: true
       hostPID: true
       serviceAccountName: synology-csi-node
+      initContainers:
+        - name: iscsi-lock-cleanup
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - rm -f /host/run/lock/iscsi/lock.write && echo "iSCSI stale lock cleared"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: host-root
+              mountPath: /host
       containers:
         - name: csi-node-driver-registrar
           image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0


### PR DESCRIPTION
## Problem

When the `synology-csi-node` pod restarts (OOM, eviction, node event), any running `iscsiadm` process it spawned may be killed with SIGKILL before it releases `/run/lock/iscsi/lock.write`. This orphaned lock blocks all subsequent iSCSI mount attempts on the node, causing all pods with iSCSI PVCs to stay stuck in `Init:0/N` indefinitely.

## Solution

Add an `initContainer` (`iscsi-lock-cleanup`) that runs before the CSI driver starts and removes the stale lock file:

```sh
rm -f /host/run/lock/iscsi/lock.write
```

Uses the existing `host-root` volume (already mounted at `/host` in the pod). Idempotent — no-ops if the lock doesn't exist.

## Risk

Very low. The init container only runs at pod startup, at which point the previous pod is already dead and any lock it held is already orphaned.

## Testing

- Verified `kustomize build overlays/prod` includes the initContainer
- yamllint clean (warning only: line-length)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic iSCSI resource cleanup during pod initialization for improved system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->