### PR TITLE
fix(argocd): controller V-large→SB-medium to unblock scheduling

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
+++ b/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
@@ -37,7 +37,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.argocd-application-controller: V-large
+        vixens.io/sizing.argocd-application-controller: SB-medium
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
## Problème

argocd-application-controller-0 était Pending depuis plusieurs heures (Insufficient memory). Le cluster est saturé en *requests* (97-98%) post VPA cold-start sizing-v2.

Sans le controller : **GitOps cassé**, aucun sync possible.

## Fix

V-large (1Gi req) → **SB-medium** (512Mi req / 2Gi limit)

- phoebe a ~745Mi libres en requests → schedulable ✓
- VPA target ~990Mi < 2Gi limit → pas d'OOMKill ✓
- Burstable QoS acceptable pour ce composant (on préfère qu'il tourne plutôt qu'il soit Guaranteed-mais-Pending)

## Sizing confirmé

SB-medium = Super Burstable, mem req=512Mi, mem limit=2Gi (4x req), cpu req=50m, cpu limit=500m

## Prochaine étape

Remettre en V-large (VPA-géré) une fois que le cluster a de la marge (VPA cold-start terminé).