### PR TITLE
fix(sizing): casser les OOM loops + désactiver robusta

### DIFF
--- a/apps/03-security/authentik/overlays/prod/server-resources.yaml
+++ b/apps/03-security/authentik/overlays/prod/server-resources.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.authentik-server: G-medium
+        vixens.io/sizing.authentik-server: G-large
         vixens.io/sizing.config-syncer: G-small
     spec:
       priorityClassName: vixens-critical

--- a/apps/20-media/booklore/base/deployment.yaml
+++ b/apps/20-media/booklore/base/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: booklore
     vixens.io/sizing-v2: "true"
-    vixens.io/vpa-mode: Auto
+    vixens.io/vpa-mode: Off
 spec:
   replicas: 1
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         app: booklore
-        vixens.io/sizing.booklore: V-medium
+        vixens.io/sizing.booklore: B-small
         vixens.io/sizing.config-syncer: V-nano
         vixens.io/sizing.restore-config: B-nano
     spec:

--- a/apps/70-tools/netbox/base/deployment.yaml
+++ b/apps/70-tools/netbox/base/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: netbox
     vixens.io/sizing-v2: "true"
-    vixens.io/vpa-mode: Auto
+    vixens.io/vpa-mode: Off
 spec:
   replicas: 1
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         app: netbox
-        vixens.io/sizing.netbox: V-medium
+        vixens.io/sizing.netbox: B-medium
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane
@@ -60,11 +60,18 @@ spec:
               value: netbox.dev.truxonline.com # Should be patched in overlays
             - name: DB_WAIT_DEBUG
               value: "1"
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /
               port: http
-            initialDelaySeconds: 120 # Increased for migrations
+            initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 6

--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -8,7 +8,7 @@ metadata:
     app: penpot-backend
     component: backend
     vixens.io/sizing-v2: "true"
-    vixens.io/vpa-mode: Auto
+    vixens.io/vpa-mode: Off
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -22,7 +22,7 @@ spec:
       labels:
         app: penpot-backend
         component: backend
-        vixens.io/sizing.backend: V-large
+        vixens.io/sizing.backend: B-large
     spec:
       priorityClassName: vixens-medium
       tolerations:

--- a/apps/70-tools/stirling-pdf/base/values.yaml
+++ b/apps/70-tools/stirling-pdf/base/values.yaml
@@ -9,7 +9,7 @@ image:
   pullPolicy: IfNotPresent
   tag: 2.6.0
 replicaCount: 1
-# resources managed by Kyverno sizing (medium tier: 512Mi request/1Gi limit)
+# resources managed by Kyverno sizing (B-large: req=1Gi, lim=2Gi — Java+LibreOffice combo)
 # Tolerations for control-plane nodes if needed
 tolerations:
   - key: node-role.kubernetes.io/control-plane
@@ -40,4 +40,4 @@ securityContext:
   enabled: true
   fsGroup: 1000
 podLabels:
-  vixens.io/sizing.stirling-pdf-chart: V-medium
+  vixens.io/sizing.stirling-pdf-chart: B-large

--- a/apps/70-tools/stirling-pdf/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/stirling-pdf/overlays/prod/kustomization.yaml
@@ -16,7 +16,10 @@ patches:
         value: "true"
       - op: add
         path: /metadata/labels/vixens.io~1vpa-mode
-        value: Auto
+        value: "Off"
+      - op: add
+        path: /spec/template/metadata/labels/vixens.io~1sizing-v2
+        value: "true"
     target:
       kind: Deployment
       name: stirling-pdf-stirling-pdf-chart

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -89,7 +89,7 @@ resources:
   - apps/mariadb-shared.yaml
   - apps/penpot.yaml
   - apps/vikunja.yaml
-  - apps/robusta.yaml
+  # - apps/robusta.yaml  # disabled 2026-03-05 — reporting-only, OOMKilling, no local value
   - apps/trivy.yaml
   - apps/radar.yaml
   - apps/maturity-controller.yaml


### PR DESCRIPTION
## Problème

Plusieurs apps en CrashLoop OOMKilled dû à un **VPA Auto death spiral** : le pod crashe trop vite pour que VPA accumule de l'historique → VPA recommande une limite basse → OOM → boucle infinie.

## Changements

| App | Avant | Après | Note |
|-----|-------|-------|------|
| **netbox** | `V-medium` + vpa Auto | `B-medium` (req=512Mi, lim=1Gi) + startup probe | SIGTERM = liveness kill ; B-medium + startup 300s |
| **penpot-backend** | `V-large` + vpa Auto | `B-large` (req=1Gi, lim=2Gi) | VPA target=826Mi |
| **stirling-pdf** | `V-medium` + bug pod labels | `B-large` (req=1Gi, lim=2Gi) + fix propagation | Java+LibreOffice+unoserver combo |
| **booklore** | `V-medium` + vpa Auto | `B-small` (req=256Mi, lim=512Mi) | Spring Boot, VPA target=283Mi |
| **authentik-server** | `G-medium` (512Mi Guaranteed) | `G-large` (1Gi Guaranteed) | VPA target=729Mi, Guaranteed QoS = pas de burst |
| **robusta** | activé | commenté dans app-of-apps prod | Reporting-only webapp, OOMKilling, sans valeur locale |

## Bug stirling-pdf

Les labels `vixens.io/sizing-v2: "true"` et `vpa-mode` étaient patchés sur `Deployment.metadata.labels` mais **pas** sur `Deployment.spec.template.metadata.labels` → Kyverno mutate ne voyait pas les pods → fallback 128Mi. Fixé en ajoutant le patch sur le pod template.

## VPA

Toutes les apps modifiées passent en `vpa-mode: Off` → plus de VPA généré. Une fois stables (7j), on pourra réévaluer le retour en V-*.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Updates**
  * Optimized resource allocation across multiple services with adjusted sizing configurations
  * Disabled automatic pod scaling for select applications to maintain stability
  * Enhanced service health monitoring with improved startup probe configurations
  * Disabled a reporting service experiencing performance issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->