### PR TITLE
fix(argocd): argocd-server G-small→G-medium (v1/v2 policy collision)

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
+++ b/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.argocd-server: G-small
+        vixens.io/sizing.argocd-server: G-medium
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
Root cause: sizing-mutate v1 maps G-small to 128Mi, sizing-v2-mutate maps G-small to 256Mi. v1 runs last and wins. 128Mi too tight for argocd-server. G-medium (512Mi) is consistent between both policies.