### PR TITLE
fix: cluster stability improvements

### DIFF
--- a/apps/00-infra/traefik/values/prod.yaml
+++ b/apps/00-infra/traefik/values/prod.yaml
@@ -29,6 +29,16 @@ resources:
 # High availability with multiple replicas
 deployment:
   replicas: 2
+  podLabels:
+    app.kubernetes.io/name: traefik
+# Ensure traefik pods spread across nodes
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: traefik
 # ============================================================================
 # Production Metrics & Monitoring
 # ============================================================================

--- a/apps/03-security/authentik/base/deployment-server.yaml
+++ b/apps/03-security/authentik/base/deployment-server.yaml
@@ -17,6 +17,7 @@ spec:
     metadata:
       labels:
         app: authentik-server
+        vixens.io/backup-profile: critical
       annotations:
         reloader.stakater.com/auto: "true"
     spec:

--- a/apps/03-security/authentik/base/deployment-worker.yaml
+++ b/apps/03-security/authentik/base/deployment-worker.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
         app: authentik-worker
         vixens.io/service-binding: "false"
+        vixens.io/backup-profile: critical
       annotations:
         reloader.stakater.com/auto: "true"
     spec:

--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: homeassistant
     vixens.io/sizing: B-large
-    vixens.io/sizing.litestream: V-nano
+    vixens.io/sizing.litestream: V-small
     vixens.io/sizing.config-syncer: V-nano
     vixens.io/sizing.restore-config: B-nano
     vixens.io/sizing.restore-db: B-nano
@@ -27,7 +27,7 @@ spec:
       labels:
         app: homeassistant
         vixens.io/sizing: B-large
-        vixens.io/sizing.litestream: V-nano
+        vixens.io/sizing.litestream: V-small
         vixens.io/sizing.config-syncer: V-nano
         vixens.io/sizing.restore-config: B-nano
         vixens.io/sizing.restore-db: B-nano

--- a/apps/20-media/birdnet-go/base/deployment.yaml
+++ b/apps/20-media/birdnet-go/base/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               mountPath: /data
       containers:
         - name: birdnet-go
-          image: ghcr.io/tphakala/birdnet-go:nightly-20251223
+          image: ghcr.io/tphakala/birdnet-go:v0.6.4
           imagePullPolicy: Always
           ports:
             - name: http

--- a/apps/20-media/pyload/base/infisical-secret.yaml
+++ b/apps/20-media/pyload/base/infisical-secret.yaml
@@ -18,4 +18,4 @@ spec:
   managedSecretReference:
     secretName: pyload-secrets
     creationPolicy: Owner
-    secretNamespace: media
+    secretNamespace: downloads

--- a/apps/20-media/pyload/overlays/prod/patch-infisical-env.yaml
+++ b/apps/20-media/pyload/overlays/prod/patch-infisical-env.yaml
@@ -10,4 +10,4 @@ spec:
         envSlug: prod
         secretsPath: /apps/20-media/pyload
   managedSecretReference:
-    secretNamespace: media
+    secretNamespace: downloads

--- a/apps/60-services/docspell/base/statefulset-restserver.yaml
+++ b/apps/60-services/docspell/base/statefulset-restserver.yaml
@@ -21,6 +21,7 @@ spec:
         app: docspell
         component: restserver
         vixens.io/sizing.restserver: V-medium
+        vixens.io/backup-profile: standard
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane

--- a/apps/60-services/firefly-iii/base/deployment.yaml
+++ b/apps/60-services/firefly-iii/base/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         vixens.io/sizing.restore-config: B-nano
         vixens.io/sizing.firefly-iii: V-medium
         vixens.io/sizing.config-syncer: V-nano
+        vixens.io/backup-profile: standard
       annotations:
         reloader.stakater.com/auto: "true"
         vixens.io/health-bump: "5"

--- a/apps/60-services/vaultwarden/base/deployment.yaml
+++ b/apps/60-services/vaultwarden/base/deployment.yaml
@@ -23,6 +23,7 @@ spec:
         vixens.io/sizing.vaultwarden: V-nano
         vixens.io/sizing.litestream: V-nano
         vixens.io/sizing.config-syncer: V-nano
+        vixens.io/backup-profile: critical
       annotations:
         reloader.stakater.com/auto: "true"
         prometheus.io/scrape: "true"

--- a/apps/70-tools/linkwarden/base/deployment.yaml
+++ b/apps/70-tools/linkwarden/base/deployment.yaml
@@ -19,6 +19,7 @@ spec:
       labels:
         app: linkwarden
         vixens.io/sizing.linkwarden: V-medium
+        vixens.io/backup-profile: relaxed
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane

--- a/apps/70-tools/nocodb/base/deployment.yaml
+++ b/apps/70-tools/nocodb/base/deployment.yaml
@@ -19,6 +19,7 @@ spec:
       labels:
         app.kubernetes.io/name: nocodb
         vixens.io/sizing.nocodb: V-small
+        vixens.io/backup-profile: relaxed
       annotations:
         reloader.stakater.com/auto: "true"
     spec:

--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -23,6 +23,7 @@ spec:
         app: penpot-backend
         component: backend
         vixens.io/sizing.backend: B-large
+        vixens.io/backup-profile: standard
     spec:
       priorityClassName: vixens-medium
       tolerations:

--- a/apps/70-tools/vikunja/base/deployment.yaml
+++ b/apps/70-tools/vikunja/base/deployment.yaml
@@ -19,6 +19,7 @@ spec:
       labels:
         app.kubernetes.io/name: vikunja
         vixens.io/sizing.vikunja: V-small
+        vixens.io/backup-profile: relaxed
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
## Summary

- **homeassistant litestream OOMKill fix**: upsize `V-nano` → `V-small` (256Mi→512Mi limit) to prevent litestream container from being OOM-killed
- **birdnet-go stable tag**: pin to `v0.6.4` (2025-03-15) instead of `nightly-20251223` (2 months stale nightly)
- **pyload cross-namespace InfisicalSecret bug**: fix `secretNamespace: media → downloads` — InfisicalSecret is in namespace `downloads`, creating a secret in another namespace is disallowed with `creationPolicy: Owner`
- **Backup labels coverage**: add `vixens.io/backup-profile` to 9 apps that were missing it (Kyverno audit violation)
  | App | Profile | Reason |
  |-----|---------|--------|
  | vaultwarden | critical | Password manager, cannot lose data |
  | authentik-server | critical | Auth provider, cannot lose data |
  | authentik-worker | critical | Same deployment unit as server |
  | firefly-iii | standard | Financial tracking |
  | docspell | standard | Document management |
  | penpot-backend | standard | Design tool with user data |
  | linkwarden | relaxed | Bookmarks, recoverable |
  | nocodb | relaxed | Spreadsheet tool |
  | vikunja | relaxed | Task manager |
- **traefik topology spread**: add `topologySpreadConstraints` to guarantee 2 replicas land on different nodes (currently works by luck)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced infrastructure reliability with improved pod distribution and labeling across deployment environments.
  * Implemented backup profile classifications across services to optimize data protection policies.
  * Updated container image to stable release version, improving platform stability.
  * Adjusted resource allocation configuration for optimized performance.
  * Refined service namespace configurations for improved organization management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->