### PR TITLE
fix(argocd): repo-server G-large -> SB-large to prevent OOMKill on mass reconciliation

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
+++ b/apps/00-infra/argocd/overlays/prod/resources-patch.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.argocd-repo-server: G-large
+        vixens.io/sizing.argocd-repo-server: SB-large
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
## Problem

argocd-repo-server is in CrashLoopBackOff (13 restarts) with OOMKill (exit code 137).

Root cause: After every prod-stable update, the repo-server needs to concurrently:
- Build kustomize manifests for 90 apps (all cache misses)
- Pull Helm charts from external registries (grafana, velero, etc.)

This saturates the 1Gi Guaranteed limit and crashes the process.

Observed in logs:
```
helm pull grafana ... failed timeout after 1m30s
grpc.error: error fetching chart ... failed timeout after 1m30s
exitCode: 137, reason: Error (OOMKill)
```

## Impact

When repo-server is down, ArgoCD cannot reconcile ANY app. This blocks:
- lidarr SB-medium fix from being applied (app stuck with crashing pod)
- whisparr litestream rollout
- frigate media-xlarge rollout
- All 90 apps from syncing to new prod-stable

## Fix

Change `argocd-repo-server` from `G-large` to `SB-large`:
- CPU: 100m req / 1000m limit (was 100m req=limit)
- Memory: 1Gi req / 4Gi limit (was 1Gi req=limit)

SB-large gives 4x memory burst to handle cold-cache reconciliation spikes without raising the scheduling request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production infrastructure resource sizing configuration to optimize system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->