### PR TITLE
feat(goldification): wave4 partial securityContext on netbird + mosquitto + traefik

### DIFF
--- a/apps/00-infra/traefik/values/common.yaml
+++ b/apps/00-infra/traefik/values/common.yaml
@@ -98,3 +98,19 @@ ports:
     port: 9000
     expose: false
     exposedPort: 9000
+
+# ============================================================================
+# Security Context
+# ============================================================================
+# Pod-level: seccomp profile
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+# Container-level: drop all caps, add NET_BIND_SERVICE for ports < 1024 (80, 443, 53)
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    add:
+      - NET_BIND_SERVICE
+    drop:
+      - ALL

--- a/apps/10-home/mosquitto/base/statefulset.yaml
+++ b/apps/10-home/mosquitto/base/statefulset.yaml
@@ -110,6 +110,10 @@ spec:
               mountPath: /mosquitto/config/auth/mosquitto.passwd
               subPath: mosquitto.passwd
               readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           livenessProbe:
             tcpSocket:
               port: 1883
@@ -155,6 +159,9 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
         - name: config
           persistentVolumeClaim:

--- a/apps/40-network/netbird/base/dashboard.yaml
+++ b/apps/40-network/netbird/base/dashboard.yaml
@@ -26,9 +26,17 @@ spec:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: dashboard
           image: netbirdio/dashboard:v2.33.0
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add: ["NET_BIND_SERVICE"]
+              drop: ["ALL"]
           livenessProbe:
             tcpSocket:
               port: 80

--- a/apps/40-network/netbird/base/management.yaml
+++ b/apps/40-network/netbird/base/management.yaml
@@ -95,10 +95,18 @@ spec:
           volumeMounts:
             - name: config-writable
               mountPath: /etc/netbird
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: management
           image: netbirdio/management:0.66.2
           args: ["--port=80", "--log-file=console", "--log-level=info", "--config=/etc/netbird/management.json"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add: ["NET_BIND_SERVICE"]
+              drop: ["ALL"]
           livenessProbe:
             tcpSocket:
               port: 80

--- a/apps/40-network/netbird/base/signal-relay.yaml
+++ b/apps/40-network/netbird/base/signal-relay.yaml
@@ -26,10 +26,18 @@ spec:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: signal
           image: netbirdio/signal:0.66.2
           args: ["--port=80"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add: ["NET_BIND_SERVICE"]
+              drop: ["ALL"]
           livenessProbe:
             tcpSocket:
               port: 80
@@ -83,6 +91,9 @@ spec:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: relay
           image: netbirdio/relay:0.66.2
@@ -96,6 +107,10 @@ spec:
               value: "netbird-relay-secret-change-me"
             - name: NETBIRD_RELAY_AUTH_SECRET
               value: "netbird-relay-secret-change-me"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           livenessProbe:
             tcpSocket:
               port: 33080


### PR DESCRIPTION
## Summary

Goldification Wave 4 — adds partial `securityContext` hardening on the last batch of apps identified from the probe audit.

**Changes:**

| App / Container | Container SC | Pod seccompProfile | Notes |
|-----------------|-------------|-------------------|-------|
| netbird-management | `allowPrivEsc=false` + `drop ALL` + `NET_BIND_SERVICE` | ✅ RuntimeDefault | Port 80 < 1024 |
| netbird-signal | same | ✅ RuntimeDefault | Port 80 < 1024 |
| netbird-relay | `allowPrivEsc=false` + `drop ALL` | ✅ RuntimeDefault | Port 33080 > 1024 |
| netbird-dashboard | `allowPrivEsc=false` + `drop ALL` + `NET_BIND_SERVICE` | ✅ RuntimeDefault | Port 80 < 1024 |
| mosquitto | `allowPrivEsc=false` + `drop ALL` | ✅ RuntimeDefault | Port 1883 > 1024 |
| traefik (Helm) | `allowPrivEsc=false` + `drop ALL` + `NET_BIND_SERVICE` | ✅ RuntimeDefault | Ports 80/443/53 < 1024 |

**Skipped:** adguard-home — already had full SC with NET_BIND_SERVICE from a previous wave.

**runAsNonRoot excluded** for all: UIDs unconfirmed or known to be root.

**Kustomize build:** ✅ netbird (dev + prod), mosquitto (dev + prod), adguard-home (dev + prod) all pass  
**yamllint:** ✅ No errors (pre-existing line-length warnings only)