### PR TITLE
feat(sizing): migrate sonarr, lidarr, whisparr to sizing v2 with VPA Auto

### DIFF
--- a/apps/20-media/lidarr/base/deployment.yaml
+++ b/apps/20-media/lidarr/base/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: lidarr
   labels:
     app: lidarr
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   strategy:
     type: Recreate
@@ -16,6 +18,12 @@ spec:
     metadata:
       labels:
         app: lidarr
+        vixens.io/sizing.lidarr: V-medium
+        vixens.io/sizing.litestream: V-nano
+        vixens.io/sizing.config-syncer: V-nano
+        vixens.io/sizing.fix-permissions: G-nano
+        vixens.io/sizing.restore-config: B-nano
+        vixens.io/sizing.restore-db: B-nano
       annotations:
         reloader.stakater.com/auto: "true"
         prometheus.io/scrape: "true"
@@ -53,13 +61,6 @@ spec:
           envFrom:
             - secretRef:
                 name: lidarr-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /config
@@ -78,13 +79,6 @@ spec:
           envFrom:
             - secretRef:
                 name: lidarr-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /config
@@ -109,13 +103,6 @@ spec:
               port: http
             initialDelaySeconds: 15
             periodSeconds: 10
-          resources:
-            requests:
-              cpu: 100m
-              memory: 256Mi
-            limits:
-              cpu: 1000m
-              memory: 1Gi
           env:
             - name: LIDARR__API_KEY
               valueFrom:
@@ -151,13 +138,6 @@ spec:
           ports:
             - containerPort: 9090
               name: metrics
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           envFrom:
             - secretRef:
                 name: lidarr-secrets
@@ -192,13 +172,6 @@ spec:
           envFrom:
             - secretRef:
                 name: lidarr-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/20-media/sonarr/base/deployment.yaml
+++ b/apps/20-media/sonarr/base/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: sonarr
   labels:
     app: sonarr
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   strategy:
     type: Recreate
@@ -16,6 +18,12 @@ spec:
     metadata:
       labels:
         app: sonarr
+        vixens.io/sizing.sonarr: V-medium
+        vixens.io/sizing.litestream: V-nano
+        vixens.io/sizing.config-syncer: V-nano
+        vixens.io/sizing.fix-permissions: G-nano
+        vixens.io/sizing.restore-config: B-nano
+        vixens.io/sizing.restore-db: B-nano
       annotations:
         reloader.stakater.com/auto: "true"
         prometheus.io/scrape: "true"
@@ -53,13 +61,6 @@ spec:
           envFrom:
             - secretRef:
                 name: sonarr-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /config
@@ -78,13 +79,6 @@ spec:
           envFrom:
             - secretRef:
                 name: sonarr-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /config
@@ -109,13 +103,6 @@ spec:
               port: http
             initialDelaySeconds: 15
             periodSeconds: 10
-          resources:
-            requests:
-              cpu: 100m
-              memory: 256Mi
-            limits:
-              cpu: 1000m
-              memory: 1Gi
           env:
             - name: SONARR__API_KEY
               valueFrom:
@@ -161,13 +148,6 @@ spec:
               port: 9090
             initialDelaySeconds: 10
             periodSeconds: 30
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           envFrom:
             - secretRef:
                 name: sonarr-secrets
@@ -202,13 +182,6 @@ spec:
           envFrom:
             - secretRef:
                 name: sonarr-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/20-media/whisparr/base/deployment.yaml
+++ b/apps/20-media/whisparr/base/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: whisparr
   labels:
     app: whisparr
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   strategy:
     type: Recreate
@@ -16,6 +18,11 @@ spec:
     metadata:
       labels:
         app: whisparr
+        vixens.io/sizing.whisparr: V-medium
+        vixens.io/sizing.litestream: V-nano
+        vixens.io/sizing.config-syncer: V-nano
+        vixens.io/sizing.fix-permissions: G-nano
+        vixens.io/sizing.restore-config: B-nano
       annotations:
         reloader.stakater.com/auto: "true"
         prometheus.io/scrape: "true"
@@ -59,13 +66,6 @@ spec:
           envFrom:
             - secretRef:
                 name: whisparr-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /config
@@ -86,13 +86,6 @@ spec:
               port: 6969
             initialDelaySeconds: 15
             periodSeconds: 10
-          resources:
-            requests:
-              cpu: 100m
-              memory: 256Mi
-            limits:
-              cpu: 1000m
-              memory: 1Gi
           env:
             - name: WHISPARR__API_KEY
               valueFrom:
@@ -163,13 +156,6 @@ spec:
           envFrom:
             - secretRef:
                 name: whisparr-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /config


### PR DESCRIPTION
## Summary

Migrate sonarr, lidarr, and whisparr to the sizing v2 system, following the same pattern as radarr (#1764/#1765).

## Changes per app

| App | Main container | Sidecars | InitContainers |
|-----|---------------|----------|----------------|
| sonarr | `V-medium` | litestream `V-nano`, config-syncer `V-nano` | fix-permissions `G-nano`, restore-config `B-nano`, restore-db `B-nano` |
| lidarr | `V-medium` | litestream `V-nano`, config-syncer `V-nano` | fix-permissions `G-nano`, restore-config `B-nano`, restore-db `B-nano` |
| whisparr | `V-medium` | litestream `V-nano`, config-syncer `V-nano` | fix-permissions `G-nano`, restore-config `B-nano` |

## Migration contract applied

- ✅ Added `vixens.io/sizing-v2: "true"` + `vixens.io/vpa-mode: Auto` on Deployment metadata
- ✅ Added per-container sizing labels on pod template (`spec.template.metadata.labels`)
- ✅ Removed all hardcoded `resources:` blocks (Kyverno injects via sizing-v2-mutate policy)
- ✅ Main containers use `V-*` mode → VPA Auto will manage resources after data collection

## Post-merge steps (REQUIRED)

```bash
export KUBECONFIG=.secrets/prod/kubeconfig-prod
TS=$(date +%s)
kubectl -n media annotate deployment sonarr vixens.io/force-vpa-regen="$TS" --overwrite
kubectl -n media annotate deployment lidarr vixens.io/force-vpa-regen="$TS" --overwrite
kubectl -n media annotate deployment whisparr vixens.io/force-vpa-regen="$TS" --overwrite
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resource configuration for Lidarr, Sonarr, and Whisparr media applications.
  * Added sizing and VPA (Vertical Pod Autoscaler) labels for dynamic resource management.
  * Removed fixed CPU/memory constraints, enabling automatic resource allocation and optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->