### PR TITLE
fix(whisparr): V-medium/G-small VPA death spiral → B-medium + probe delays

### DIFF
--- a/apps/20-media/whisparr/base/deployment.yaml
+++ b/apps/20-media/whisparr/base/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: whisparr
     vixens.io/sizing-v2: "true"
-    vixens.io/vpa-mode: Auto
+    vixens.io/vpa-mode: Off
 spec:
   strategy:
     type: Recreate
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         app: whisparr
-        vixens.io/sizing.whisparr: V-medium
+        vixens.io/sizing.whisparr: B-medium
         vixens.io/sizing.litestream: V-nano
         vixens.io/sizing.config-syncer: V-nano
         vixens.io/sizing.fix-permissions: G-nano
@@ -78,13 +78,13 @@ spec:
             httpGet:
               path: /ping
               port: 6969
-            initialDelaySeconds: 30
+            initialDelaySeconds: 120
             periodSeconds: 20
           readinessProbe:
             httpGet:
               path: /ping
               port: 6969
-            initialDelaySeconds: 15
+            initialDelaySeconds: 60
             periodSeconds: 10
           env:
             - name: WHISPARR__API_KEY

--- a/apps/20-media/whisparr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/whisparr/overlays/prod/resources-patch.yaml
@@ -4,13 +4,13 @@ kind: Deployment
 metadata:
   name: whisparr
   labels:
-    vixens.io/sizing.whisparr: G-small
+    vixens.io/sizing.whisparr: B-medium
     vixens.io/sizing.litestream: V-nano
     vixens.io/sizing.config-syncer: V-nano
 spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.whisparr: G-small
+        vixens.io/sizing.whisparr: B-medium
         vixens.io/sizing.litestream: V-nano
         vixens.io/sizing.config-syncer: V-nano


### PR DESCRIPTION
## Problème

Whisparr était dans un VPA Auto death spiral :

1. `overlays/prod/resources-patch.yaml` surchargeait la base avec `sizing.whisparr: G-small` → QoS Guaranteed, req=lim=25m/256Mi
2. VPA Auto observait une faible utilisation (app en crash loop) → réduisait encore à ~63m/121Mi
3. .NET app + SQLite migration à 25m CPU ne peut pas démarrer → shutdown propre exit 0
4. Probe liveness timeout 1s sur une app throttlée → CrashLoopBackOff en 67 restarts

## Corrections

- `base/deployment.yaml`: `V-medium → B-medium`, `vpa-mode: Off`
- `overlays/prod/resources-patch.yaml`: `G-small → B-medium` (écrasait la base)
- liveness probe: `initialDelaySeconds: 30 → 120` (laisser .NET démarrer + migrer)
- readiness probe: `initialDelaySeconds: 15 → 60`

B-medium = req=50m/512Mi, lim=500m/1Gi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Deployment resource sizing configuration updated across base and production environments.
- Vertical pod autoscaling has been disabled.
- Health check initialization delays extended: liveness probe now waits 120 seconds before checks begin (previously 30 seconds), readiness probe now waits 60 seconds (previously 15 seconds).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->