### PR TITLE
feat(sizing): migrate full media stack to v2 sizing with VPA Auto

### DIFF
--- a/apps/20-media/amule/base/deployment.yaml
+++ b/apps/20-media/amule/base/deployment.yaml
@@ -3,6 +3,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: amule
+  labels:
+    app: amule
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:
@@ -14,6 +18,8 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: amule
+        vixens.io/sizing.amule: V-small
+        vixens.io/sizing.configure-proxy: G-nano
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane
@@ -62,12 +68,6 @@ spec:
               mountPath: /home/amule/.aMule
             - name: downloads
               mountPath: /downloads
-          resources:
-            requests:
-              cpu: 50m
-              memory: 128Mi
-            limits:
-              memory: 512Mi
       initContainers:
         - name: configure-proxy
           image: busybox

--- a/apps/20-media/birdnet-go/base/deployment.yaml
+++ b/apps/20-media/birdnet-go/base/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app: birdnet-go
     app.kubernetes.io/managed-by: argocd
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:
@@ -17,6 +19,10 @@ spec:
     metadata:
       labels:
         app: birdnet-go
+        vixens.io/sizing.birdnet-go: V-medium
+        vixens.io/sizing.litestream: V-nano
+        vixens.io/sizing.data-syncer: V-nano
+        vixens.io/sizing.fix-permissions: G-nano
       annotations:
         goldilocks.fairwinds.com/enabled: "true"
         reloader.stakater.com/auto: "true"
@@ -75,13 +81,6 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 3
             failureThreshold: 3
-          resources:
-            requests:
-              memory: 256Mi
-              cpu: 200m
-            limits:
-              memory: 1Gi
-              cpu: 1000m
         - name: litestream
           image: litestream/litestream:0.5.9
           securityContext:
@@ -94,13 +93,6 @@ spec:
           ports:
             - containerPort: 9090
               name: metrics
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           envFrom:
             - secretRef:
                 name: birdnet-go-secrets
@@ -139,13 +131,6 @@ spec:
           envFrom:
             - secretRef:
                 name: birdnet-go-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: data
               mountPath: /data

--- a/apps/20-media/booklore/base/deployment.yaml
+++ b/apps/20-media/booklore/base/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: booklore
   labels:
     app: booklore
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:
@@ -16,6 +18,9 @@ spec:
     metadata:
       labels:
         app: booklore
+        vixens.io/sizing.booklore: V-medium
+        vixens.io/sizing.config-syncer: V-nano
+        vixens.io/sizing.restore-config: B-nano
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane
@@ -78,13 +83,6 @@ spec:
           envFrom:
             - secretRef:
                 name: booklore-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: data
               mountPath: /app/data
@@ -147,13 +145,6 @@ spec:
           envFrom:
             - secretRef:
                 name: booklore-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: data
               mountPath: /app/data

--- a/apps/20-media/booklore/base/mariadb-deployment.yaml
+++ b/apps/20-media/booklore/base/mariadb-deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: booklore-mariadb
   labels:
     app: booklore-mariadb
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:
@@ -16,7 +18,8 @@ spec:
     metadata:
       labels:
         app: booklore-mariadb
-        vixens.io/sizing.mariadb: G-medium
+        vixens.io/sizing.mariadb: V-medium
+        vixens.io/sizing.db-backup: V-nano
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane
@@ -101,13 +104,6 @@ spec:
           envFrom:
             - secretRef:
                 name: booklore-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 200m
-              memory: 256Mi
       volumes:
         - name: config
           persistentVolumeClaim:

--- a/apps/20-media/booklore/overlays/prod/mariadb-resources-patch.yaml
+++ b/apps/20-media/booklore/overlays/prod/mariadb-resources-patch.yaml
@@ -1,17 +1,2 @@
 ---
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: booklore-mariadb
-spec:
-  template:
-    spec:
-      containers:
-        - name: mariadb
-          resources:
-            requests:
-              cpu: 15m
-              memory: 334Mi
-            limits:
-              cpu: 49m
-              memory: 362Mi
+# v2 sizing managed by Kyverno (vixens.io/sizing-v2: "true" in base deployment)

