### PR TITLE
fix(frigate): install pyyaml to fix config validation

### DIFF
--- a/apps/20-media/frigate/base/deployment.yaml
+++ b/apps/20-media/frigate/base/deployment.yaml
@@ -70,6 +70,7 @@ spec:
             - -c
           args:
             - |
+              pip install pyyaml -q >/dev/null 2>&1
               echo "Validating Frigate config..."
               if [ -f /config/config.yml ]; then
                 if python3 -c "import yaml; yaml.safe_load(open('/config/config.yml'))" 2>/dev/null; then
@@ -191,6 +192,7 @@ spec:
             - |
               # Install rclone
               apk add --no-cache rclone
+              pip install pyyaml -q >/dev/null 2>&1
               
               export RCLONE_CONFIG_S3_TYPE=s3
               export RCLONE_CONFIG_S3_PROVIDER=Other


### PR DESCRIPTION
## Problème

`python:3.14-alpine` n'inclut pas `pyyaml`. La validation YAML utilise `import yaml` (module externe), ce qui levait systématiquement une `ModuleNotFoundError`.

**Conséquence à chaque restart du pod :**
- `validate-config` interprétait le code retour 1 comme « config corrompue »
- Il restaurait `backup_config.yaml` (ancienne config v0.16) par-dessus la vraie config v0.17
- `config-syncer` n'a jamais créé un seul backup timestampé depuis le déploiement

## Fix

Ajout de `pip install pyyaml -q >/dev/null 2>&1` dans :
- `validate-config` initContainer (avant la validation)
- `config-syncer` sidecar (après `apk add rclone`)