### PR TITLE
feat: goldification wave2 - securityContext hardening (silver → diamond)

### DIFF
--- a/apps/20-media/prowlarr/base/deployment.yaml
+++ b/apps/20-media/prowlarr/base/deployment.yaml
@@ -118,6 +118,10 @@ spec:
           envFrom:
             - secretRef:
                 name: prowlarr-secrets
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: config
               mountPath: /config
@@ -180,3 +184,5 @@ spec:
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault

--- a/apps/20-media/radarr/base/deployment.yaml
+++ b/apps/20-media/radarr/base/deployment.yaml
@@ -106,6 +106,10 @@ spec:
           envFrom:
             - secretRef:
                 name: radarr-secrets
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: config
               mountPath: /config
@@ -200,3 +204,5 @@ spec:
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault

--- a/apps/20-media/sonarr/base/deployment.yaml
+++ b/apps/20-media/sonarr/base/deployment.yaml
@@ -118,6 +118,10 @@ spec:
           envFrom:
             - secretRef:
                 name: sonarr-secrets
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: config
               mountPath: /config
@@ -203,3 +207,5 @@ spec:
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault

--- a/apps/60-services/firefly-iii/base/deployment.yaml
+++ b/apps/60-services/firefly-iii/base/deployment.yaml
@@ -32,8 +32,11 @@ spec:
     spec:
       priorityClassName: vixens-medium
       securityContext:
+        runAsNonRoot: true
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
         - name: restore-config
           image: rclone/rclone:1.73
@@ -103,6 +106,10 @@ spec:
               value: "admin@truxonline.com"
             - name: TZ
               value: "Europe/Paris"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: static
               mountPath: /var/www/html/storage/upload

--- a/apps/70-tools/linkwarden/base/deployment.yaml
+++ b/apps/70-tools/linkwarden/base/deployment.yaml
@@ -55,6 +55,10 @@ spec:
             # Optional: Disable registration if desired
             - name: NEXT_PUBLIC_DISABLE_REGISTRATION
               value: "false"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: data
               mountPath: /data/data
@@ -81,3 +85,5 @@ spec:
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault

--- a/apps/70-tools/nocodb/base/deployment.yaml
+++ b/apps/70-tools/nocodb/base/deployment.yaml
@@ -59,6 +59,10 @@ spec:
                 secretKeyRef:
                   name: nocodb-secrets
                   key: NC_AUTH_JWT_SECRET
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: data
               mountPath: /usr/app/data
@@ -81,3 +85,5 @@ spec:
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault

--- a/apps/70-tools/vikunja/base/deployment.yaml
+++ b/apps/70-tools/vikunja/base/deployment.yaml
@@ -71,6 +71,10 @@ spec:
                   key: VIKUNJA_SERVICE_JWTSECRET
             - name: VIKUNJA_SERVICE_PUBLICURL
               value: https://vikunja.truxonline.com
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: vikunja-files
               mountPath: /app/vikunja/files
@@ -91,5 +95,8 @@ spec:
           persistentVolumeClaim:
             claimName: vikunja-files-pvc
       securityContext:
+        runAsNonRoot: true
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault


### PR DESCRIPTION
## Summary

Security context hardening on 7 apps. Based on verified runtime UID analysis.

### Full Diamond SC (runAsNonRoot + seccompProfile + allowPrivilegeEscalation + drop ALL capabilities)

| App | Evidence |
|-----|---------|
| vikunja | `USER 1000` confirmed in Dockerfile |
| firefly-iii | Runtime uid=33 (www-data) confirmed via `kubectl exec` |

### Partial SC (seccompProfile + allowPrivilegeEscalation: false + capabilities: drop [ALL])
*No `runAsNonRoot` — root needed for init containers or runtime*

| App | Reason |
|-----|--------|
| sonarr | linuxserver with fix-permissions init (uid=0) |
| radarr | same |
| prowlarr | same |
| linkwarden | Next.js app, confirmed uid=0 at runtime |
| nocodb | Node.js app, confirmed uid=0 at runtime |

### Skipped (deferred)
- lidarr/mylar/whisparr — PID1=0 confirmed, more risky
- vaultwarden — exec-failed, UID unknown, kept conservative
- mealie/homepage — uid=0 confirmed

## Validation
- yamllint: ✅ no errors  
- kustomize build: ✅ 7/7 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enhanced security hardening across deployed applications by implementing stricter container security policies. Changes include restricting privilege escalation, removing unnecessary system capabilities, enforcing non-root user execution where applicable, and implementing default system call filtering. These improvements strengthen overall security posture and reduce the potential attack surface of your services without impacting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->