### PR TITLE
feat(maturity): QW1-4 cluster maturity quick wins

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/argocd/overlays/prod/kustomization.yaml
@@ -27,6 +27,29 @@ patches:
       kind: Deployment
       name: argocd-dex-server
     path: patches/dex-run-as-user-json.yaml
+  # QW3: priorityClassName vixens-critical for all ArgoCD workloads
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: placeholder
+      spec:
+        template:
+          spec:
+            priorityClassName: vixens-critical
+    target:
+      kind: Deployment
+  - patch: |
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: placeholder
+      spec:
+        template:
+          spec:
+            priorityClassName: vixens-critical
+    target:
+      kind: StatefulSet
 
 components:
   - ../../../../_shared/components/revision-history-limit

--- a/apps/00-infra/reloader/base/kustomization.yaml
+++ b/apps/00-infra/reloader/base/kustomization.yaml
@@ -18,6 +18,9 @@ patches:
             annotations:
               prometheus.io/scrape: "true"
               prometheus.io/port: "9090"
+              vixens.io/fast-start: "true"
             labels:
               vixens.io/sizing.reloader-reloader: G-nano
               vixens.io/service-binding: "false"
+          spec:
+            priorityClassName: vixens-high

--- a/apps/01-storage/synology-csi/base/controller.yaml
+++ b/apps/01-storage/synology-csi/base/controller.yaml
@@ -19,6 +19,7 @@ spec:
           operator: Exists
           effect: NoSchedule
       serviceAccountName: synology-csi-controller
+      priorityClassName: vixens-critical
       containers:
         - name: csi-provisioner
           image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0

--- a/apps/01-storage/synology-csi/base/node.yaml
+++ b/apps/01-storage/synology-csi/base/node.yaml
@@ -27,6 +27,7 @@ spec:
           volumeMounts:
             - name: host-root
               mountPath: /host
+      priorityClassName: vixens-critical
       containers:
         - name: csi-node-driver-registrar
           image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0

--- a/apps/02-monitoring/promtail/base/daemonset.yaml
+++ b/apps/02-monitoring/promtail/base/daemonset.yaml
@@ -14,6 +14,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9080"
+        vixens.io/fast-start: "true"
       labels:
         app: promtail
         vixens.io/sizing.promtail: G-small

--- a/apps/02-monitoring/robusta/base/holmes.yaml
+++ b/apps/02-monitoring/robusta/base/holmes.yaml
@@ -79,7 +79,7 @@ spec:
           emptyDir: {}
       initContainers:
         - name: config-interpolator
-          image: busybox
+          image: busybox:1.37.0
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -104,6 +104,7 @@ spec:
               mountPath: /etc/robusta/config-src
             - name: playbooks-config-processed
               mountPath: /etc/robusta/config
+      priorityClassName: vixens-low
       containers:
         - name: holmes
           image: "us-central1-docker.pkg.dev/genuine-flight-317411/devel/holmes:0.20.0"

--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -45,14 +45,14 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
-      priorityClassName: vixens-critical
+      priorityClassName: vixens-high
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
       initContainers:
         - name: fix-perms
-          image: busybox:latest
+          image: busybox:1.37.0
           securityContext:
             runAsUser: 0
           command:
@@ -124,7 +124,7 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: config-init
-          image: busybox:latest
+          image: busybox:1.37.0
           command:
             - sh
             - -c

--- a/apps/10-home/mealie/base/deployment.yaml
+++ b/apps/10-home/mealie/base/deployment.yaml
@@ -85,6 +85,7 @@ spec:
             - name: mealie-litestream-config
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
+      priorityClassName: vixens-low
       containers:
         - name: mealie
           image: ghcr.io/mealie-recipes/mealie:v3.11.0

--- a/apps/10-home/mosquitto/base/statefulset.yaml
+++ b/apps/10-home/mosquitto/base/statefulset.yaml
@@ -90,6 +90,7 @@ spec:
               readOnly: true
             - name: mosquitto-auth-writable
               mountPath: /auth
