### PR TITLE
fix(media): fix sonarr/radarr/prowlarr CrashLoopBackOff - override runAsNonRoot for linuxserver s6-overlay

### DIFF
--- a/apps/20-media/prowlarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/prowlarr/overlays/prod/kustomization.yaml
@@ -30,3 +30,4 @@ patches:
         path: /spec/authentication/universalAuth/secretsScope/envSlug
         value: prod
   - path: resources-patch.yaml
+  - path: securitycontext-patch.yaml

--- a/apps/20-media/prowlarr/overlays/prod/securitycontext-patch.yaml
+++ b/apps/20-media/prowlarr/overlays/prod/securitycontext-patch.yaml
@@ -1,0 +1,16 @@
+---
+# Override _shared/components/base securityContext for s6-overlay images.
+# linuxserver images need to start as root (s6-overlay runs usermod before dropping to PUID).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prowlarr
+  namespace: media
+spec:
+  template:
+    spec:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: false
+        runAsUser: 0

--- a/apps/20-media/radarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/radarr/overlays/prod/kustomization.yaml
@@ -29,3 +29,4 @@ patches:
       - op: replace
         path: /spec/authentication/universalAuth/secretsScope/envSlug
         value: prod
+  - path: securitycontext-patch.yaml

--- a/apps/20-media/radarr/overlays/prod/securitycontext-patch.yaml
+++ b/apps/20-media/radarr/overlays/prod/securitycontext-patch.yaml
@@ -1,0 +1,16 @@
+---
+# Override _shared/components/base securityContext for s6-overlay images.
+# linuxserver images need to start as root (s6-overlay runs usermod before dropping to PUID).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: radarr
+  namespace: media
+spec:
+  template:
+    spec:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: false
+        runAsUser: 0

--- a/apps/20-media/sonarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/sonarr/overlays/prod/kustomization.yaml
@@ -26,3 +26,4 @@ patches:
       kind: Deployment
       name: sonarr
     path: resources-patch.yaml
+  - path: securitycontext-patch.yaml

--- a/apps/20-media/sonarr/overlays/prod/securitycontext-patch.yaml
+++ b/apps/20-media/sonarr/overlays/prod/securitycontext-patch.yaml
@@ -1,0 +1,16 @@
+---
+# Override _shared/components/base securityContext for s6-overlay images.
+# linuxserver images need to start as root (s6-overlay runs usermod before dropping to PUID).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sonarr
+  namespace: media
+spec:
+  template:
+    spec:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: false
+        runAsUser: 0


### PR DESCRIPTION
## Problem

sonarr, radarr, and prowlarr are in CrashLoopBackOff since wave 5 (PR #1819) with:
\`\`\`
/package/admin/s6-overlay/libexec/preinit: fatal: wrong permissions on /run for a gid 0 setup
s6-overlay-suexec: fatal: child failed with exit code 100
\`\`\`

## Root Cause

\`apps/_shared/components/base\` sets \`runAsNonRoot: true\` + \`runAsUser: 1000\` at pod level.
linuxserver images require PID1 to run as root — s6-overlay does \`usermod\` before switching to PUID.
These apps restarted after wave 5 and picked up the shared component's securityContext.

## Fix

Add \`securitycontext-patch.yaml\` in prod overlays to override to \`runAsNonRoot: false\` + \`runAsUser: 0\`.

This is exactly the pattern already used by lidarr, whisparr, and mylar.

## Impact

- sonarr, radarr, prowlarr: CrashLoopBackOff → Running
- No change to dev/staging overlays

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Applied security context configuration updates to Prowlarr, Radarr, and Sonarr deployments to optimize permission handling and ensure proper application startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->