### PR TITLE
feat(sizing-v2): migrate apps/40-network stack to v2 + VPA Auto

### DIFF
--- a/apps/40-network/external-dns-gandi/values/prod.yaml
+++ b/apps/40-network/external-dns-gandi/values/prod.yaml
@@ -31,13 +31,5 @@ policy: sync
 sources:
   - ingress
 priorityClassName: vixens-high
-resources:
-  requests:
-    cpu: 20m
-    memory: 64Mi
-  limits:
-    cpu: 100m
-    memory: 128Mi
 podLabels:
-  vixens.io/sizing.external-dns: micro
-  vixens.io/sizing: micro
+  vixens.io/sizing.external-dns: G-nano

--- a/apps/40-network/external-dns-unifi/values/common.yaml
+++ b/apps/40-network/external-dns-unifi/values/common.yaml
@@ -36,13 +36,6 @@ sidecars:
         value: debug
       - name: UNIFI_SKIP_TLS_VERIFY
         value: "true"
-    resources:
-      requests:
-        cpu: 50m
-        memory: 64Mi
-      limits:
-        cpu: 50m
-        memory: 64Mi
 tolerations:
   - key: node-role.kubernetes.io/control-plane
     operator: Exists
@@ -56,6 +49,5 @@ policy: sync
 sources:
   - ingress
 podLabels:
-  vixens.io/sizing.external-dns: micro
-  vixens.io/sizing.unifi-webhook: micro
-  vixens.io/sizing: micro
+  vixens.io/sizing.external-dns: G-nano
+  vixens.io/sizing.unifi-webhook: G-nano

--- a/apps/40-network/netbird/base/dashboard.yaml
+++ b/apps/40-network/netbird/base/dashboard.yaml
@@ -6,6 +6,9 @@ metadata:
   annotations:
     vpa.kubernetes.io/updateMode: "Off"
     goldilocks.fairwinds.com/enabled: "true"
+  labels:
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -16,8 +19,7 @@ spec:
     metadata:
       labels:
         app: netbird-dashboard
-        vixens.io/sizing.dashboard: small
-        vixens.io/sizing: small
+        vixens.io/sizing.dashboard: V-small
     spec:
       priorityClassName: vixens-high
       tolerations:
@@ -27,13 +29,6 @@ spec:
       containers:
         - name: dashboard
           image: netbirdio/dashboard:v2.33.0
-          resources:
-            requests:
-              cpu: 100m
-              memory: 256Mi
-            limits:
-              cpu: 100m
-              memory: 256Mi
           livenessProbe:
             tcpSocket:
               port: 80

--- a/apps/40-network/netbird/base/management.yaml
+++ b/apps/40-network/netbird/base/management.yaml
@@ -6,6 +6,9 @@ metadata:
   annotations:
     vpa.kubernetes.io/updateMode: "Off"
     goldilocks.fairwinds.com/enabled: "true"
+  labels:
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -18,8 +21,8 @@ spec:
     metadata:
       labels:
         app: netbird-management
-        vixens.io/sizing.netbird-management: small
-        vixens.io/sizing: small
+        vixens.io/sizing.init-config: G-nano
+        vixens.io/sizing.management: V-medium
     spec:
       priorityClassName: vixens-high
       tolerations:
@@ -29,13 +32,6 @@ spec:
       initContainers:
         - name: init-config
           image: busybox:1.37
-          resources:
-            requests:
-              cpu: 50m
-              memory: 64Mi
-            limits:
-              cpu: 50m
-              memory: 64Mi
           env:
             - name: AUTH_ISSUER
               value: "https://authentik.dev.truxonline.com/application/o/netbird/"
@@ -103,13 +99,6 @@ spec:
         - name: management
           image: netbirdio/management:0.66.1
           args: ["--port=80", "--log-file=console", "--log-level=info", "--config=/etc/netbird/management.json"]
-          resources:
-            requests:
-              cpu: 200m
-              memory: 512Mi
-            limits:
-              cpu: 200m
-              memory: 512Mi
           livenessProbe:
             tcpSocket:
               port: 80