+      priorityClassName: vixens-high
       containers:
         - name: mosquitto
           image: eclipse-mosquitto:2.0.22

--- a/apps/20-media/amule/base/deployment.yaml
+++ b/apps/20-media/amule/base/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      priorityClassName: vixens-low
       containers:
         - name: amule
           image: tchabaud/amule:latest
@@ -70,7 +71,7 @@ spec:
               mountPath: /downloads
       initContainers:
         - name: configure-proxy
-          image: busybox
+          image: busybox:1.37.0
           command:
             - sh
             - -c

--- a/apps/20-media/birdnet-go/base/deployment.yaml
+++ b/apps/20-media/birdnet-go/base/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: fix-permissions
-          image: busybox:latest
+          image: busybox:1.37.0
           command:
             - sh
             - -c

--- a/apps/20-media/booklore/base/deployment.yaml
+++ b/apps/20-media/booklore/base/deployment.yaml
@@ -86,6 +86,7 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /app/data
+      priorityClassName: vixens-low
       containers:
         - name: booklore
           image: ghcr.io/booklore-app/booklore:v2.0.5

--- a/apps/20-media/booklore/base/mariadb-deployment.yaml
+++ b/apps/20-media/booklore/base/mariadb-deployment.yaml
@@ -25,6 +25,7 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      priorityClassName: vixens-low
       containers:
         - name: mariadb
           image: lscr.io/linuxserver/mariadb:11.4.8

--- a/apps/20-media/hydrus-client/base/deployment.yaml
+++ b/apps/20-media/hydrus-client/base/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: fix-permissions
-          image: busybox:latest
+          image: busybox:1.37.0
           command:
             - sh
             - -c
@@ -51,7 +51,7 @@ spec:
             - name: config
               mountPath: /opt/hydrus/db
         - name: check-integrity
-          image: keinos/sqlite3:latest
+          image: keinos/sqlite3:3.51.2
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/20-media/jellyfin/base/deployment.yaml
+++ b/apps/20-media/jellyfin/base/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app: jellyfin
         vixens.io/sizing.jellyfin: V-large
     spec:
-      priorityClassName: homelab-important
+      priorityClassName: vixens-medium
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists

--- a/apps/20-media/jellyseerr/base/deployment.yaml
+++ b/apps/20-media/jellyseerr/base/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      priorityClassName: vixens-medium
       containers:
         - name: jellyseerr
           image: fallenbagel/jellyseerr:2.7

--- a/apps/20-media/lazylibrarian/base/deployment.yaml
+++ b/apps/20-media/lazylibrarian/base/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: fix-permissions
-          image: busybox:latest
+          image: busybox:1.37.0
           command: ["sh", "-c", "chown -R 1000:1000 /config && rm -rf /config/*.db-litestream /config/.*-litestream"]
           volumeMounts:
             - name: config
@@ -95,9 +95,10 @@ spec:
             - name: lazylibrarian-litestream-config
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
+      priorityClassName: vixens-low
       containers:
         - name: lazylibrarian
-          image: lscr.io/linuxserver/lazylibrarian:latest
+          image: lscr.io/linuxserver/lazylibrarian:version-e7c7ce2d
           ports:
             - containerPort: 5299
               name: http

--- a/apps/20-media/lidarr/base/deployment.yaml
+++ b/apps/20-media/lidarr/base/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: fix-permissions
-          image: busybox:latest
+          image: busybox:1.37.0
           command: ["sh", "-c", "chown -R 1000:1000 /config && rm -rf /config/*.db-litestream /config/.*-litestream"]
           volumeMounts:
             - name: config

--- a/apps/20-media/music-assistant/base/deployment.yaml
+++ b/apps/20-media/music-assistant/base/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      priorityClassName: vixens-medium
       containers:
         - name: music-assistant
           image: ghcr.io/music-assistant/server:2.8.0b9

--- a/apps/20-media/mylar/base/deployment.yaml
+++ b/apps/20-media/mylar/base/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: fix-permissions
-          image: busybox:latest
+          image: busybox:1.37.0
           command: ["sh", "-c", "chown -R 1000:1000 /config && rm -rf /config/*.db-litestream /config/.*-litestream"]
           volumeMounts:
             - name: config

