### PR TITLE
fix: argocd-controller sizing + litestream db path corrections

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
+++ b/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
@@ -37,7 +37,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.argocd-application-controller: G-xlarge
+        vixens.io/sizing.argocd-application-controller: V-large
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane

--- a/apps/20-media/mylar/base/litestream-config.yaml
+++ b/apps/20-media/mylar/base/litestream-config.yaml
@@ -6,8 +6,8 @@ metadata:
 data:
   litestream.yml: |
     dbs:
-      - path: /config/mylar.db
+      - path: /config/mylar/mylar.db
         replicas:
-          - url: s3://$LITESTREAM_BUCKET/mylar.db
+          - url: s3://$LITESTREAM_BUCKET/mylar/mylar.db
             endpoint: $LITESTREAM_ENDPOINT
     addr: ":9090"

--- a/apps/20-media/sabnzbd/base/litestream-config.yaml
+++ b/apps/20-media/sabnzbd/base/litestream-config.yaml
@@ -10,8 +10,4 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/sabnzbd/history1.db
             endpoint: $LITESTREAM_ENDPOINT
-      - path: /config/sabnzbd.db
-        replicas:
-          - url: s3://$LITESTREAM_BUCKET/sabnzbd.db
-            endpoint: $LITESTREAM_ENDPOINT
     addr: ":9090"


### PR DESCRIPTION
## Summary

### argocd-application-controller: G-xlarge → V-large
- G-xlarge (2Gi Guaranteed) ne peut pas être schedulé sur le cluster actuellement saturé en mémoire (0/5 nodes Insufficient memory)
- V-large (1Gi req, 4Gi limit) contourne la collision Kyverno v1/v2 — v1 ne connaît pas V-*, son fallback ne surécrit pas les mappings explicites v2
- VPA pas généré (pas de `sizing-v2: true` sur le StatefulSet) → configuration statique stable

### mylar: litestream path correction
- Config: `/config/mylar.db` mais DB réelle: `/config/mylar/mylar.db`
- Litestream `status: no database` → pas de réplication S3 silencieuse
- Fix: path et bucket S3 alignés avec l'emplacement réel

### sabnzbd: suppression entrée litestream morte
- `/config/sabnzbd.db` n'existe pas (SABnzbd utilise `.ini`, pas SQLite pour sa config)
- Entrée `no database` dans litestream, jamais peuplée → supprimée

## Testing

yamllint: ✅ no errors