--- a/apps/20-media/booklore/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/booklore/overlays/prod/resources-patch.yaml
@@ -1,14 +1,2 @@
 ---
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: booklore
-  labels:
-    vixens.io/sizing.booklore: medium
-    vixens.io/sizing.config-syncer: small
-spec:
-  template:
-    metadata:
-      labels:
-        vixens.io/sizing.booklore: medium
-        vixens.io/sizing.config-syncer: small
+# v2 sizing managed by Kyverno (vixens.io/sizing-v2: "true" in base deployment)

--- a/apps/20-media/hydrus-client/base/deployment.yaml
+++ b/apps/20-media/hydrus-client/base/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: hydrus-client
   labels:
     app: hydrus-client
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:
@@ -16,6 +18,14 @@ spec:
     metadata:
       labels:
         app: hydrus-client
+        vixens.io/sizing.hydrus-client: V-large
+        vixens.io/sizing.litestream: V-nano
+        vixens.io/sizing.fix-permissions: G-nano
+        vixens.io/sizing.check-integrity: G-nano
+        vixens.io/sizing.restore-db: B-nano
+        vixens.io/sizing.restore-mappings: B-nano
+        vixens.io/sizing.restore-master: B-nano
+        vixens.io/sizing.restore-caches: B-nano
       annotations:
         reloader.stakater.com/auto: "true"
         prometheus.io/scrape: "true"
@@ -80,13 +90,6 @@ spec:
           envFrom:
             - secretRef:
                 name: hydrus-client-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /opt/hydrus/db
@@ -112,13 +115,6 @@ spec:
           envFrom:
             - secretRef:
                 name: hydrus-client-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /opt/hydrus/db
@@ -144,13 +140,6 @@ spec:
           envFrom:
             - secretRef:
                 name: hydrus-client-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /opt/hydrus/db
@@ -173,13 +162,6 @@ spec:
           envFrom:
             - secretRef:
                 name: hydrus-client-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /opt/hydrus/db
@@ -213,13 +195,6 @@ spec:
               value: "1000"
             - name: TZ
               value: Europe/Paris
-          resources:
-            requests:
-              cpu: 500m
-              memory: 1Gi
-            limits:
-              cpu: "2"
-              memory: 4Gi
           volumeMounts:
             - name: config
               mountPath: /opt/hydrus/db
@@ -240,13 +215,6 @@ spec:
           envFrom:
             - secretRef:
                 name: hydrus-client-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /opt/hydrus/db

--- a/apps/20-media/jellyfin/base/deployment.yaml
+++ b/apps/20-media/jellyfin/base/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: jellyfin
   labels:
     app: jellyfin
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:
@@ -16,8 +18,7 @@ spec:
     metadata:
       labels:
         app: jellyfin
-        vixens.io/sizing.jellyfin: large
-        vixens.io/sizing: large
+        vixens.io/sizing.jellyfin: V-large
     spec:
       priorityClassName: homelab-important
       tolerations:

--- a/apps/20-media/jellyseerr/base/deployment.yaml
+++ b/apps/20-media/jellyseerr/base/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: jellyseerr
   labels:
     app: jellyseerr
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:
@@ -16,8 +18,7 @@ spec:
     metadata:
       labels:
         app: jellyseerr
-        vixens.io/sizing.jellyseerr: small
-        vixens.io/sizing: small
+        vixens.io/sizing.jellyseerr: V-small
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane

--- a/apps/20-media/lazylibrarian/base/deployment.yaml
+++ b/apps/20-media/lazylibrarian/base/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: lazylibrarian
   labels:
     app: lazylibrarian
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:
@@ -16,8 +18,12 @@ spec:
     metadata:
       labels:
         app: lazylibrarian
-        vixens.io/sizing.lazylibrarian: small
-        vixens.io/sizing: small
+        vixens.io/sizing.lazylibrarian: V-small
+        vixens.io/sizing.litestream: V-nano
+        vixens.io/sizing.config-syncer: V-nano
+        vixens.io/sizing.fix-permissions: G-nano
+        vixens.io/sizing.restore-config: B-nano
+        vixens.io/sizing.restore-db: B-nano
       annotations:
         reloader.stakater.com/auto: "true"
         prometheus.io/scrape: "true"
@@ -65,13 +71,6 @@ spec:
           envFrom:
             - secretRef:
                 name: lazylibrarian-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /config
@@ -90,13 +89,6 @@ spec:
           envFrom:
             - secretRef:
                 name: lazylibrarian-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /config
@@ -138,13 +130,6 @@ spec:
           envFrom:
             - secretRef:
                 name: lazylibrarian-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /config
