### PR TITLE
fix(argocd): migrate patchesJson6902→patches + fix ConfigMap namespace mismatch

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/argocd/overlays/prod/kustomization.yaml
@@ -9,29 +9,24 @@ resources:
 patches:
   - path: resources-patch.yaml
   - path: patches/argocd-params.yaml
-
-components:
-  - ../../../../_shared/components/revision-history-limit
-
-patchesJson6902:
   - target:
       group: apps
       version: v1
       kind: Deployment
       name: argocd-redis
-      namespace: argocd
     path: patches/redis-resources-json.yaml
   - target:
       group: apps
       version: v1
       kind: Deployment
       name: argocd-redis
-      namespace: argocd
     path: patches/redis-probes-json.yaml
   - target:
       group: apps
       version: v1
       kind: Deployment
       name: argocd-dex-server
-      namespace: argocd
     path: patches/dex-run-as-user-json.yaml
+
+components:
+  - ../../../../_shared/components/revision-history-limit

--- a/apps/00-infra/argocd/overlays/prod/patches/argocd-params.yaml
+++ b/apps/00-infra/argocd/overlays/prod/patches/argocd-params.yaml
@@ -1,8 +1,8 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: argocd-cmd-params-cm
-  namespace: argocd
 data:
   # Run server without TLS - Traefik handles TLS termination
   server.insecure: "true"


### PR DESCRIPTION
## Problem

After Renovate PR #1748 updated ArgoCD v3.3.0→v3.3.2 + dex v2.43→v2.45.1, the kustomize build started failing in ArgoCD with:

```
Warning: 'patchesJson6902' is deprecated. Please use 'patches' instead.
Error: no resource matches strategic merge patch "ConfigMap.v1.[noGrp]/argocd-cmd-params-cm.argocd"
```

Two root causes:
1. **`patchesJson6902` deprecated**: ArgoCD v3.3's bundled kustomize version emits a deprecation warning AND has stricter behavior
2. **Namespace conflict in patch**: `patches/argocd-params.yaml` had `namespace: argocd` in its metadata. Combined with the global `namespace: argocd` setter in kustomization.yaml, ArgoCD's kustomize version fails to match the ConfigMap.

This was a pre-existing issue unmasked when the application-controller (which was Pending for 4h+) came back up and tried to sync.

## Fix

1. **Migrate `patchesJson6902` → `patches`** with explicit `target:` selectors (supports both strategic merge and JSON6902 patch formats in kustomize v5)
2. **Remove `namespace: argocd`** from `patches/argocd-params.yaml` — the global `namespace:` setter in kustomization.yaml already applies it

## Validation

```bash
kustomize build apps/00-infra/argocd/overlays/prod  # exits 0, no warnings
yamllint -c yamllint-config.yml ...  # no errors
```