--- a/apps/40-network/netbird/base/signal-relay.yaml
+++ b/apps/40-network/netbird/base/signal-relay.yaml
@@ -6,6 +6,9 @@ metadata:
   annotations:
     vpa.kubernetes.io/updateMode: "Off"
     goldilocks.fairwinds.com/enabled: "true"
+  labels:
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -16,8 +19,7 @@ spec:
     metadata:
       labels:
         app: netbird-signal
-        vixens.io/sizing.signal: small
-        vixens.io/sizing: small
+        vixens.io/sizing.signal: V-small
     spec:
       priorityClassName: vixens-high
       tolerations:
@@ -28,13 +30,6 @@ spec:
         - name: signal
           image: netbirdio/signal:0.66.1
           args: ["--port=80"]
-          resources:
-            requests:
-              cpu: 100m
-              memory: 256Mi
-            limits:
-              cpu: 100m
-              memory: 256Mi
           livenessProbe:
             tcpSocket:
               port: 80
@@ -68,6 +63,9 @@ metadata:
   annotations:
     vpa.kubernetes.io/updateMode: "Off"
     goldilocks.fairwinds.com/enabled: "true"
+  labels:
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -78,6 +76,7 @@ spec:
     metadata:
       labels:
         app: netbird-relay
+        vixens.io/sizing.relay: V-small
     spec:
       priorityClassName: vixens-high
       tolerations:
@@ -97,13 +96,6 @@ spec:
               value: "netbird-relay-secret-change-me"
             - name: NETBIRD_RELAY_AUTH_SECRET
               value: "netbird-relay-secret-change-me"
-          resources:
-            requests:
-              cpu: 100m
-              memory: 256Mi
-            limits:
-              cpu: 100m
-              memory: 256Mi
           livenessProbe:
             tcpSocket:
               port: 33080

--- a/apps/40-network/netbird/overlays/dev/patches.yaml
+++ b/apps/40-network/netbird/overlays/dev/patches.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -7,18 +8,18 @@ spec:
   template:
     spec:
       containers:
-      - env:
-        - name: NETBIRD_DOMAIN_NAME
-          value: netbird.dev.truxonline.com
-        - name: NETBIRD_MGMT_API_ENDPOINT
-          value: https://netbird-api.dev.truxonline.com
-        - name: NETBIRD_SIGNAL_ENDPOINT
-          value: https://netbird-signal.dev.truxonline.com
-        - name: NETBIRD_RELAY_ENDPOINT
-          value: https://netbird-relay.dev.truxonline.com
-        - name: NETBIRD_IDP_SKIP_TLS_VERIFY
-          value: 'true'
-        name: management
+        - name: management
+          env:
+            - name: NETBIRD_DOMAIN_NAME
+              value: netbird.dev.truxonline.com
+            - name: NETBIRD_MGMT_API_ENDPOINT
+              value: https://netbird-api.dev.truxonline.com
+            - name: NETBIRD_SIGNAL_ENDPOINT
+              value: https://netbird-signal.dev.truxonline.com
+            - name: NETBIRD_RELAY_ENDPOINT
+              value: https://netbird-relay.dev.truxonline.com
+            - name: NETBIRD_IDP_SKIP_TLS_VERIFY
+              value: 'true'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -29,10 +30,10 @@ spec:
   template:
     spec:
       containers:
-      - env:
-        - name: NB_EXPOSED_ADDRESS
-          value: rels://netbird-relay.dev.truxonline.com:443
-        name: relay
+        - name: relay
+          env:
+            - name: NB_EXPOSED_ADDRESS
+              value: rels://netbird-relay.dev.truxonline.com:443
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -43,21 +44,21 @@ spec:
   template:
     spec:
       containers:
