### PR TITLE
feat(maturity): bypass philosophy — invert probe/hook defaults, fix storage env, drop runbook/DR/SLO

### DIFF
--- a/apps/00-infra/kyverno/base/policies/check-graceful-shutdown.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-graceful-shutdown.yaml
@@ -8,8 +8,9 @@ metadata:
     policies.kyverno.io/category: Maturity (Platinum)
     policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
-      Apps with long-lived connections must define a preStop lifecycle hook for maturity Level 4 (Platinum).
-      Set annotation vixens.io/has-long-connections: "true" to require it.
+      All containers must define a preStop lifecycle hook for maturity Level 4 (Platinum).
+      Set vixens.io/no-long-connections: "true" to bypass (explicit acknowledgement that
+      the app has no long-lived connections and does not need graceful draining).
 spec:
   validationFailureAction: Audit
   background: true
@@ -20,13 +21,17 @@ spec:
           - resources:
               kinds:
                 - Pod
-      preconditions:
-        all:
-          - key: "{{ request.object.metadata.annotations.\"vixens.io/has-long-connections\" || '' }}"
-            operator: Equals
-            value: "true"
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kyverno
+          - resources:
+              annotations:
+                vixens.io/no-long-connections: "true"
       validate:
-        message: "A preStop lifecycle hook is required on all containers when vixens.io/has-long-connections: 'true' is set (Level 4 Platinum)."
+        message: "A preStop lifecycle hook is required on all containers (Level 4 Platinum). Set vixens.io/no-long-connections: 'true' to bypass."
         pattern:
           spec:
             containers:

--- a/apps/00-infra/kyverno/base/policies/check-startup-probe.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-startup-probe.yaml
@@ -4,12 +4,13 @@ kind: ClusterPolicy
 metadata:
   name: check-startup-probe
   annotations:
-    policies.kyverno.io/title: Require Startup Probe for Slow-Starting Apps
+    policies.kyverno.io/title: Require Startup Probe
     policies.kyverno.io/category: Maturity (Silver)
     policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
-      If annotation vixens.io/slow-start: "true" is set, a startupProbe is required
-      on all containers for maturity Level 2 (Silver).
+      All containers must define a startupProbe for maturity Level 2 (Silver).
+      Set vixens.io/fast-start: "true" to bypass (explicit acknowledgement that the
+      container starts quickly and does not need a startup probe).
 spec:
   validationFailureAction: Audit
   background: true
@@ -20,13 +21,17 @@ spec:
           - resources:
               kinds:
                 - Pod
-      preconditions:
-        all:
-          - key: "{{ request.object.metadata.annotations.\"vixens.io/slow-start\" || '' }}"
-            operator: Equals
-            value: "true"
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kyverno
+          - resources:
+              annotations:
+                vixens.io/fast-start: "true"
       validate:
-        message: "A startupProbe is required on all containers when vixens.io/slow-start: 'true' is set (Level 2 Silver)."
+        message: "A startupProbe is required on all containers (Level 2 Silver). Set vixens.io/fast-start: 'true' to bypass."
         pattern:
           spec:
             containers:

--- a/scripts/reports/evaluate_maturity.py
+++ b/scripts/reports/evaluate_maturity.py
@@ -175,12 +175,12 @@ def check_silver(ns: str, app: str, workload, pods: list) -> dict:
         cnt.get("readinessProbe") is not None for cnt in containers
     )
 
