### PR TITLE
fix(hydrus-client): clear prod overlay v1 sizing labels

### DIFF
--- a/apps/20-media/hydrus-client/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/resources-patch.yaml
@@ -1,11 +1,2 @@
 ---
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: hydrus-client
-spec:
-  template:
-    metadata:
-      labels:
-        vixens.io/sizing.hydrus-client: small
-        vixens.io/sizing.litestream: micro
+# v2 sizing managed by Kyverno (vixens.io/sizing-v2: "true" in base deployment)


### PR DESCRIPTION
Remove v1 sizing labels from prod overlay resources-patch.yaml that were overriding v2 sizing from base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified resource sizing configuration by delegating management to automated policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->