### PR TITLE
fix(external-dns): rightsize gandi+unifi to micro (-768Mi)

### DIFF
--- a/apps/40-network/external-dns-gandi/values/prod.yaml
+++ b/apps/40-network/external-dns-gandi/values/prod.yaml
@@ -39,5 +39,5 @@ resources:
     cpu: 100m
     memory: 128Mi
 podLabels:
-  vixens.io/sizing.external-dns: small
-  vixens.io/sizing: small
+  vixens.io/sizing.external-dns: micro
+  vixens.io/sizing: micro

--- a/apps/40-network/external-dns-unifi/values/common.yaml
+++ b/apps/40-network/external-dns-unifi/values/common.yaml
@@ -56,6 +56,6 @@ policy: sync
 sources:
   - ingress
 podLabels:
-  vixens.io/sizing.external-dns: small
+  vixens.io/sizing.external-dns: micro
   vixens.io/sizing.unifi-webhook: micro
-  vixens.io/sizing: small
+  vixens.io/sizing: micro


### PR DESCRIPTION
## Problem

Both external-dns instances had \`vixens.io/sizing.external-dns: small\` → Kyverno injecting **512Mi req** instead of the 64Mi configured in Helm values (Kyverno mutation webhook takes precedence over Helm-rendered resources).

external-dns is a lightweight DNS sync daemon — 128Mi is more than sufficient.

## Changes

| App | Label Before | Label After | Memory Before | Memory After | Delta |
|-----|-------------|-------------|--------------|--------------|-------|
| external-dns-gandi | small | micro | 512Mi req | 128Mi req | **-384Mi** |
| external-dns-unifi | small | micro | 512Mi req | 128Mi req | **-384Mi** |
| unifi-webhook | micro (unchanged) | micro | 128Mi req | 128Mi req | 0 |

**Total: -768Mi memory requests**