--- a/apps/20-media/prowlarr/base/deployment.yaml
+++ b/apps/20-media/prowlarr/base/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: fix-permissions
-          image: busybox:latest
+          image: busybox:1.37.0
           command: ["sh", "-c", "chown -R 1000:1000 /config && rm -rf /config/*.db-litestream /config/.*-litestream"]
           volumeMounts:
             - name: config

--- a/apps/20-media/pyload/base/deployment.yaml
+++ b/apps/20-media/pyload/base/deployment.yaml
@@ -24,9 +24,10 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      priorityClassName: vixens-low
       containers:
         - name: pyload
-          image: lscr.io/linuxserver/pyload-ng:latest
+          image: lscr.io/linuxserver/pyload-ng:0.5.0
           ports:
             - containerPort: 8000
               name: http

--- a/apps/20-media/qbittorrent/base/deployment.yaml
+++ b/apps/20-media/qbittorrent/base/deployment.yaml
@@ -25,9 +25,10 @@ spec:
           operator: Exists
           effect: NoSchedule
       initContainers: []
+      priorityClassName: vixens-medium
       containers:
         - name: qbittorrent
-          image: lscr.io/linuxserver/qbittorrent:latest
+          image: lscr.io/linuxserver/qbittorrent:5.1.4
           ports:
             - containerPort: 8080
               name: http

--- a/apps/20-media/sonarr/base/deployment.yaml
+++ b/apps/20-media/sonarr/base/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: fix-permissions
-          image: busybox:latest
+          image: busybox:1.37.0
           command: ["sh", "-c", "chown -R 1000:1000 /config && rm -rf /config/*.db-litestream /config/.*-litestream"]
           volumeMounts:
             - name: config

--- a/apps/20-media/whisparr/base/deployment.yaml
+++ b/apps/20-media/whisparr/base/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: fix-permissions
-          image: busybox:latest
+          image: busybox:1.37.0
           command: ["sh", "-c", "chown -R 1000:1000 /config && rm -rf /config/*.db-litestream /config/.*-litestream"]
           volumeMounts:
             - name: config

--- a/apps/40-network/netbird/base/dashboard.yaml
+++ b/apps/40-network/netbird/base/dashboard.yaml
@@ -21,7 +21,7 @@ spec:
         app: netbird-dashboard
         vixens.io/sizing.dashboard: V-small
     spec:
-      priorityClassName: vixens-high
+      priorityClassName: vixens-low
       tolerations:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"

--- a/apps/40-network/netbird/base/management.yaml
+++ b/apps/40-network/netbird/base/management.yaml
@@ -24,7 +24,7 @@ spec:
         vixens.io/sizing.init-config: G-nano
         vixens.io/sizing.management: V-medium
     spec:
-      priorityClassName: vixens-high
+      priorityClassName: vixens-low
       tolerations:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"

--- a/apps/40-network/netbird/base/signal-relay.yaml
+++ b/apps/40-network/netbird/base/signal-relay.yaml
@@ -21,7 +21,7 @@ spec:
         app: netbird-signal
         vixens.io/sizing.signal: V-small
     spec:
-      priorityClassName: vixens-high
+      priorityClassName: vixens-low
       tolerations:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
@@ -78,7 +78,7 @@ spec:
         app: netbird-relay
         vixens.io/sizing.relay: V-small
     spec:
-      priorityClassName: vixens-high
+      priorityClassName: vixens-low
       tolerations:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"

--- a/apps/40-network/netvisor/base/daemon-daemonset.yaml
+++ b/apps/40-network/netvisor/base/daemon-daemonset.yaml
@@ -11,6 +11,8 @@ spec:
       app: netvisor-daemon
   template:
     metadata:
+      annotations:
+        vixens.io/fast-start: "true"
       labels:
         app: netvisor-daemon
         vixens.io/sizing.daemon: G-nano
