### PR TITLE
fix(sizing): right-size authentik-worker, jellyfin, linkwarden per VPA recs

### DIFF
--- a/apps/03-security/authentik/overlays/prod/worker-resources.yaml
+++ b/apps/03-security/authentik/overlays/prod/worker-resources.yaml
@@ -7,6 +7,6 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.authentik-worker: G-xlarge
+        vixens.io/sizing.authentik-worker: B-large
     spec:
       priorityClassName: vixens-critical

--- a/apps/20-media/jellyfin/base/deployment.yaml
+++ b/apps/20-media/jellyfin/base/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         app: jellyfin
-        vixens.io/sizing.jellyfin: V-large
+        vixens.io/sizing.jellyfin: V-medium
     spec:
       priorityClassName: vixens-medium
       tolerations:

--- a/apps/70-tools/linkwarden/base/deployment.yaml
+++ b/apps/70-tools/linkwarden/base/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         app: linkwarden
-        vixens.io/sizing.linkwarden: V-large
+        vixens.io/sizing.linkwarden: V-medium
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
## Summary

Right-size 3 apps based on Goldilocks VPA recommendations to free ~2Gi of memory requests and resolve linkwarden Pending scheduling issue.

| App | Before | After | Request freed |
|-----|--------|-------|--------------|
| authentik-worker | G-xlarge (req=2Gi, lim=2Gi) | B-large (req=1Gi, lim=2Gi) | -1Gi |
| jellyfin | V-large (req=1Gi, lim=4Gi) | V-medium (req=512Mi, lim=2Gi) | -512Mi |
| linkwarden | V-large (req=1Gi, lim=4Gi) | V-medium (req=512Mi, lim=2Gi) | -512Mi |

VPA recommendations: authentik-worker=1568Mi, jellyfin=334Mi, linkwarden=728Mi — all within new limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted resource sizing configurations for internal services to optimize infrastructure performance and allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->