### PR TITLE
fix(sizing): radar V-small → B-medium + velero-maintenance-config kustomization

### DIFF
--- a/apps/00-infra/velero/base/kustomization.yaml
+++ b/apps/00-infra/velero/base/kustomization.yaml
@@ -1,2 +1,6 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: velero
+resources:
+# Placeholder — Velero CRDs (Schedules, BackupStorageLocations) à ajouter ici

--- a/apps/70-tools/radar/base/manifests.yaml
+++ b/apps/70-tools/radar/base/manifests.yaml
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/version: "0.4.2"
     app.kubernetes.io/managed-by: Helm
     vixens.io/sizing-v2: "true"
-    vixens.io/vpa-mode: Auto
+    vixens.io/vpa-mode: Off
 spec:
   replicas: 1
   selector:
@@ -159,7 +159,7 @@ spec:
       labels:
         app.kubernetes.io/name: radar
         app.kubernetes.io/instance: radar
-        vixens.io/sizing.radar: V-small
+        vixens.io/sizing.radar: B-medium
     spec:
       priorityClassName: vixens-medium
       serviceAccountName: radar


### PR DESCRIPTION
## radar — OOM loop (136 restarts)

Même pattern VPA death spiral que PR #1802 : `V-small` (lim=1Gi) écrasé par VPA à 128Mi.
VPA target = 560Mi.

- `V-small + vpa Auto` → `B-medium` (req=512Mi, lim=1Gi) + `vpa-mode: Off`

## velero-maintenance-config — Unknown

ArgoCD pointait vers `apps/00-infra/velero/base` dont le `kustomization.yaml` était vide (juste l'header). Kustomize erreur: `kustomization.yaml is empty`.

Fix : kustomization valide avec `namespace: velero` et section `resources:` commentée (placeholder pour les futures VeleroSchedules/BackupStorageLocations).