### PR TITLE
fix(kyverno): fix VPA mode field and sidecar precondition

### DIFF
--- a/apps/00-infra/kyverno/base/policies/sizing-v2-mutate.yaml
+++ b/apps/00-infra/kyverno/base/policies/sizing-v2-mutate.yaml
@@ -120,10 +120,11 @@ spec:
           - list: "request.object.spec.containers || '[]'"
             preconditions:
               all:
-                # Only act on containers that have NO v2 sizing label
-                - key: "{{ request.object.metadata.labels.\"vixens.io/sizing.{{element.name}}\" }}"
+                # Only act on containers that have NO v2 sizing label.
+                # Use keys() to avoid 'Unknown key' JMESPath error on absent labels.
+                - key: "{{ request.object.metadata.labels | keys(@) | [?@ == 'vixens.io/sizing.{{element.name}}'] | length(@) }}"
                   operator: Equals
-                  value: ""
+                  value: "0"
             patchStrategicMerge:
               spec:
                 containers:

--- a/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
+++ b/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
@@ -104,12 +104,9 @@ spec:
               updateMode: "Off"
             resourcePolicy:
               containerPolicies:
-                # Default policy for all containers not explicitly managed by Kyverno sizing
-                # VPA will observe and recommend — containers with G-*/B-*/SB-* labels
-                # will have their own containerPolicy injected by the app owner if needed.
-                # This catch-all covers unlabeled sidecars with RequestsOnly mode.
+                # Observe all containers — unlabeled sidecars get VPA recommendations.
+                # minAllowed is the floor; VPA won't shrink below this.
                 - containerName: "*"
-                  mode: "RequestsOnly"
                   minAllowed:
                     cpu: "5m"
                     memory: "64Mi"


### PR DESCRIPTION
## Problem

Two bugs in the Kyverno v2 sizing policies were blocking full validation of the whoami migration.

### Bug 1 — `sizing-vpa-generate.yaml`: invalid `mode: RequestsOnly`

The generated VPA object included `mode: RequestsOnly` in `containerPolicies[*]`, which the VPA webhook (`vpa.k8s.io`) rejects with *"unexpected Mode value RequestsOnly"*. This prevented any VPA from being created by the generate rule.

**Fix:** Remove the `mode` field entirely from the wildcard `containerName: "*"` entry. Only `minAllowed` is needed — VPA will observe and recommend without a mode restriction.

### Bug 2 — `sizing-v2-mutate.yaml`: JMESPath `Unknown key` on absent labels

The `v2-unlabeled-sidecar-defaults` rule precondition accessed `request.object.metadata.labels."vixens.io/sizing.<container>"` directly. When this label is absent, Kyverno's JMESPath evaluator throws `Unknown key`, which propagates as an error on **every pod in the cluster** (velero, renovate, trivy, etc.).

**Fix:** Use `keys()` to check label existence without direct access:
```yaml
key: "{{ request.object.metadata.labels | keys(@) | [?@ == 'vixens.io/sizing.{{element.name}}'] | length(@) }}"
operator: Equals
value: "0"
```

## Impact

- ✅ `vixens-whoami` VPA will be created after `kubectl delete clusterpolicy sizing-vpa-generate` + ArgoCD sync
- ✅ No more `Unknown key` errors from `sizing-v2-mutate` in admission-controller logs
- ✅ Whoami migration to v2 fully validated

## Post-merge manual step required

The generate rule is immutable (Kyverno limitation). After merge + ArgoCD sync:
```bash
kubectl delete clusterpolicy sizing-vpa-generate
# ArgoCD will recreate it on next sync
```