### PR TITLE
fix(media): rightsize sonarr/whisparr/mylar/sabnzbd (-1.1Gi)

### DIFF
--- a/apps/20-media/mylar/base/deployment.yaml
+++ b/apps/20-media/mylar/base/deployment.yaml
@@ -16,8 +16,8 @@ spec:
     metadata:
       labels:
         app: mylar
-        vixens.io/sizing.mylar: small
-        vixens.io/sizing: small
+        vixens.io/sizing.mylar: micro
+        vixens.io/sizing: micro
       annotations:
         reloader.stakater.com/auto: "true"
         prometheus.io/scrape: "true"

--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -16,8 +16,8 @@ spec:
     metadata:
       labels:
         app: sabnzbd
-        vixens.io/sizing.sabnzbd: medium
-        vixens.io/sizing: medium
+        vixens.io/sizing.sabnzbd: small
+        vixens.io/sizing: small
       annotations:
         reloader.stakater.com/auto: "true"
         prometheus.io/scrape: "true"

--- a/apps/20-media/sonarr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/sonarr/overlays/prod/resources-patch.yaml
@@ -7,6 +7,6 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.sonarr: small
+        vixens.io/sizing.sonarr: micro
         vixens.io/sizing.litestream: micro
         vixens.io/sizing.config-syncer: micro

--- a/apps/20-media/whisparr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/whisparr/overlays/prod/resources-patch.yaml
@@ -4,13 +4,13 @@ kind: Deployment
 metadata:
   name: whisparr
   labels:
-    vixens.io/sizing.whisparr: G-medium
+    vixens.io/sizing.whisparr: G-small
     vixens.io/sizing.litestream: micro
     vixens.io/sizing.config-syncer: micro
 spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.whisparr: G-medium
+        vixens.io/sizing.whisparr: G-small
         vixens.io/sizing.litestream: micro
         vixens.io/sizing.config-syncer: micro


### PR DESCRIPTION
## Problem

Several media stack apps had oversized memory requests via Kyverno sizing labels.

## Changes

| App | Sizing Before | Sizing After | Memory Before | Memory After | Delta |
|-----|--------------|-------------|--------------|--------------|-------|
| sonarr | small | **micro** | 512Mi req | 128Mi req | **-384Mi** |
| whisparr | G-medium | **G-small** | 512Mi req | 128Mi req | **-384Mi** |
| mylar | small | **micro** | 512Mi req | 128Mi req | **-384Mi** |
| sabnzbd | medium | **small** | 512Mi req | 512Mi req | 0 (stays, downloader needs buffer) |

**Total: -1152Mi memory requests**

## Rationale

- sonarr/mylar/whisparr: lightweight arr-type apps that index/manage media metadata — 128Mi is appropriate
- sabnzbd: kept at 512Mi (NZB downloader with active downloads can spike memory)