### PR TITLE
fix(sizing): rightsize mariadb-shared, radarr, prowlarr sidecars (-4.5Gi)

### DIFF
--- a/apps/04-databases/mariadb-shared/base/statefulset.yaml
+++ b/apps/04-databases/mariadb-shared/base/statefulset.yaml
@@ -15,8 +15,8 @@ spec:
     metadata:
       labels:
         app: mariadb-shared
-        vixens.io/sizing.mariadb: large
-        vixens.io/sizing: large
+        vixens.io/sizing.mariadb: small
+        vixens.io/sizing: small
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane

--- a/apps/04-databases/mariadb-shared/overlays/prod/kustomization.yaml
+++ b/apps/04-databases/mariadb-shared/overlays/prod/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../base
 patches:
   - path: patch-infisical-env.yaml
+  - path: resources-patch.yaml
 labels:
   - pairs:
       environment: prod

--- a/apps/04-databases/mariadb-shared/overlays/prod/resources-patch.yaml
+++ b/apps/04-databases/mariadb-shared/overlays/prod/resources-patch.yaml
@@ -7,12 +7,3 @@ spec:
   template:
     spec:
       priorityClassName: vixens-critical
-      containers:
-        - name: mariadb
-          resources:
-            requests:
-              cpu: 200m
-              memory: 512Mi
-            limits:
-              cpu: 1000m
-              memory: 1Gi

--- a/apps/20-media/prowlarr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/prowlarr/overlays/prod/resources-patch.yaml
@@ -5,12 +5,12 @@ metadata:
   name: prowlarr
   labels:
     vixens.io/sizing.prowlarr: medium
-    vixens.io/sizing.litestream: small
-    vixens.io/sizing.config-syncer: small
+    vixens.io/sizing.litestream: micro
+    vixens.io/sizing.config-syncer: micro
 spec:
   template:
     metadata:
       labels:
         vixens.io/sizing.prowlarr: medium
-        vixens.io/sizing.litestream: small
-        vixens.io/sizing.config-syncer: small
+        vixens.io/sizing.litestream: micro
+        vixens.io/sizing.config-syncer: micro

--- a/apps/20-media/radarr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/radarr/overlays/prod/resources-patch.yaml
@@ -5,12 +5,12 @@ metadata:
   name: radarr
   labels:
     vixens.io/sizing.radarr: medium
-    vixens.io/sizing.litestream: small
-    vixens.io/sizing.config-syncer: small
+    vixens.io/sizing.litestream: micro
+    vixens.io/sizing.config-syncer: micro
 spec:
   template:
     metadata:
       labels:
         vixens.io/sizing.radarr: medium
-        vixens.io/sizing.litestream: small
-        vixens.io/sizing.config-syncer: small
+        vixens.io/sizing.litestream: micro
+        vixens.io/sizing.config-syncer: micro


### PR DESCRIPTION
## Problem

Cluster at 95-99% memory on all 5 nodes, 20 pods Pending including ArgoCD components.

Root causes fixed:
1. **mariadb-shared**: `vixens.io/sizing.mariadb: large` → Kyverno injects 4Gi req. The `resources-patch.yaml` that should override this was **never referenced** in `overlays/prod/kustomization.yaml`.
2. **radarr/prowlarr sidecars**: litestream + config-syncer sized `small` (512Mi each) → should be `micro` (128Mi).

## Changes

| App | Before | After | Delta |
|-----|--------|-------|-------|
| mariadb-shared | 4Gi req (large) | 512Mi req (small) | **-3.5Gi** |
| prowlarr: litestream | 512Mi req (small) | 128Mi req (micro) | **-384Mi** |
| prowlarr: config-syncer | 512Mi req (small) | 128Mi req (micro) | **-384Mi** |
| radarr: litestream | 512Mi req (small) | 128Mi req (micro) | **-384Mi** |
| radarr: config-syncer | 512Mi req (small) | 128Mi req (micro) | **-384Mi** |

**Total: ~4.6Gi memory requests freed**

## Implementation

- `mariadb-shared/base/statefulset.yaml`: sizing label `large` → `small`
- `mariadb-shared/overlays/prod/resources-patch.yaml`: stripped hardcoded resources (now handled by Kyverno), kept `priorityClassName: vixens-critical`
- `mariadb-shared/overlays/prod/kustomization.yaml`: added `resources-patch.yaml` to patches list
- `prowlarr/overlays/prod/resources-patch.yaml`: sidecars `small` → `micro`
- `radarr/overlays/prod/resources-patch.yaml`: sidecars `small` → `micro`

## Expected outcome

~4.6Gi of memory requests freed → nodes drop from 99% to ~70% → Pending pods schedule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resource sizing configurations for MariaDB, Prowlarr, and Radarr services to optimize deployment efficiency across production environments.
  * Modified container resource constraints for MariaDB deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->