### PR TITLE
fix(velero): remove velero-maintenance-config ArgoCD app (CM owned by Helm)

### DIFF
--- a/apps/00-infra/velero/base/kustomization.yaml
+++ b/apps/00-infra/velero/base/kustomization.yaml
@@ -1,6 +1,2 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: velero
-resources:
-# Placeholder — Velero CRDs (Schedules, BackupStorageLocations) à ajouter ici

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - apps/infisical-operator.yaml
   - apps/velero-secrets.yaml
   - apps/velero.yaml
-  - apps/velero-maintenance-config.yaml
+  # - apps/velero-maintenance-config.yaml  # removed 2026-03-05 — CM now owned by Helm chart (velero values repositoryMaintenanceJob)
   - apps/cilium-lb.yaml
   - apps/traefik.yaml
   - apps/traefik-middlewares.yaml


### PR DESCRIPTION
## Problem

The `velero-maintenance-config` ArgoCD app points to `apps/00-infra/velero/base` which was intentionally emptied in PR #859b6858 (Helm chart now owns the `velero-repo-maintenance-config` ConfigMap via `repositoryMaintenanceJob.repositoryConfigData` in Helm values).

This causes a hard Kustomize error in ArgoCD:
\`\`\`
Failed to load target state: kustomization.yaml is empty
\`\`\`

## Root Cause

PR #859b6858 moved the CM to Helm management and removed `maintenance-config.yaml` from the kustomization, but didn't remove the ArgoCD app from the app-of-apps. The empty `resources:` section added in our previous fix attempt made it worse.

## Fix

- Comment out `velero-maintenance-config` from `argocd/overlays/prod/kustomization.yaml`
- Restore `apps/00-infra/velero/base/kustomization.yaml` to minimal valid state (no resources)

## Verification

\`\`\`bash
kustomize build argocd/overlays/prod  # exit 0
yamllint -c yamllint-config.yml ...   # warnings only, no errors
\`\`\`