### PR TITLE
fix(just): fix maturity recipe syntax

### DIFF
--- a/justfile
+++ b/justfile
@@ -1109,12 +1109,7 @@ maturity:
     @export KUBECONFIG=.secrets/prod/kubeconfig-prod; \
     (printf "NAMESPACE\tAPPLICATION\tTIER\tMANQUE POUR SUIVANT\n" && \
     kubectl get deployment,statefulset,daemonset -A -o json | \
-    jq -r '.items[] | [
-      .metadata.namespace,
-      .metadata.name,
-      (.metadata.labels["vixens.io/maturity"] // "none"),
-      (.metadata.labels["vixens.io/maturity-missing"] // "-")
-    ] | @tsv') | \
+    jq -r '.items[] | [.metadata.namespace, .metadata.name, (.metadata.labels["vixens.io/maturity"] // "none"), (.metadata.labels["vixens.io/maturity-missing"] // "-")] | @tsv') | \
     column -t -s $'\t'
     @echo ""
     @echo "Tiers: bronze→silver→gold→platinum→emerald→diamond→orichalcum"


### PR DESCRIPTION
Flatten multiline jq in maturity recipe — just doesn't allow extra leading whitespace in continuation lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Internal formatting optimizations with no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->