### PR TITLE
fix(sizing): booklore B-small→B-medium + jellyseerr V-small→B-medium (OOM loops)

### DIFF
--- a/apps/20-media/booklore/base/deployment.yaml
+++ b/apps/20-media/booklore/base/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         app: booklore
-        vixens.io/sizing.booklore: B-small
+        vixens.io/sizing.booklore: B-medium
         vixens.io/sizing.config-syncer: V-nano
         vixens.io/sizing.restore-config: B-nano
     spec:

--- a/apps/20-media/jellyseerr/base/deployment.yaml
+++ b/apps/20-media/jellyseerr/base/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: jellyseerr
     vixens.io/sizing-v2: "true"
-    vixens.io/vpa-mode: Auto
+    vixens.io/vpa-mode: Off
 spec:
   replicas: 1
   strategy:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         app: jellyseerr
-        vixens.io/sizing.jellyseerr: V-small
+        vixens.io/sizing.jellyseerr: B-medium
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
## booklore
Usage réel **646Mi** > limite B-small **512Mi** → OOMKill systématique (43 restarts).
Goldilocks recommande ~933Mi. Fix: `B-small → B-medium` (lim=1Gi).

## jellyseerr
VPA Auto death spiral : target 308Mi mais pod tournait à 128Mi (V-small throttlé par VPA).
48 OOMKills actifs. Fix: `V-small → B-medium` + `vpa-mode: Off`.

B-medium = req=256Mi/50m, lim=1Gi/500m

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment labels for Booklore: adjusted resource sizing from B-small to B-medium.
  * Updated deployment labels for Jellyseerr: changed autoscaling mode from Auto to Off and adjusted resource sizing from V-small to B-medium.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->