### PR TITLE
feat(maturity): goldification wave 5 - startupProbe + fast-start (30 apps)

### DIFF
--- a/apps/03-security/authentik/base/deployment-worker.yaml
+++ b/apps/03-security/authentik/base/deployment-worker.yaml
@@ -83,6 +83,12 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 3
+          startupProbe:
+            exec:
+              command: ["ak", "healthcheck"]
+            failureThreshold: 30
+            periodSeconds: 10
+            timeoutSeconds: 10
           volumeMounts:
             - name: authentik-data
               mountPath: /var/lib/authentik

--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -168,6 +168,13 @@ spec:
               port: http
             initialDelaySeconds: 30
             periodSeconds: 15
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/10-home/mealie/base/deployment.yaml
+++ b/apps/10-home/mealie/base/deployment.yaml
@@ -111,6 +111,13 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /api/app/about
+              port: http
+            failureThreshold: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
           volumeMounts:
             - name: data
               mountPath: /app/data

--- a/apps/20-media/amule/base/deployment.yaml
+++ b/apps/20-media/amule/base/deployment.yaml
@@ -78,6 +78,11 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
+          startupProbe:
+            tcpSocket:
+              port: http
+            failureThreshold: 15
+            periodSeconds: 10
           volumeMounts:
             - name: config
               mountPath: /home/amule/.aMule

--- a/apps/20-media/birdnet-go/base/deployment.yaml
+++ b/apps/20-media/birdnet-go/base/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         vixens.io/sizing.fix-permissions: G-nano
       annotations:
         goldilocks.fairwinds.com/enabled: "true"
+        vixens.io/fast-start: "true"
         reloader.stakater.com/auto: "true"
     spec:
       priorityClassName: vixens-medium

--- a/apps/20-media/booklore/base/deployment.yaml
+++ b/apps/20-media/booklore/base/deployment.yaml
@@ -118,6 +118,29 @@ spec:
               mountPath: /books
             - name: bookdrop
               mountPath: /bookdrop
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
         - name: config-syncer
           image: rclone/rclone:1.73
           securityContext:

--- a/apps/20-media/frigate/base/deployment.yaml
+++ b/apps/20-media/frigate/base/deployment.yaml
@@ -135,6 +135,11 @@ spec:
               port: http
             initialDelaySeconds: 60
             periodSeconds: 10
+          startupProbe:
+            tcpSocket:
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
           resources:
             requests:
               cpu: 500m

--- a/apps/20-media/jellyfin/base/deployment.yaml
+++ b/apps/20-media/jellyfin/base/deployment.yaml
@@ -52,6 +52,13 @@ spec:
             periodSeconds: 15
             timeoutSeconds: 3
             failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/20-media/jellyseerr/base/deployment.yaml
+++ b/apps/20-media/jellyseerr/base/deployment.yaml
@@ -52,6 +52,13 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /api/v1/status
+              port: http
+            failureThreshold: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
           volumeMounts:
             - name: config
               mountPath: /app/config

--- a/apps/20-media/lazylibrarian/base/deployment.yaml
+++ b/apps/20-media/lazylibrarian/base/deployment.yaml
@@ -125,6 +125,13 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/20-media/lidarr/base/deployment.yaml
+++ b/apps/20-media/lidarr/base/deployment.yaml
@@ -107,6 +107,13 @@ spec:
               port: http
             initialDelaySeconds: 15
             periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /ping
+              port: http
+            failureThreshold: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
           env:
             - name: LIDARR__API_KEY
               valueFrom:

--- a/apps/20-media/music-assistant/base/deployment.yaml
+++ b/apps/20-media/music-assistant/base/deployment.yaml
@@ -52,6 +52,29 @@ spec:
               mountPath: /data
             - name: media
               mountPath: /media
+          livenessProbe:
+            httpGet:
+              path: /
+              port: web
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: web
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: web
+            failureThreshold: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
       volumes:
         - name: config
           persistentVolumeClaim:

--- a/apps/20-media/mylar/base/deployment.yaml
+++ b/apps/20-media/mylar/base/deployment.yaml
@@ -107,6 +107,13 @@ spec:
               port: http
             initialDelaySeconds: 60
             periodSeconds: 20
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
           env:
             - name: PUID
               value: "1000"