-      - env:
-        - name: AUTH_AUDIENCE
-          value: netbird
-        - name: AUTH_CLIENT_ID
-          value: netbird
-        - name: AUTH_AUTHORITY
-          value: https://authentik.dev.truxonline.com/application/o/netbird/
-        - name: NETBIRD_AUTH_OIDC_CONFIGURATION_ENDPOINT
-          value: https://authentik.dev.truxonline.com/application/o/netbird/.well-known/openid-configuration
-        - name: AUTH_SUPPORTED_SCOPES
-          value: openid profile email offline_access
-        - name: NETBIRD_MGMT_API_ENDPOINT
-          value: https://netbird-api.dev.truxonline.com
-        - name: NETBIRD_MGMT_GRPC_API_ENDPOINT
-          value: https://netbird-api.dev.truxonline.com
-        - name: USE_AUTH0
-          value: 'false'
-        name: dashboard
+        - name: dashboard
+          env:
+            - name: AUTH_AUDIENCE
+              value: netbird
+            - name: AUTH_CLIENT_ID
+              value: netbird
+            - name: AUTH_AUTHORITY
+              value: https://authentik.dev.truxonline.com/application/o/netbird/
+            - name: NETBIRD_AUTH_OIDC_CONFIGURATION_ENDPOINT
+              value: https://authentik.dev.truxonline.com/application/o/netbird/.well-known/openid-configuration
+            - name: AUTH_SUPPORTED_SCOPES
+              value: openid profile email offline_access
+            - name: NETBIRD_MGMT_API_ENDPOINT
+              value: https://netbird-api.dev.truxonline.com
+            - name: NETBIRD_MGMT_GRPC_API_ENDPOINT
+              value: https://netbird-api.dev.truxonline.com
+            - name: USE_AUTH0
+              value: 'false'

--- a/apps/40-network/netvisor/base/daemon-daemonset.yaml
+++ b/apps/40-network/netvisor/base/daemon-daemonset.yaml
@@ -13,8 +13,7 @@ spec:
     metadata:
       labels:
         app: netvisor-daemon
-        vixens.io/sizing.daemon: micro
-        vixens.io/sizing: micro
+        vixens.io/sizing.daemon: G-nano
     spec:
       hostNetwork: false
       tolerations:

--- a/apps/40-network/netvisor/base/server-deployment.yaml
+++ b/apps/40-network/netvisor/base/server-deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: netvisor-server
   labels:
     app: netvisor-server
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   selector:
@@ -14,8 +16,7 @@ spec:
     metadata:
       labels:
         app: netvisor-server
-        vixens.io/sizing.server: small
-        vixens.io/sizing: small
+        vixens.io/sizing.server: V-small
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
## Summary

Migrate the \`apps/40-network/\` stack to Kyverno sizing v2 with VPA Auto.

## Apps migrated

| App | Containers | Notes |
|-----|-----------|-------|
| netbird-management | init-config: \`G-nano\`, management: \`V-medium\` | initContainer config write |
| netbird-signal | signal: \`V-small\` | |
| netbird-relay | relay: \`V-small\` | |
| netbird-dashboard | dashboard: \`V-small\` | |
| netvisor-server | server: \`V-small\` | Deployment + VPA Auto |
| netvisor-daemon | daemon: \`G-nano\` | **DaemonSet** — sizing label only, no VPA |
| external-dns-gandi | external-dns: \`G-nano\` | Helm values, skip VPA |
| external-dns-unifi | external-dns: \`G-nano\`, unifi-webhook: \`G-nano\` | Helm values, skip VPA |

Skipped (protected): \`adguard-home\`

## Changes

- Added \`vixens.io/sizing-v2: "true"\` + \`vixens.io/vpa-mode: Auto\` on all Deployment metadata
- Added per-container sizing labels on pod templates (v1 labels removed)
- Removed all hardcoded \`resources:\` blocks
- Helm values: removed \`resources:\` from values files, updated \`podLabels\` to v2 format
- Fixed pre-existing indentation bug in \`netbird/overlays/dev/patches.yaml\`

## Validation

- ✅ \`yamllint -c yamllint-config.yml apps/40-network/\` — 0 errors
- ✅ \`kustomize build\` on all dev + prod overlays — all pass
- ✅ All 5 netbird + 2 netvisor sizing labels confirmed in build output