@@ -185,13 +170,6 @@ spec:
           envFrom:
             - secretRef:
                 name: lazylibrarian-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/20-media/music-assistant/base/deployment.yaml
+++ b/apps/20-media/music-assistant/base/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: music-assistant
   labels:
     app: music-assistant
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:
@@ -16,6 +18,7 @@ spec:
     metadata:
       labels:
         app: music-assistant
+        vixens.io/sizing.music-assistant: V-medium
     spec:
       securityContext:
         fsGroup: 1000

--- a/apps/20-media/mylar/base/deployment.yaml
+++ b/apps/20-media/mylar/base/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: mylar
   labels:
     app: mylar
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:
@@ -16,8 +18,12 @@ spec:
     metadata:
       labels:
         app: mylar
-        vixens.io/sizing.mylar: micro
-        vixens.io/sizing: micro
+        vixens.io/sizing.mylar: V-medium
+        vixens.io/sizing.litestream: V-nano
+        vixens.io/sizing.config-syncer: V-nano
+        vixens.io/sizing.fix-permissions: G-nano
+        vixens.io/sizing.restore-config: B-nano
+        vixens.io/sizing.restore-db: B-nano
       annotations:
         reloader.stakater.com/auto: "true"
         prometheus.io/scrape: "true"
@@ -55,13 +61,6 @@ spec:
           envFrom:
             - secretRef:
                 name: mylar-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /config
@@ -80,13 +79,6 @@ spec:
           envFrom:
             - secretRef:
                 name: mylar-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /config
@@ -111,13 +103,6 @@ spec:
               port: http
             initialDelaySeconds: 60
             periodSeconds: 20
-          resources:
-            requests:
-              cpu: 100m
-              memory: 256Mi
-            limits:
-              cpu: 500m
-              memory: 512Mi
           env:
             - name: PUID
               value: "1000"
@@ -148,13 +133,6 @@ spec:
           ports:
             - containerPort: 9090
               name: metrics
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           envFrom:
             - secretRef:
                 name: mylar-secrets
@@ -189,13 +167,6 @@ spec:
           envFrom:
             - secretRef:
                 name: mylar-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/20-media/prowlarr/base/deployment.yaml
+++ b/apps/20-media/prowlarr/base/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: prowlarr
   labels:
     app: prowlarr
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   strategy:
     type: Recreate
@@ -16,6 +18,12 @@ spec:
     metadata:
       labels:
         app: prowlarr
+        vixens.io/sizing.prowlarr: V-medium
+        vixens.io/sizing.litestream: V-nano
+        vixens.io/sizing.config-syncer: V-nano
+        vixens.io/sizing.fix-permissions: G-nano
+        vixens.io/sizing.restore-config: B-nano
+        vixens.io/sizing.restore-db: B-nano
       annotations:
         reloader.stakater.com/auto: "true"
         prometheus.io/scrape: "true"
@@ -53,13 +61,6 @@ spec:
           envFrom:
             - secretRef:
                 name: prowlarr-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /config
@@ -78,13 +79,6 @@ spec:
           envFrom:
             - secretRef:
                 name: prowlarr-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /config
@@ -109,13 +103,6 @@ spec:
               port: http
             initialDelaySeconds: 15
             periodSeconds: 10
-          resources:
-            requests:
-              cpu: 100m
-              memory: 256Mi
-            limits:
-              cpu: 500m
-              memory: 512Mi
           env:
             - name: PROWLARR__API_KEY
               valueFrom:
@@ -146,13 +133,6 @@ spec:
           ports:
             - containerPort: 9090
               name: metrics
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           envFrom:
             - secretRef:
                 name: prowlarr-secrets
@@ -187,13 +167,6 @@ spec:
           envFrom:
             - secretRef:
                 name: prowlarr-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/20-media/pyload/base/deployment.yaml
+++ b/apps/20-media/pyload/base/deployment.yaml
@@ -3,6 +3,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pyload
+  labels:
+    app: pyload
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:
@@ -14,8 +18,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: pyload
-        vixens.io/sizing.pyload: medium
-        vixens.io/sizing: medium
+        vixens.io/sizing.pyload: V-small
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane
@@ -45,12 +48,6 @@ spec:
               mountPath: /config
             - name: downloads
               mountPath: /downloads
-          resources:
-            requests:
-              cpu: 50m
-              memory: 128Mi
-            limits:
-              memory: 512Mi
       volumes:
         - name: config
           persistentVolumeClaim:

