### PR TITLE
fix(openclaw): increase data-syncer probe initialDelaySeconds 10→180

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -405,7 +405,7 @@ spec:
                 - sh
                 - -c
                 - "test -f /tmp/healthy"
-            initialDelaySeconds: 10
+            initialDelaySeconds: 180
             periodSeconds: 30
           readinessProbe:
             exec:
@@ -413,7 +413,7 @@ spec:
                 - sh
                 - -c
                 - "test -f /tmp/healthy"
-            initialDelaySeconds: 5
+            initialDelaySeconds: 180
             periodSeconds: 10
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Problem

\`data-syncer\` sidecar stuck in CrashLoopBackOff (13+ restarts).

The liveness probe checks \`test -f /tmp/healthy\`, which is only written **after** the first \`rclone sync\` completes. With a large dataset (\`workspace/\`, \`venv/\`, ICU libs...) the first sync takes >90s, but the probe fires at \`initialDelaySeconds: 10\` and kills the container after 3 failures (70s). The file never gets created → infinite loop.

## Fix

Raise \`initialDelaySeconds\` from \`10\`→\`180\` (liveness) and \`5\`→\`180\` (readiness) to give the first sync time to complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted service deployment health check timing to provide additional startup buffer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->