### PR TITLE
fix(goldification): fix firefly-iii crash + authentik liveness restart loop

### DIFF
--- a/apps/03-security/authentik/base/deployment-server.yaml
+++ b/apps/03-security/authentik/base/deployment-server.yaml
@@ -106,11 +106,17 @@ spec:
               value: "https://netbird.dev.truxonline.com,https://netbird.truxonline.com"
             - name: AUTHENTIK_BLUEPRINTS__BOOTSTRAP_AND_OVERWRITE
               value: "true"
+          startupProbe:
+            httpGet:
+              path: /api/v3/-/health/live/
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /api/v3/-/health/live/
               port: http
-            initialDelaySeconds: 60
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3
@@ -118,7 +124,6 @@ spec:
             httpGet:
               path: /api/v3/-/health/live/
               port: http
-            initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3

--- a/apps/60-services/firefly-iii/base/deployment.yaml
+++ b/apps/60-services/firefly-iii/base/deployment.yaml
@@ -107,6 +107,8 @@ spec:
             - name: TZ
               value: "Europe/Paris"
           securityContext:
+            runAsNonRoot: true
+            runAsUser: 33
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]


### PR DESCRIPTION
## Hotfixes

### firefly-iii — CreateContainerConfigError 🔴
**Root cause:** `runAsNonRoot: true` at pod level + image uses `USER www-data` (string, not numeric). Kubernetes cannot verify non-root from a string username and rejects the container.

**Fix:** Add `runAsUser: 33` to the firefly-iii container `securityContext`. With an explicit numeric UID, Kubernetes can verify 33 ≠ 0 and the pod starts normally.

### authentik-server — liveness probe 503 restart loop 🔴
**Root cause:** Authentik takes >60s to become `/api/v3/-/health/live/` healthy. With `initialDelaySeconds: 60` + `failureThreshold: 3` × `periodSeconds: 30`, the pod gets killed at ~150s before authentik is fully up.

**Fix:** Add a `startupProbe` (failureThreshold=30 × periodSeconds=10 = up to 5min for startup). Once startupProbe passes, liveness takes over with no delay. This also satisfies the Silver maturity level requirement (`require-startup-probe` Kyverno policy).

**Kustomize build:** ✅ Both overlays pass  
**yamllint:** ✅ No errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced Authentik server health checks for more reliable startup and deployment monitoring.
  * Strengthened Firefly III security by enforcing non-root container execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->