### PR TITLE
fix(kyverno): v1 sizing policy skips containers with v2-style labels

### DIFF
--- a/apps/00-infra/kyverno/base/policies/sizing-mutate.yaml
+++ b/apps/00-infra/kyverno/base/policies/sizing-mutate.yaml
@@ -29,6 +29,13 @@ spec:
       mutate:
         foreach:
           - list: "request.object.spec.containers || '[]'" # Safety for empty containers list
+            preconditions:
+              all:
+                # Skip containers whose sizing label is a v2-style label (contains '-')
+                # e.g. B-xlarge, G-small, SB-nano, V-medium, media-xlarge — v2 handles those
+                - key: "{{ contains(request.object.metadata.labels.\"vixens.io/sizing.{{element.name}}\" || 'none', '-') }}"
+                  operator: Equals
+                  value: "false"
             patchStrategicMerge:
               spec:
                 containers:
@@ -58,6 +65,12 @@ spec:
       mutate:
         foreach:
           - list: "request.object.spec.initContainers || '[]'" # Safety for missing initContainers
+            preconditions:
+              all:
+                # Skip init containers with v2-style labels (contains '-')
+                - key: "{{ contains(request.object.metadata.labels.\"vixens.io/sizing.{{element.name}}\" || 'none', '-') }}"
+                  operator: Equals
+                  value: "false"
             patchStrategicMerge:
               spec:
                 initContainers:


### PR DESCRIPTION
## Problem

Race condition between v1 (`sizing-mutate`) and v2 (`sizing-v2-mutate`) Kyverno policies.

When Kyverno's 3 admission-controller replicas process policies in non-deterministic order, v1 sometimes runs AFTER v2, overwriting correct v2-computed resources with its default (128Mi). 

**Symptom:** HomeAssistant pod gets 128Mi instead of `B-xlarge` = 2Gi, causing OOMKill.

**Evidence:**
- Frigate (namespace `media`) → gets `SB-xlarge` correctly ✅  
- HomeAssistant (namespace `homeassistant`) → gets 128Mi instead of B-xlarge=2Gi ❌
- Dry-run on fresh pod → correct result (2Gi) ✅ — confirms timing/replica is the issue

## Fix

Add `preconditions` to both `foreach` loops in `sizing-mutate` (v1):

```yaml
preconditions:
  all:
    # Skip containers with v2-style labels (contains '-')
    - key: "{{ contains(request.object.metadata.labels.\"vixens.io/sizing.{{element.name}}\" || 'none', '-') }}"
      operator: Equals
      value: "false"
```

Labels containing `-` (e.g. `B-xlarge`, `G-small`, `SB-nano`, `V-medium`, `media-xlarge`) → handled exclusively by v2, skipped by v1.  
Labels without `-` (e.g. `large`, `medium`, `small`, `micro`) → still handled by v1 (backward compat).

This makes v1 and v2 **mutually exclusive per container**, eliminating the race condition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Container sizing mutation logic has been updated. Containers with v2-style sizing labels are now excluded from automatic sizing mutation processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->