### PR TITLE
fix(kyverno): fix JMESPath pipe context bug in VPA updateMode expression

### DIFF
--- a/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
+++ b/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
@@ -102,7 +102,7 @@ spec:
               name: "{{ request.object.metadata.name }}"
             updatePolicy:
               updateMode: >-
-                {{ request.object.metadata.labels | keys(@) | [?@ == 'vixens.io/vpa-mode'] | length(@) > `0` && request.object.metadata.labels."vixens.io/vpa-mode" || 'Off' }}
+                {{ contains(keys(request.object.metadata.labels), 'vixens.io/vpa-mode') && request.object.metadata.labels."vixens.io/vpa-mode" || 'Off' }}
             resourcePolicy:
               containerPolicies:
                 # Observe all containers — unlabeled sidecars get VPA recommendations.


### PR DESCRIPTION
## Problem

The `sizing-vpa-generate` ClusterPolicy had a broken JMESPath expression for determining the VPA `updateMode`.

### Root cause

```yaml
# BROKEN — after the last pipe, @ = filtered array, not the request object
updateMode: >-
  {{ request.object.metadata.labels | keys(@) | [?@ == 'vixens.io/vpa-mode'] | length(@) > `0` && request.object.metadata.labels."vixens.io/vpa-mode" || 'Off' }}
```

After the last `|`, the JMESPath context `@` is the filtered array. So `request.object.metadata.labels` looks for key `request` in an array → returns `null` → `null || 'Off'` = `'Off'` for **all** deployments, even those with `vixens.io/vpa-mode: Auto`.

## Fix

```yaml
# CORRECT — contains(keys(...)) uses function calls, no context shift
updateMode: >-
  {{ contains(keys(request.object.metadata.labels), 'vixens.io/vpa-mode') && request.object.metadata.labels."vixens.io/vpa-mode" || 'Off' }}
```

`contains()` and `keys()` are JMESPath function calls that don't shift `@`, so `request.object.metadata.labels` remains accessible after the check.

## Impact

- whoami: had `vixens.io/vpa-mode: Auto` label → VPA was generated with `Off` ❌ → will now get `Auto` ✅
- radarr: same ✅
- Deployments without the label → still `Off` (no regression)

## Post-merge steps (REQUIRED)

The generate rule is **immutable** in Kyverno — must delete before re-sync:

```bash
kubectl delete clusterpolicy sizing-vpa-generate
# ArgoCD sync kyverno app
kubectl -n whoami annotate deployment whoami vixens.io/force-vpa-regen="$(date +%s)" --overwrite
kubectl -n media annotate deployment radarr vixens.io/force-vpa-regen="$(date +%s)" --overwrite
```