-    if wl_ann.get("vixens.io/slow-start") == "true":
-        c["Startup probe (vixens.io/slow-start set)"] = bool(containers) and all(
+    if wl_ann.get("vixens.io/fast-start") == "true":
+        c["Startup probe on all containers (bypass: vixens.io/fast-start)"] = None
+    else:
+        c["Startup probe on all containers (bypass: vixens.io/fast-start)"] = bool(containers) and all(
             cnt.get("startupProbe") is not None for cnt in containers
         )
-    else:
-        c["Startup probe (vixens.io/slow-start set)"] = None
 
     uses_secrets = _workload_uses_secrets(workload)
     if not uses_secrets:
@@ -192,7 +192,9 @@ def check_silver(ns: str, app: str, workload, pods: list) -> dict:
     if not pvcs:
         c["Storage strategy (StorageClass suffix -retain/-delete)"] = None
     else:
-        suffix = "-retain" if "prod" in ns else "-delete"
+        ns_data = _kubectl_json(f"get ns {ns}")
+        ns_env = (ns_data.get("metadata", {}).get("labels", {}) if ns_data else {}).get("environment", "")
+        suffix = "-retain" if ns_env == "prod" else "-delete"
         c["Storage strategy (StorageClass suffix -retain/-delete)"] = all(
             pvc.get("spec", {}).get("storageClassName", "").endswith(suffix)
             for pvc in pvcs
@@ -263,13 +265,13 @@ def check_platinum(ns: str, app: str, workload, pods: list) -> dict:
             or bool(pspec.get("affinity", {}).get("podAntiAffinity"))
         )
 
-    if wl_ann.get("vixens.io/has-long-connections") == "true":
-        containers = _containers(workload)
-        c["preStop lifecycle hook (vixens.io/has-long-connections set)"] = bool(containers) and all(
-            cnt.get("lifecycle", {}).get("preStop") is not None for cnt in containers
-        )
+    if wl_ann.get("vixens.io/no-long-connections") == "true":
+        c["preStop lifecycle hook (bypass: vixens.io/no-long-connections)"] = None
     else:
-        c["preStop lifecycle hook (vixens.io/has-long-connections set)"] = None
+        _ctrs = _containers(workload)
+        c["preStop lifecycle hook (bypass: vixens.io/no-long-connections)"] = bool(_ctrs) and all(
+            cnt.get("lifecycle", {}).get("preStop") is not None for cnt in _ctrs
+        )
 
     if wl_ann.get("vixens.io/needs-autoscaling") == "true":
         hpas = list_resources("hpa", ns, f"app={app}")
@@ -322,7 +324,9 @@ def check_diamond(ns: str, app: str, workload, pods: list) -> dict:
         for p in netpols
     )
 
-    if containers:
+    if wl_ann.get("vixens.io/explicitly-allow-root") == "true":
+        c["Security context hardened (runAsNonRoot + drop:ALL)"] = None
+    elif containers:
         psc = _pod_spec(workload).get("securityContext", {})
         c["Security context hardened (runAsNonRoot + drop:ALL)"] = (
             psc.get("runAsNonRoot", False)
@@ -373,11 +377,6 @@ def check_orichalcum(ns: str, app: str, workload, pods: list) -> dict:
     containers = _containers(workload)
     pt_labels = _pt_labels(workload)
 
-    c["Runbook certified (vixens.io/runbook-certified: <date>)"] = (
-        "vixens.io/runbook-certified" in wl_ann
-    )
-    c["DR tested (vixens.io/dr-tested: <date>)"] = "vixens.io/dr-tested" in wl_ann
-    c["SLO defined (vixens.io/slo-defined: <date>)"] = "vixens.io/slo-defined" in wl_ann
 
     if pods:
         zero_restarts = all(


### PR DESCRIPTION
Applies the \"volonté\" bypass pattern consistently: every check requires the feature OR an explicit opt-out annotation.

**evaluate_maturity.py**
- Startup probe: required by default → bypass \`vixens.io/fast-start: \"true\"\`
- Storage strategy: use namespace \`environment\` label (not \`"prod" in ns\` string match)
- preStop hook: required by default → bypass \`vixens.io/no-long-connections: \"true\"\`
- Security context: bypass \`vixens.io/explicitly-allow-root: \"true\"\` → N/A
- Orichalcum: remove runbook/DR/SLO checks (manual, non-automatable, removed from scoring)

**Kyverno**
- \`check-startup-probe\`: inverted — all Pods require startupProbe, exclude \`vixens.io/fast-start: \"true\"\`
- \`check-graceful-shutdown\`: inverted — all Pods require preStop, exclude \`vixens.io/no-long-connections: \"true\"\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bypass annotation support for graceful shutdown and startup probe policies via `vixens.io/no-long-connections` and `vixens.io/fast-start` flags.

* **Policy Updates**
  * Renamed "Require Startup Probe for Slow-Starting Apps" to "Require Startup Probe" with broadened applicability.
  * Restructured policy conditions from preconditions to explicit exclusion rules for improved clarity and flexibility.

* **Evaluation Changes**
  * Updated maturity tier assessments to align with new annotation-based bypass mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->