--- a/apps/20-media/prowlarr/base/deployment.yaml
+++ b/apps/20-media/prowlarr/base/deployment.yaml
@@ -103,6 +103,13 @@ spec:
               port: http
             initialDelaySeconds: 15
             periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /ping
+              port: http
+            failureThreshold: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
           env:
             - name: PROWLARR__API_KEY
               valueFrom:

--- a/apps/20-media/pyload/base/deployment.yaml
+++ b/apps/20-media/pyload/base/deployment.yaml
@@ -60,6 +60,13 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/20-media/qbittorrent/base/deployment.yaml
+++ b/apps/20-media/qbittorrent/base/deployment.yaml
@@ -73,6 +73,13 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/20-media/radarr/base/deployment.yaml
+++ b/apps/20-media/radarr/base/deployment.yaml
@@ -91,6 +91,13 @@ spec:
               port: http
             initialDelaySeconds: 15
             periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /ping
+              port: http
+            failureThreshold: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
           env:
             - name: RADARR__API_KEY
               valueFrom:

--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -84,6 +84,13 @@ spec:
               port: http
             initialDelaySeconds: 15
             periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
           env:
             - name: PUID
               value: "1000"

--- a/apps/20-media/sonarr/base/deployment.yaml
+++ b/apps/20-media/sonarr/base/deployment.yaml
@@ -103,6 +103,13 @@ spec:
               port: http
             initialDelaySeconds: 15
             periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /ping
+              port: http
+            failureThreshold: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
           env:
             - name: SONARR__API_KEY
               valueFrom:

--- a/apps/20-media/whisparr/base/deployment.yaml
+++ b/apps/20-media/whisparr/base/deployment.yaml
@@ -90,6 +90,13 @@ spec:
               port: 6969
             initialDelaySeconds: 60
             periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /ping
+              port: 6969
+            failureThreshold: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
           env:
             - name: WHISPARR__API_KEY
               valueFrom:

--- a/apps/40-network/adguard-home/base/adguard-ss.yaml
+++ b/apps/40-network/adguard-home/base/adguard-ss.yaml
@@ -29,6 +29,7 @@ spec:
         vixens.io/sizing.config-syncer: V-nano
         vixens.io/backup-profile: "relaxed"
       annotations:
+        vixens.io/fast-start: "true"
         reloader.stakater.com/auto: "true"
         prometheus.io/scrape: "true"
         prometheus.io/port: "9090"

--- a/apps/60-services/docspell/base/statefulset-restserver.yaml
+++ b/apps/60-services/docspell/base/statefulset-restserver.yaml
@@ -69,6 +69,13 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /api/info/version
+              port: api
+            failureThreshold: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
           volumeMounts:
             - name: config
               mountPath: /opt/docspell.conf

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -368,6 +368,17 @@ spec:
               port: 18789
             initialDelaySeconds: 120
             periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: 18789
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+          startupProbe:
+            tcpSocket:
+              port: 18789
+            failureThreshold: 30
+            periodSeconds: 10
           volumeMounts:
             - name: data
               mountPath: /data

--- a/apps/60-services/vaultwarden/base/deployment.yaml
+++ b/apps/60-services/vaultwarden/base/deployment.yaml
@@ -93,6 +93,13 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /alive
+              port: http
+            failureThreshold: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
           volumeMounts:
             - name: data
               mountPath: /data

--- a/apps/70-tools/changedetection/base/deployment.yaml
+++ b/apps/70-tools/changedetection/base/deployment.yaml
@@ -66,6 +66,29 @@ spec:
           volumeMounts:
             - name: datastore
               mountPath: /datastore
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
         - name: browserless
           image: browserless/chrome:1.61.1-puppeteer-16.2.0
           ports:

--- a/apps/70-tools/homepage/base/deployment.yaml
+++ b/apps/70-tools/homepage/base/deployment.yaml
@@ -78,6 +78,13 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
           volumeMounts:
             # Mount the writable PVC, which is now populated by the
             # initContainer.

