### PR TITLE
feat: goldification wave1 - probes on 12 apps (bronze → silver)

### DIFF
--- a/apps/03-security/authentik/base/deployment-server.yaml
+++ b/apps/03-security/authentik/base/deployment-server.yaml
@@ -106,6 +106,22 @@ spec:
               value: "https://netbird.dev.truxonline.com,https://netbird.truxonline.com"
             - name: AUTHENTIK_BLUEPRINTS__BOOTSTRAP_AND_OVERWRITE
               value: "true"
+          livenessProbe:
+            httpGet:
+              path: /api/v3/-/health/live/
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/v3/-/health/live/
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           volumeMounts:
             - name: authentik-data
               mountPath: /var/lib/authentik

--- a/apps/03-security/authentik/base/deployment-worker.yaml
+++ b/apps/03-security/authentik/base/deployment-worker.yaml
@@ -69,6 +69,20 @@ spec:
               value: "https://netbird.dev.truxonline.com,https://netbird.truxonline.com"
             - name: AUTHENTIK_BLUEPRINTS__BOOTSTRAP_AND_OVERWRITE
               value: "true"
+          livenessProbe:
+            exec:
+              command: ["ak", "healthcheck"]
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["ak", "healthcheck"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 3
           volumeMounts:
             - name: authentik-data
               mountPath: /var/lib/authentik

--- a/apps/10-home/mealie/base/deployment.yaml
+++ b/apps/10-home/mealie/base/deployment.yaml
@@ -95,6 +95,22 @@ spec:
           envFrom:
             - secretRef:
                 name: mealie-secrets
+          livenessProbe:
+            httpGet:
+              path: /api/app/about
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/app/about
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           volumeMounts:
             - name: data
               mountPath: /app/data

--- a/apps/20-media/amule/base/deployment.yaml
+++ b/apps/20-media/amule/base/deployment.yaml
@@ -64,6 +64,20 @@ spec:
               value: http://gluetun.services.svc.cluster.local:8888
             - name: NO_PROXY
               value: localhost,127.0.0.1,10.0.0.0/8,192.168.0.0/16
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           volumeMounts:
             - name: config
               mountPath: /home/amule/.aMule

--- a/apps/20-media/jellyfin/base/deployment.yaml
+++ b/apps/20-media/jellyfin/base/deployment.yaml
@@ -36,6 +36,22 @@ spec:
               value: Europe/Paris
             - name: JELLYFIN_LOG_DIR
               value: /config/log
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/20-media/jellyseerr/base/deployment.yaml
+++ b/apps/20-media/jellyseerr/base/deployment.yaml
@@ -36,6 +36,22 @@ spec:
               value: debug
             - name: TZ
               value: Europe/Paris
+          livenessProbe:
+            httpGet:
+              path: /api/v1/status
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/v1/status
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           volumeMounts:
             - name: config
               mountPath: /app/config

--- a/apps/20-media/lazylibrarian/base/deployment.yaml
+++ b/apps/20-media/lazylibrarian/base/deployment.yaml
@@ -109,6 +109,22 @@ spec:
               value: "1000"
             - name: TZ
               value: Europe/Paris
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/20-media/pyload/base/deployment.yaml
+++ b/apps/20-media/pyload/base/deployment.yaml
@@ -44,6 +44,22 @@ spec:
               value: http://gluetun.services.svc.cluster.local:8888
             - name: NO_PROXY
               value: localhost,127.0.0.1,10.0.0.0/8,192.168.0.0/16
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/20-media/qbittorrent/base/deployment.yaml
+++ b/apps/20-media/qbittorrent/base/deployment.yaml
@@ -57,6 +57,22 @@ spec:
               value: http://gluetun.services.svc.cluster.local:8888
             - name: NO_PROXY
               value: localhost,127.0.0.1,10.0.0.0/8,192.168.0.0/16
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/60-services/docspell/base/statefulset-joex.yaml
+++ b/apps/60-services/docspell/base/statefulset-joex.yaml
@@ -55,6 +55,22 @@ spec:
                 secretKeyRef:
                   name: docspell-db-credentials
                   key: password
+          livenessProbe:
+            httpGet:
+              path: /api/info/version
+              port: api
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/info/version
+              port: api
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           volumeMounts:
             - name: config
               mountPath: /opt/docspell.conf

--- a/apps/60-services/docspell/base/statefulset-restserver.yaml
+++ b/apps/60-services/docspell/base/statefulset-restserver.yaml
@@ -53,6 +53,22 @@ spec:
                 secretKeyRef:
                   name: docspell-db-credentials
                   key: password
+          livenessProbe:
+            httpGet:
+              path: /api/info/version
+              port: api
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/info/version
+              port: api
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           volumeMounts:
             - name: config
               mountPath: /opt/docspell.conf

--- a/apps/70-tools/homepage/base/deployment.yaml
+++ b/apps/70-tools/homepage/base/deployment.yaml
@@ -62,6 +62,22 @@ spec:
                 secretKeyRef:
                   name: homepage-secrets
                   key: HOMEASSISTANT_API_KEY
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           volumeMounts:
             # Mount the writable PVC, which is now populated by the
             # initContainer.


### PR DESCRIPTION
## Summary

Maturity uplift: **Bronze → Silver** for 12 apps. Adds `livenessProbe` + `readinessProbe` on all main containers that were missing them.

| App | Probe type | Path / Port | Slow start |
|-----|-----------|-------------|------------|
| authentik-server | httpGet | `/api/v3/-/health/live/` : 9000 | 60s |
| authentik-worker | exec | `ak healthcheck` | 60s |
| jellyfin | httpGet | `/health` : 8096 | 120s |
| jellyseerr | httpGet | `/api/v1/status` : 5055 | — |
| mealie | httpGet | `/api/app/about` : 9000 | — |
| homepage | httpGet | `/` : 3000 | — |
| qbittorrent | httpGet | `/` : 8080 | — |
| amule | tcpSocket | 4711 | — |
| pyload | httpGet | `/` : 8000 | — |
| lazylibrarian | httpGet | `/` : 5299 | — |
| docspell-restserver | httpGet | `/api/info/version` : 7880 | 60s |
| docspell-joex | httpGet | `/api/info/version` : 7878 | 60s |

## Validation
- yamllint: ✅ no errors
- kustomize build: ✅ all 10 overlays/bases build successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Kubernetes health probes to 12 containerized services across authentik, mealie, amule, jellyfin, jellyseerr, lazylibrarian, pyload, qbittorrent, docspell, and homepage. Each service now includes liveness and readiness checks to improve container lifecycle management and enable faster detection of unhealthy instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->