@@ -21,6 +23,7 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      priorityClassName: vixens-low
       containers:
         - name: daemon
           image: ghcr.io/scanopy/scanopy/daemon:v0.14.13

--- a/apps/40-network/netvisor/base/server-deployment.yaml
+++ b/apps/40-network/netvisor/base/server-deployment.yaml
@@ -14,6 +14,8 @@ spec:
       app: netvisor-server
   template:
     metadata:
+      annotations:
+        vixens.io/fast-start: "true"
       labels:
         app: netvisor-server
         vixens.io/sizing.server: V-small
@@ -22,6 +24,7 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      priorityClassName: vixens-low
       containers:
         - name: server
           image: ghcr.io/scanopy/scanopy/server:v0.14.13

--- a/apps/60-services/docspell/base/statefulset-joex.yaml
+++ b/apps/60-services/docspell/base/statefulset-joex.yaml
@@ -26,6 +26,7 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      priorityClassName: vixens-medium
       containers:
         - name: joex
           image: ghcr.io/docspell/joex:v0.43.0

--- a/apps/60-services/docspell/base/statefulset-restserver.yaml
+++ b/apps/60-services/docspell/base/statefulset-restserver.yaml
@@ -26,6 +26,7 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      priorityClassName: vixens-medium
       containers:
         - name: restserver
           image: ghcr.io/docspell/restserver:v0.43.0

--- a/apps/60-services/firefly-iii-importer/base/deployment.yaml
+++ b/apps/60-services/firefly-iii-importer/base/deployment.yaml
@@ -13,6 +13,8 @@ spec:
       app.kubernetes.io/name: firefly-iii-importer
   template:
     metadata:
+      annotations:
+        vixens.io/fast-start: "true"
       labels:
         app.kubernetes.io/name: firefly-iii-importer
         vixens.io/sizing.importer: V-small
@@ -24,7 +26,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: importer
-          image: fireflyiii/data-importer:latest
+          image: fireflyiii/data-importer:version-2.1.1
           ports:
             - containerPort: 8080
               name: http

--- a/apps/60-services/gluetun/base/deployment.yaml
+++ b/apps/60-services/gluetun/base/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      priorityClassName: vixens-medium
       containers:
         - name: gluetun
           image: ghcr.io/qdm12/gluetun:v3.41.1

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -45,7 +45,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: fix-perms
-          image: busybox:latest
+          image: busybox:1.37.0
           securityContext:
             runAsUser: 0
           command:
@@ -280,7 +280,7 @@ spec:
               mountPath: /data
         # Setup Gemini config from Infisical secrets
         - name: setup-gemini-config
-          image: busybox:latest
+          image: busybox:1.37.0
           command:
             - sh
             - -c
@@ -318,7 +318,7 @@ spec:
               mountPath: /data
       containers:
         - name: openclaw
-          image: ghcr.io/openclaw/openclaw:latest
+          image: ghcr.io/openclaw/openclaw:2026.3.2
           imagePullPolicy: Always
           command:
             - node

--- a/apps/60-services/vaultwarden/base/deployment.yaml
+++ b/apps/60-services/vaultwarden/base/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: fix-permissions
-          image: busybox:latest
+          image: busybox:1.37.0
           command: ["sh", "-c", "chown -R 1000:1000 /data && rm -rf /data/*.db-litestream /data/.*-litestream"]
           volumeMounts:
             - name: data

--- a/apps/70-tools/changedetection/base/deployment.yaml
+++ b/apps/70-tools/changedetection/base/deployment.yaml
@@ -51,6 +51,7 @@ spec:
           volumeMounts:
             - name: datastore
               mountPath: /datastore
+      priorityClassName: vixens-low
       containers:
         - name: changedetection
           image: ghcr.io/dgtlmoon/changedetection.io:0.54.4

--- a/apps/70-tools/headlamp/base/deployment.yaml
+++ b/apps/70-tools/headlamp/base/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         reloader.stakater.com/auto: "true"
         prometheus.io/scrape: "true"
         prometheus.io/port: "4466"
+        vixens.io/fast-start: "true"
     spec:
       serviceAccountName: headlamp
       priorityClassName: vixens-medium

