### PR TITLE
fix(kyverno): grant admission-controller VPA list/get for generate policy

### DIFF
--- a/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
+++ b/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
@@ -1,5 +1,5 @@
 ---
-# RBAC: Allow Kyverno background controller to create/manage VPA objects
+# RBAC: Allow Kyverno controllers to manage/inspect VPA objects
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -33,6 +33,9 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kyverno-background-controller
+    namespace: kyverno
+  - kind: ServiceAccount
+    name: kyverno-admission-controller
     namespace: kyverno
 ---
 # Kyverno Policy: Sizing VPA Generate


### PR DESCRIPTION
The sizing-vpa-generate ClusterPolicy was rejected by the Kyverno admission webhook because kyverno-admission-controller lacked list/get permissions on VPA resources. Added it as a subject to the kyverno:vpa-manager ClusterRoleBinding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system permission configuration to grant the admission controller access to VerticalPodAutoscaler resources. This enables both the background and admission controllers to collaborate on managing and inspecting pod autoscaling configurations, enhancing the system's efficiency and reliability in handling vertical pod autoscaling operations across your cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->