--- a/apps/70-tools/linkwarden/base/deployment.yaml
+++ b/apps/70-tools/linkwarden/base/deployment.yaml
@@ -78,6 +78,13 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 3
             failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
       volumes:
         - name: data
           persistentVolumeClaim:

--- a/apps/70-tools/nocodb/base/deployment.yaml
+++ b/apps/70-tools/nocodb/base/deployment.yaml
@@ -78,6 +78,13 @@ spec:
               port: http
             initialDelaySeconds: 30
             periodSeconds: 20
+          startupProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http
+            failureThreshold: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
       volumes:
         - name: data
           persistentVolumeClaim:

--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -72,6 +72,13 @@ spec:
             initialDelaySeconds: 120
             periodSeconds: 30
             failureThreshold: 5
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            failureThreshold: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/apps/70-tools/penpot/base/deployment-exporter.yaml
+++ b/apps/70-tools/penpot/base/deployment-exporter.yaml
@@ -60,6 +60,11 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 30
             failureThreshold: 3
+          startupProbe:
+            tcpSocket:
+              port: http
+            failureThreshold: 20
+            periodSeconds: 10
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/apps/70-tools/vikunja/base/deployment.yaml
+++ b/apps/70-tools/vikunja/base/deployment.yaml
@@ -90,6 +90,13 @@ spec:
               port: http
             initialDelaySeconds: 30
             periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /api/v1/info
+              port: http
+            failureThreshold: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
       volumes:
         - name: vikunja-files
           persistentVolumeClaim:

--- a/apps/99-test/whoami/base/deployment.yaml
+++ b/apps/99-test/whoami/base/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         vixens.io/sizing.whoami: "V-nano"
       annotations:
         vixens.io/nometrics: "true"
+        vixens.io/fast-start: "true"
         goldilocks.fairwinds.com/enabled: "true"
         autoscaling.k8s.io/vpa: "true"
     spec:


### PR DESCRIPTION
## Summary

Wave 5 of the goldification process — unblocking **bronze → silver** for ~30 apps by adding `startupProbe` (or `vixens.io/fast-start: \"true\"`) to all apps that had liveness + readiness probes but no startup probe.

Silver tier requires all three probes (or `fast-start` annotation).

## Changes

### fast-start annotation (Go/instant apps)
- `adguard-home` — Go binary, starts in <5s
- `birdnet-go` — Go binary
- `whoami` — Go, instant

### startupProbe added (*arr apps, failureThreshold=15 = 150s max)
- `sonarr`, `radarr`, `prowlarr`, `lidarr` — httpGet /ping
- `whisparr` — httpGet /ping port 6969 (FT=20)

### startupProbe added (media apps)
- `jellyfin` — httpGet /health (FT=30 = 300s, slow startup)
- `jellyseerr` — httpGet /api/v1/status
- `sabnzbd`, `pyload`, `qbittorrent`, `lazylibrarian` — httpGet /
- `mylar` — httpGet / (FT=20)
- `amule` — tcpSocket port http

### startupProbe added (service/tool apps)
- `vaultwarden` — httpGet /alive
- `homeassistant` — httpGet / (FT=30 = 300s, very slow)
- `mealie` — httpGet /api/app/about
- `frigate` — tcpSocket http (FT=30, privileged container)
- `homepage`, `linkwarden` — httpGet /
- `nocodb` — httpGet /api/v1/health
- `vikunja` — httpGet /api/v1/info
- `penpot-backend` — httpGet /readyz (FT=20)
- `penpot-exporter` — tcpSocket http (FT=20)
- `docspell-restserver` — httpGet /api/info/version (FT=20)
- `changedetection` — httpGet / + added liveness/readiness (missing)
- `booklore` — httpGet / + added liveness/readiness (missing)
- `music-assistant` — httpGet / port web + added liveness/readiness (missing)

### Complex cases
- `authentik-worker` — exec `ak healthcheck` (FT=30 = 300s)
- `openclaw` — tcpSocket 18789 + added readinessProbe (FT=30)

## Validation
- All 32 files pass `yamllint` with zero errors
- No changes to init containers or sidecar containers (litestream, config-syncer, etc.)