--- a/apps/70-tools/homepage/base/deployment.yaml
+++ b/apps/70-tools/homepage/base/deployment.yaml
@@ -46,6 +46,7 @@ spec:
             - name: config-vol # The writable PVC
               mountPath: /config
       # Main application container
+      priorityClassName: vixens-low
       containers:
         - name: homepage
           image: ghcr.io/gethomepage/homepage:v1.10

--- a/apps/70-tools/linkwarden/base/deployment.yaml
+++ b/apps/70-tools/linkwarden/base/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      priorityClassName: vixens-low
       containers:
         - name: linkwarden
           image: ghcr.io/linkwarden/linkwarden:v2.13.5

--- a/apps/70-tools/netbox/base/deployment.yaml
+++ b/apps/70-tools/netbox/base/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      priorityClassName: vixens-medium
       containers:
         - name: netbox
           image: netboxcommunity/netbox:v4.5.4 # Pinned image version

--- a/apps/70-tools/penpot/base/deployment-frontend.yaml
+++ b/apps/70-tools/penpot/base/deployment-frontend.yaml
@@ -17,6 +17,8 @@ spec:
       app: penpot-frontend
   template:
     metadata:
+      annotations:
+        vixens.io/fast-start: "true"
       labels:
         app: penpot-frontend
         component: frontend

--- a/apps/70-tools/vikunja/base/deployment.yaml
+++ b/apps/70-tools/vikunja/base/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      priorityClassName: vixens-low
       containers:
         - name: vikunja
           image: vikunja/vikunja:2.1.0

--- a/argocd/overlays/prod/apps/argocd.yaml
+++ b/argocd/overlays/prod/apps/argocd.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: argocd
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0" # ArgoCD self-management, core infra tier
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argocd/overlays/prod/apps/contacts.yaml
+++ b/argocd/overlays/prod/apps/contacts.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: contacts
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10" # Standard application tier
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argocd/overlays/prod/apps/firefly-iii-importer.yaml
+++ b/argocd/overlays/prod/apps/firefly-iii-importer.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: firefly-iii-importer
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10" # Standard application tier
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argocd/overlays/prod/apps/firefly-iii.yaml
+++ b/argocd/overlays/prod/apps/firefly-iii.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: firefly-iii
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10" # Standard application tier
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argocd/overlays/prod/apps/goldilocks.yaml
+++ b/argocd/overlays/prod/apps/goldilocks.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: goldilocks
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "6" # Monitoring/observability tier
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argocd/overlays/prod/apps/maturity-controller.yaml
+++ b/argocd/overlays/prod/apps/maturity-controller.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: maturity-controller
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10" # Standard application tier
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argocd/overlays/prod/apps/nocodb.yaml
+++ b/argocd/overlays/prod/apps/nocodb.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: nocodb
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10" # Standard application tier
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argocd/overlays/prod/apps/penpot.yaml
+++ b/argocd/overlays/prod/apps/penpot.yaml
@@ -5,6 +5,7 @@ metadata:
   name: penpot
   namespace: argocd
   annotations:
+    argocd.argoproj.io/sync-wave: "10" # Standard application tier
     argocd.argoproj.io/manifest-generate-paths: .
   finalizers:
     - resources-finalizer.argocd.argoproj.io

--- a/argocd/overlays/prod/apps/postgresql.yaml
+++ b/argocd/overlays/prod/apps/postgresql.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: postgresql
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "4" # Database/storage tier
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argocd/overlays/prod/apps/radar.yaml
+++ b/argocd/overlays/prod/apps/radar.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: radar
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "7" # Low-priority monitoring
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argocd/overlays/prod/apps/robusta.yaml
+++ b/argocd/overlays/prod/apps/robusta.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: robusta
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "6" # Monitoring/observability tier
 spec:
   project: default
   sources:

--- a/argocd/overlays/prod/apps/trivy.yaml
+++ b/argocd/overlays/prod/apps/trivy.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: trivy
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "5" # Security scanning tier
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argocd/overlays/prod/apps/velero-maintenance-config.yaml
+++ b/argocd/overlays/prod/apps/velero-maintenance-config.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: velero-maintenance-config
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2" # After velero (wave 1)
 spec:
   project: default
   destination:

