### PR TITLE
fix(lidarr): G-medium -> SB-medium to fix startup liveness probe failures

### DIFF
--- a/apps/20-media/lidarr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/lidarr/overlays/prod/resources-patch.yaml
@@ -4,13 +4,13 @@ kind: Deployment
 metadata:
   name: lidarr
   labels:
-    vixens.io/sizing.lidarr: G-medium
+    vixens.io/sizing.lidarr: SB-medium
     vixens.io/sizing.litestream: micro
     vixens.io/sizing.config-syncer: micro
 spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.lidarr: G-medium
+        vixens.io/sizing.lidarr: SB-medium
         vixens.io/sizing.litestream: micro
         vixens.io/sizing.config-syncer: micro


### PR DESCRIPTION
## Problem

lidarr is in CrashLoopBackOff (82+ restarts) with liveness probe failures:
```
Container lidarr failed liveness probe, will be restarted
Readiness probe failed: Get "http://10.244.3.191:8686/ping": connection refused
```

Root cause: `G-medium` sizing sets CPU req=limit=50m (Guaranteed QoS). lidarr's .NET runtime requires burst CPU during startup to JIT compile and initialize. At 50m, it's throttled so heavily it never finishes booting before the liveness probe timeout.

## Fix

Change `lidarr` container from `G-medium` to `SB-medium`:
- CPU: 50m req → 500m limit (10x burst)
- Memory: 512Mi req=limit (unchanged, Guaranteed mem)

SB (Super Burstable) gives the startup burst while keeping the memory Guaranteed for stability. VPA will refine CPU requests over time.

## Evidence

- Pod events: `Killing: Container lidarr failed liveness probe` (939 occurrences)
- Exit code 137 = SIGKILL from kubelet (liveness probe kill, not OOM)
- G-medium CPU limit = 50m which is insufficient for .NET startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application resource allocation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->