### PR TITLE
fix(sizing): reduce frigate to SB-xlarge, migrate homeassistant to B-xlarge

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/resources-patch.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/resources-patch.yaml
@@ -4,12 +4,12 @@ kind: Deployment
 metadata:
   name: homeassistant
   labels:
-    vixens.io/sizing: G-xlarge
+    vixens.io/sizing: B-xlarge
 spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing: G-xlarge
-        vixens.io/sizing.homeassistant: G-xlarge
-        vixens.io/sizing.litestream: G-small
-        vixens.io/sizing.config-syncer: G-small
+        vixens.io/sizing: B-xlarge
+        vixens.io/sizing.homeassistant: B-xlarge
+        vixens.io/sizing.litestream: B-nano
+        vixens.io/sizing.config-syncer: B-nano

--- a/apps/20-media/frigate/overlays/prod/kustomization.yaml
+++ b/apps/20-media/frigate/overlays/prod/kustomization.yaml
@@ -44,7 +44,7 @@ patches:
         template:
           metadata:
             labels:
-              vixens.io/sizing.frigate: media-xlarge
+              vixens.io/sizing.frigate: SB-xlarge
               vixens.io/sizing.litestream: micro
               vixens.io/sizing.config-syncer: micro
             annotations:


### PR DESCRIPTION
## Summary

- **frigate**: `media-xlarge` (4Gi req/8Gi lim) → `SB-xlarge` (2Gi req/8Gi lim) — Breaks deadlock where frigate's 4Gi request fills `poison` (99%) leaving no room for `synology-csi-node`
- **homeassistant**: `G-xlarge` → `B-xlarge` (2Gi req/4Gi lim) — Fixes CrashLoopBackOff/OOMKill caused by v1 sizing policy defaulting `G-xlarge` to 128Mi; litestream/config-syncer downsized to B-nano (64Mi req) to fit on peach node

## Cluster State

Both apps are critically broken:
- frigate: `Init:0/2` — PVC mount fails (synology-csi-node can't schedule on `poison`)
- homeassistant: `CrashLoopBackOff` — OOMKilled (128Mi vs 2Gi needed)