--- a/argocd/overlays/prod/apps/vpa.yaml
+++ b/argocd/overlays/prod/apps/vpa.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: vpa
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "4" # Database/storage tier
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:


### PR DESCRIPTION
## Summary

Four maturity quick wins implemented in a single PR.

---

### QW1 — Fast-start bypass annotation

Added `vixens.io/fast-start: "true"` to pod templates of stateless/quick-start apps to bypass the `check-startup-probe` Silver policy. Criteria: Go binary or Nginx static server, no PV warmup, no DB init, starts in <5s.

| App | Reason |
|-----|--------|
| headlamp | Stateless Go K8s dashboard |
| penpot-frontend | Nginx static JS/CSS |
| promtail | Stateless Go log shipper DaemonSet |
| firefly-iii-importer | Stateless PHP import UI, no init containers |
| netvisor-server | Go HTTP server, readinessProbe handles DB |
| netvisor-daemon | Lightweight Go network scanner DaemonSet |
| reloader | Stateless Go configmap/secret watcher (via kustomize patch) |

Explicitly skipped: all config-syncer apps (rclone/litestream init containers), JVM apps, database-dependent apps, Helm-managed infra components.

---

### QW2 — Sync-wave for 14 unordered ArgoCD Applications

All 94 prod Applications now have explicit sync-waves. Wave assignments follow the existing scale:

| Wave | Apps added |
|------|-----------|
| 0 | argocd (self-management) |
| 2 | velero-maintenance-config |
| 4 | postgresql, vpa |
| 5 | trivy |
| 6 | goldilocks, robusta |
| 7 | radar |
| 10 | contacts, firefly-iii, firefly-iii-importer, maturity-controller, nocodb, penpot |

---

### QW3 — priorityClassName on 25 apps + 3 corrections

**Added** (first-time):
- `vixens-critical`: synology-csi controller + node DaemonSet, ArgoCD (all Deployments+StatefulSets via wildcard kustomize patch)
- `vixens-high`: reloader, mosquitto (user-specified correction)
- `vixens-medium`: jellyseerr, qbittorrent, music-assistant, gluetun, netvisor-server, netvisor-daemon, netbox, docspell-restserver, docspell-joex
- `vixens-low`: mealie, amule, booklore, lazylibrarian, pyload, changedetection, homepage, linkwarden, vikunja, robusta-holmes

**Corrected**:
- `jellyfin`: `homelab-important` → `vixens-medium` (invalid class name that would fail Kyverno)
- `homeassistant`: `vixens-critical` → `vixens-high` (user correction)
- `netbird` (3 files): `vixens-high` → `vixens-low` (user correction: projet non fonctionnel)

---

### QW4 — Pin :latest image tags

| Image | Old tag | New tag |
|-------|---------|---------|
| `busybox` | `:latest` | `1.37.0` (13 occurrences in config-syncer init containers) |
| `keinos/sqlite3` | `:latest` | `3.51.2` |
| `ghcr.io/openclaw/openclaw` | `:latest` | `2026.3.2` |
| `fireflyiii/data-importer` | `:latest` | `version-2.1.1` |
| `lscr.io/linuxserver/lazylibrarian` | `:latest` | `version-e7c7ce2d` |
| `lscr.io/linuxserver/qbittorrent` | `:latest` | `5.1.4` |
| `lscr.io/linuxserver/pyload-ng` | `:latest` | `0.5.0` |

Skipped (upstream publishes only `:latest`): `tchabaud/amule`, `bitnami/kubectl`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure Updates**
  * Assigned pod scheduling priorities across many services to manage workload ordering.
  * Added application sync-wave annotations to control orchestration/sync order.

* **Container Image Updates**
  * Pinned various init and app images from "latest" to specific versions for reproducibility.

* **Deployment Configuration**
  * Added fast-start metadata annotations to select workloads for quicker startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->