--- a/apps/20-media/qbittorrent/base/deployment.yaml
+++ b/apps/20-media/qbittorrent/base/deployment.yaml
@@ -3,6 +3,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: qbittorrent
+  labels:
+    app: qbittorrent
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:
@@ -14,8 +18,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: qbittorrent
-        vixens.io/sizing.qbittorrent: medium
-        vixens.io/sizing: medium
+        vixens.io/sizing.qbittorrent: V-medium
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane
@@ -58,12 +61,6 @@ spec:
               mountPath: /config
             - name: downloads
               mountPath: /downloads
-          resources:
-            requests:
-              cpu: 50m
-              memory: 256Mi
-            limits:
-              memory: 1Gi
       volumes:
         - name: config
           persistentVolumeClaim:

--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: sabnzbd
   labels:
     app: sabnzbd
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   strategy:
     type: Recreate
@@ -16,8 +18,10 @@ spec:
     metadata:
       labels:
         app: sabnzbd
-        vixens.io/sizing.sabnzbd: small
-        vixens.io/sizing: small
+        vixens.io/sizing.sabnzbd: V-medium
+        vixens.io/sizing.litestream: V-nano
+        vixens.io/sizing.config-syncer: V-nano
+        vixens.io/sizing.restore-config: B-nano
       annotations:
         reloader.stakater.com/auto: "true"
         prometheus.io/scrape: "true"
@@ -55,13 +59,6 @@ spec:
           envFrom:
             - secretRef:
                 name: sabnzbd-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /config
@@ -83,13 +80,6 @@ spec:
               port: http
             initialDelaySeconds: 15
             periodSeconds: 10
-          resources:
-            requests:
-              cpu: 100m
-              memory: 256Mi
-            limits:
-              cpu: 1000m
-              memory: 1Gi
           env:
             - name: PUID
               value: "1000"
@@ -149,13 +139,6 @@ spec:
           envFrom:
             - secretRef:
                 name: sabnzbd-secrets
-          resources:
-            requests:
-              cpu: 10m
-              memory: 64Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
           volumeMounts:
             - name: config
               mountPath: /config


### PR DESCRIPTION
## Summary

Complete migration of the media stack to sizing v2, following the radarr/sonarr/lidarr/whisparr pattern.

## Apps migrated (14 apps)

| App | Namespace | Main sizing | Notes |
|-----|-----------|------------|-------|
| prowlarr | media | V-medium | standard litestream pattern |
| sabnzbd | media | V-medium | v1 labels replaced |
| qbittorrent | media | V-medium | added metadata labels section |
| jellyfin | media | V-large | v1 label format updated |
| jellyseerr | media | V-small | v1 label format updated |
| mylar | media | V-medium | v1 micro label replaced |
| lazylibrarian | media | V-small | v1 small label replaced |
| music-assistant | media | V-medium | single container, no resources |
| hydrus-client | media | V-large | 6 initContainers, check-integrity labeled |
| booklore | media | V-medium | prod overlay resource patches cleared |
| booklore-mariadb | media | V-medium | v1 G-medium migrated, db-backup V-nano |
| birdnet-go | birdnet-go | V-medium | data-syncer (not config-syncer) |
| amule | downloads | V-small | added metadata labels section |
| pyload | downloads | V-small | v1 labels replaced |

## Pattern applied

- `vixens.io/sizing-v2: "true"` + `vixens.io/vpa-mode: Auto` on Deployment metadata
- Per-container V-*/B-nano/G-nano labels on pod template
- All hardcoded `resources:` blocks removed
- booklore prod overlay `resources-patch.yaml` and `mariadb-resources-patch.yaml` cleared (v2 handles sizing in base)

## Post-merge

```bash
export KUBECONFIG=.secrets/prod/kubeconfig-prod
TS=$(date +%s)
for app in prowlarr sabnzbd qbittorrent jellyfin jellyseerr mylar lazylibrarian music-assistant hydrus-client booklore booklore-mariadb; do
  kubectl -n media annotate deployment $app vixens.io/force-vpa-regen="$TS" --overwrite
done
kubectl -n birdnet-go annotate deployment birdnet-go vixens.io/force-vpa-regen="$TS" --overwrite
kubectl -n downloads annotate deployment amule pyload vixens.io/force-vpa-regen="$TS" --overwrite
```