### PR TITLE
feat(goldification): wave3 partial securityContext on 10 apps

### DIFF
--- a/apps/20-media/birdnet-go/base/deployment.yaml
+++ b/apps/20-media/birdnet-go/base/deployment.yaml
@@ -52,6 +52,10 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           env:
             - name: TZ
               value: Europe/Paris
@@ -151,3 +155,5 @@ spec:
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault

--- a/apps/20-media/lidarr/base/deployment.yaml
+++ b/apps/20-media/lidarr/base/deployment.yaml
@@ -91,6 +91,10 @@ spec:
           ports:
             - containerPort: 8686 # Default Lidarr UI port
               name: http
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           livenessProbe:
             httpGet:
               path: /ping
@@ -193,3 +197,5 @@ spec:
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault

--- a/apps/20-media/mylar/base/deployment.yaml
+++ b/apps/20-media/mylar/base/deployment.yaml
@@ -91,6 +91,10 @@ spec:
           ports:
             - containerPort: 8090 # Default Mylar UI port
               name: http
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           livenessProbe:
             httpGet:
               path: /
@@ -188,3 +192,5 @@ spec:
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault

--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -68,6 +68,10 @@ spec:
           ports:
             - containerPort: 8080 # Default Sabnzbd UI port
               name: http
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           livenessProbe:
             httpGet:
               path: /
@@ -156,3 +160,5 @@ spec:
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault

--- a/apps/20-media/whisparr/base/deployment.yaml
+++ b/apps/20-media/whisparr/base/deployment.yaml
@@ -74,6 +74,10 @@ spec:
           image: ghcr.io/hotio/whisparr:nightly
           ports:
             - containerPort: 6969 # Default Whisparr UI port
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           livenessProbe:
             httpGet:
               path: /ping
@@ -177,3 +181,5 @@ spec:
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault

--- a/apps/60-services/vaultwarden/base/deployment.yaml
+++ b/apps/60-services/vaultwarden/base/deployment.yaml
@@ -70,6 +70,10 @@ spec:
           ports:
             - containerPort: 80
               name: http
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           env:
             - name: DATA_FOLDER
               value: /data
@@ -158,3 +162,5 @@ spec:
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault

--- a/apps/70-tools/netbox/base/deployment.yaml
+++ b/apps/70-tools/netbox/base/deployment.yaml
@@ -31,6 +31,10 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           env:
             - name: DB_HOST
               value: postgresql-shared-rw.databases.svc.cluster.local
@@ -94,3 +98,5 @@ spec:
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault

--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -72,6 +72,10 @@ spec:
             initialDelaySeconds: 120
             periodSeconds: 30
             failureThreshold: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: data
               mountPath: /opt/data
@@ -79,4 +83,7 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: penpot-data
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       restartPolicy: Always

--- a/apps/70-tools/penpot/base/deployment-exporter.yaml
+++ b/apps/70-tools/penpot/base/deployment-exporter.yaml
@@ -45,6 +45,10 @@ spec:
           ports:
             - containerPort: 6061
               name: http
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           readinessProbe:
             tcpSocket:
               port: http
@@ -56,4 +60,7 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 30
             failureThreshold: 3
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       restartPolicy: Always

--- a/apps/70-tools/penpot/base/deployment-frontend.yaml
+++ b/apps/70-tools/penpot/base/deployment-frontend.yaml
@@ -41,6 +41,10 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           readinessProbe:
             httpGet:
               path: /
@@ -54,4 +58,7 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 3
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       restartPolicy: Always


### PR DESCRIPTION
## Summary

Goldification Wave 3 — adds partial `securityContext` hardening on 10 additional apps.

**Changes per app (partial SC: no `runAsNonRoot`, as all have uid=0 or unverified runtime UID):**

| App | Container SC | Pod seccompProfile | Reason no runAsNonRoot |
|-----|-------------|-------------------|----------------------|
| lidarr | ✅ allowPrivEsc=false + drop ALL | ✅ RuntimeDefault | Linuxserver PID1=0 |
| mylar | ✅ allowPrivEsc=false + drop ALL | ✅ RuntimeDefault | Linuxserver PID1=0 |
| whisparr | ✅ allowPrivEsc=false + drop ALL | ✅ RuntimeDefault | Linuxserver PID1=0 |
| sabnzbd | ✅ allowPrivEsc=false + drop ALL | ✅ RuntimeDefault | Linuxserver uid=0 |
| vaultwarden | ✅ allowPrivEsc=false + drop ALL | ✅ RuntimeDefault | fix-permissions init uid=0 |
| birdnet-go | ✅ allowPrivEsc=false + drop ALL | ✅ RuntimeDefault | fix-permissions init uid=0 |
| netbox | ✅ allowPrivEsc=false + drop ALL | ✅ RuntimeDefault | uid=0 confirmed |
| penpot-backend | ✅ allowPrivEsc=false + drop ALL | ✅ RuntimeDefault | uid=0 |
| penpot-frontend | ✅ allowPrivEsc=false + drop ALL | ✅ RuntimeDefault | uid=0 |
| penpot-exporter | ✅ allowPrivEsc=false + drop ALL | ✅ RuntimeDefault | uid=0 |

**Sidecar containers NOT touched:** litestream, config-syncer, data-syncer (already have their own SC with runAsUser/Group set)

**Kustomize build:** ✅ All 8 overlay builds pass  
**yamllint:** ✅ No errors (pre-existing line-length warnings only)