### PR TITLE
fix(argocd): downgrade application-controller G-xlarge→G-medium

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
+++ b/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
@@ -37,7 +37,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.argocd-application-controller: G-xlarge
+        vixens.io/sizing.argocd-application-controller: G-medium
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
## Problem

`argocd-application-controller` stuck Pending for 20+ min after sizing-v2 migration (PR #1774).

`G-xlarge` = 2Gi Guaranteed requests. Cluster nodes were at 91–99% memory allocation — no node had 2Gi free. Previous hardcoded resources were `requests.memory: 400Mi`.

ArgoCD was effectively down (no GitOps reconciliation possible).

## Fix

Downgrade `argocd-application-controller` from `G-xlarge` → `G-medium` (512Mi Guaranteed), consistent with the previous ~400Mi baseline.

**Immediate mitigation**: StatefulSet was patched directly + pod deleted to unblock scheduling before ArgoCD came back up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure resource configuration for the application controller deployment in production environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->