### PR TITLE
fix(kyverno): vpa-generate precondition looks at pod template labels

### DIFF
--- a/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
+++ b/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
@@ -77,8 +77,9 @@ spec:
                 - StatefulSet
       preconditions:
         any:
-          # Trigger if any v2 sizing label is present on the workload
-          - key: "{{ request.object.metadata.labels | keys(@) | [?starts_with(@, 'vixens.io/sizing.')] | length(@) }}"
+          # Trigger if any v2 sizing label is present on the pod template
+          # (labels are on spec.template.metadata, not Deployment metadata)
+          - key: "{{ request.object.spec.template.metadata.labels | keys(@) | [?starts_with(@, 'vixens.io/sizing.')] | length(@) }}"
             operator: GreaterThanOrEquals
             value: 1
       generate:


### PR DESCRIPTION
The generate rule precondition was checking request.object.metadata.labels (Deployment metadata) instead of request.object.spec.template.metadata.labels (pod template). Since v2 sizing labels are on the pod template, the VPA was never generated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected vertical pod autoscaling policy to inspect pod template labels instead of workload metadata, ensuring proper policy triggering based on sizing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->