### PR TITLE
fix(priority): demote reloader+vpa from vixens-critical

### DIFF
--- a/apps/00-infra/reloader/base/kustomization.yaml
+++ b/apps/00-infra/reloader/base/kustomization.yaml
@@ -19,16 +19,16 @@ patches:
               prometheus.io/scrape: "true"
               prometheus.io/port: "9090"
             labels:
-              vixens.io/sizing.reloader-reloader: small
-              vixens.io/sizing: small
+              vixens.io/sizing.reloader-reloader: micro
+              vixens.io/sizing: micro
           spec:
-            priorityClassName: vixens-critical
+            priorityClassName: vixens-low
             containers:
               - name: reloader-reloader
                 resources:
                   requests:
                     cpu: 100m
-                    memory: 256Mi
+                    memory: 128Mi
                   limits:
                     cpu: 100m
-                    memory: 256Mi
+                    memory: 128Mi

--- a/apps/00-infra/vpa/overlays/prod/resources-patch.yaml
+++ b/apps/00-infra/vpa/overlays/prod/resources-patch.yaml
@@ -8,7 +8,7 @@ spec:
   revisionHistoryLimit: 3
   template:
     spec:
-      priorityClassName: vixens-critical
+      priorityClassName: vixens-medium
       containers:
         - name: admission-controller
           resources:
@@ -28,7 +28,7 @@ spec:
   revisionHistoryLimit: 3
   template:
     spec:
-      priorityClassName: vixens-critical
+      priorityClassName: vixens-medium
       containers:
         - name: recommender
           resources:
@@ -48,7 +48,7 @@ spec:
   revisionHistoryLimit: 3
   template:
     spec:
-      priorityClassName: vixens-critical
+      priorityClassName: vixens-medium
       containers:
         - name: updater
           resources:


### PR DESCRIPTION
## Problem

reloader and all 3 VPA components had \`priorityClassName: vixens-critical\`, meaning they evict other workloads to schedule. This is incorrect — they are not cluster-critical infrastructure.

- **reloader**: A ConfigMap/Secret watcher that triggers pod restarts. Useful, but not critical.
- **vpa-admission-controller / vpa-recommender / vpa-updater**: VPA tooling that recommends resource adjustments. Important but not cluster-breaking if delayed.

With all nodes at 99% memory, these components were preventing legitimate Pending pods from scheduling via preemption.

## Changes

| Component | Priority Before | Priority After | Memory |
|-----------|----------------|----------------|--------|
| reloader | vixens-critical | **vixens-low** | 256Mi→128Mi (-128Mi) |
| vpa-admission-controller | vixens-critical | **vixens-medium** | 500Mi (unchanged) |
| vpa-recommender | vixens-critical | **vixens-medium** | 1Gi (unchanged) |
| vpa-updater | vixens-critical | **vixens-medium** | 500Mi (unchanged) |

Also: reloader sizing label \`small\`→\`micro\` (Kyverno will inject 128Mi instead of 512Mi).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized reloader deployment with reduced memory allocation and adjusted service prioritization.
  * Updated VPA component priority levels across admission controller, recommender, and updater services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->