### PR TITLE
fix(kyverno): use label selector for vpa-generate trigger

### DIFF
--- a/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
+++ b/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
@@ -75,13 +75,11 @@ spec:
               kinds:
                 - Deployment
                 - StatefulSet
-      preconditions:
-        any:
-          # Trigger if any v2 sizing label is present on the pod template
-          # (labels are on spec.template.metadata, not Deployment metadata)
-          - key: "{{ request.object.spec.template.metadata.labels | keys(@) | [?starts_with(@, 'vixens.io/sizing.')] | length(@) }}"
-            operator: GreaterThanOrEquals
-            value: 1
+              # Trigger: Deployment/StatefulSet must have this label on its OWN metadata
+              # (not pod template). Add this when migrating an app to v2 sizing.
+              selector:
+                matchLabels:
+                  vixens.io/sizing-v2: "true"
       generate:
         apiVersion: autoscaling.k8s.io/v1
         kind: VerticalPodAutoscaler

--- a/apps/99-test/whoami/base/deployment.yaml
+++ b/apps/99-test/whoami/base/deployment.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: whoami
+  labels:
+    vixens.io/sizing-v2: "true"
 spec:
   replicas: 1
   revisionHistoryLimit: 3


### PR DESCRIPTION
Replace the JMESPath precondition (checking pod template labels) with a simple label selector on the Deployment/StatefulSet metadata: \`vixens.io/sizing-v2: "true"\`.

**Why**: Kyverno generate rule preconditions using JMESPath on \`spec.template.metadata.labels\` don't trigger reliably in background mode. A Deployment metadata label selector is explicit, reliable, and easy to verify.

**Migration contract**: when migrating an app to v2 sizing, add \`vixens.io/sizing-v2: "true"\` to Deployment metadata → Kyverno auto-generates the VPA.

**whoami**: first app with this label, used as validation target.