### PR TITLE
fix(mylar): correct litestream restore-db path to /config/mylar/mylar.db

### DIFF
--- a/apps/20-media/mylar/base/deployment.yaml
+++ b/apps/20-media/mylar/base/deployment.yaml
@@ -75,7 +75,7 @@ spec:
             - /etc/litestream.yml
             - -if-db-not-exists
             - -if-replica-exists
-            - /config/mylar.db
+            - /config/mylar/mylar.db
           envFrom:
             - secretRef:
                 name: mylar-secrets


### PR DESCRIPTION
The restore-db init container arg was pointing to /config/mylar.db but the
litestream configmap (set in PR #1781) stores/restores at /config/mylar/mylar.db.

This mismatch caused mylar's restore-db init container to fail with:
```
error="database not found in config: /config/mylar.db"
```

Fix: align the restore-db arg path with the litestream configmap path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected database restoration path handling to ensure files are properly located during app initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->