### PR TITLE
fix(whisparr): correct litestream db path whisparr.db→whisparr2.db

### DIFF
--- a/apps/20-media/whisparr/base/litestream-config.yaml
+++ b/apps/20-media/whisparr/base/litestream-config.yaml
@@ -6,8 +6,8 @@ metadata:
 data:
   litestream.yml: |
     dbs:
-      - path: /config/whisparr.db
+      - path: /config/whisparr2.db
         replicas:
-          - url: s3://$LITESTREAM_BUCKET/whisparr.db
+          - url: s3://$LITESTREAM_BUCKET/whisparr2.db
             endpoint: $LITESTREAM_ENDPOINT
     addr: ":9090"


### PR DESCRIPTION
## Summary

- **Root cause**: litestream config pointait vers `/config/whisparr.db` mais Whisparr v2 utilise `whisparr2.db` comme nom de fichier DB
- **Symptôme**: 48+ restarts, exit code 0 — litestream bloquait sur `timeout waiting for db initialization` car le fichier `whisparr.db` n'existait pas
- **Fix**: `whisparr.db` → `whisparr2.db` dans la ConfigMap litestream (path local ET bucket S3)

## Details

```
time=... level=WARN msg="timeout waiting for db initialization" 
  dbs=[/config/whisparr.db] timeout=30s 
  hint="database may have corrupted local state or blocked transactions; 
        try removing -litestream directory and restarting"
```

La DB réelle `/config/whisparr2.db` (1.4MB) était présente et saine — litestream ne la voyait pas car la config pointait vers le mauvais nom.

## Testing

yamllint: ✅ no issues