### PR TITLE
feat(sizing): implement V-* mode with dynamic VPA updateMode

### DIFF
--- a/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
+++ b/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
@@ -101,7 +101,8 @@ spec:
               kind: "{{ request.object.kind }}"
               name: "{{ request.object.metadata.name }}"
             updatePolicy:
-              updateMode: "Off"
+              updateMode: >-
+                {{ request.object.metadata.labels | keys(@) | [?@ == 'vixens.io/vpa-mode'] | length(@) > `0` && request.object.metadata.labels."vixens.io/vpa-mode" || 'Off' }}
             resourcePolicy:
               containerPolicies:
                 # Observe all containers — unlabeled sidecars get VPA recommendations.

--- a/apps/20-media/radarr/base/deployment.yaml
+++ b/apps/20-media/radarr/base/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: radarr
     vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
     vixens.io/backup-profile: "standard"
     vixens.io/tier: "diamond"
 spec:
@@ -19,9 +20,9 @@ spec:
     metadata:
       labels:
         app: radarr
-        vixens.io/sizing.radarr: B-medium
-        vixens.io/sizing.litestream: B-nano
-        vixens.io/sizing.config-syncer: B-nano
+        vixens.io/sizing.radarr: V-medium
+        vixens.io/sizing.litestream: V-nano
+        vixens.io/sizing.config-syncer: V-nano
         vixens.io/sizing.fix-permissions: G-nano
         vixens.io/sizing.restore-config: B-nano
         vixens.io/backup-profile: "standard"

--- a/apps/99-test/whoami/base/deployment.yaml
+++ b/apps/99-test/whoami/base/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: whoami
   labels:
     vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -15,7 +16,7 @@ spec:
     metadata:
       labels:
         app: whoami
-        vixens.io/sizing.whoami: "B-nano"
+        vixens.io/sizing.whoami: "V-nano"
       annotations:
         vixens.io/nometrics: "true"
         goldilocks.fairwinds.com/enabled: "true"


### PR DESCRIPTION
## Summary

Implements the `V-*` sizing mode: VPA in `Auto` mode takes over resource management after initial sizing from Kyverno.

## How it works

### `sizing-vpa-generate.yaml`
`updateMode` is now dynamic — reads `vixens.io/vpa-mode` label from the Deployment metadata:
- Label present with value `Auto` → VPA created with `updateMode: Auto`
- Label absent (or any other value) → VPA created with `updateMode: Off` (safe default)

JMESPath uses `keys()` + short-circuit `&&` to safely handle absent labels without `Unknown key` errors:
```
{{ request.object.metadata.labels | keys(@) | [?@ == 'vixens.io/vpa-mode'] | length(@) > `0` && request.object.metadata.labels."vixens.io/vpa-mode" || 'Off' }}
```

### Webhook ordering (why this works)
Kyverno fires before VPA (`kyverno-*` < `vpa-*` alphabetically). On pod (re)creation:
1. Kyverno applies initial resources from `V-*` labels
2. VPA webhook overrides with its recommendations (if any exist)

So `V-*` labels = documented starting point. VPA eventually takes over.

### Apps migrated to V-* mode

| App | Label | VPA mode | Notes |
|---|---|---|---|
| `whoami` | `V-nano` | Auto | test app, safe to let VPA manage |
| `radarr` (main) | `V-medium` | Auto | will self-tune over days |
| `radarr` (litestream, config-syncer) | `V-nano` | Auto | sidecars included |
| `radarr` (fix-permissions, restore-config init) | `G-nano` / `B-nano` | — | initContainers kept static (unreliable VPA data) |

### Critical apps (not affected)
`frigate`, `homeassistant`, `adguard` — not migrated to v2, no `vixens.io/sizing-v2: "true"` label → zero impact.

## Post-merge steps (REQUIRED)

The generate rule spec changed → immutable field → must delete + let ArgoCD recreate:

```bash
kubectl delete clusterpolicy sizing-vpa-generate
# ArgoCD kyverno hard refresh + sync
```

Then Kyverno's background controller will:
1. Re-evaluate all Deployments with `vixens.io/sizing-v2: "true"`
2. Update existing VPAs: `vixens-whoami` and `vixens-radarr` → `updateMode: Auto`
3. Keep all other VPAs (no `vixens.io/vpa-mode` label) at `updateMode: Off`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vertical Pod Autoscaler modes are now dynamically configurable per application through labeling, enabling Auto or Off modes based on application requirements.

* **Chores**
  * Updated resource sizing configurations across applications and enabled VPA Auto mode for media and test deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->