### PR TITLE
fix(media): add SETGID+SETUID caps for linuxserver s6-overlay (7 apps)

### DIFF
--- a/apps/20-media/lidarr/base/deployment.yaml
+++ b/apps/20-media/lidarr/base/deployment.yaml
@@ -95,6 +95,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+              add: ["SETGID", "SETUID"]
           livenessProbe:
             httpGet:
               path: /ping

--- a/apps/20-media/mylar/base/deployment.yaml
+++ b/apps/20-media/mylar/base/deployment.yaml
@@ -95,6 +95,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+              add: ["SETGID", "SETUID"]
           livenessProbe:
             httpGet:
               path: /

--- a/apps/20-media/prowlarr/base/deployment.yaml
+++ b/apps/20-media/prowlarr/base/deployment.yaml
@@ -129,6 +129,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+              add: ["SETGID", "SETUID"]
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/20-media/radarr/base/deployment.yaml
+++ b/apps/20-media/radarr/base/deployment.yaml
@@ -117,6 +117,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+              add: ["SETGID", "SETUID"]
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -72,6 +72,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+              add: ["SETGID", "SETUID"]
           livenessProbe:
             httpGet:
               path: /

--- a/apps/20-media/sonarr/base/deployment.yaml
+++ b/apps/20-media/sonarr/base/deployment.yaml
@@ -129,6 +129,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+              add: ["SETGID", "SETUID"]
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/20-media/whisparr/base/deployment.yaml
+++ b/apps/20-media/whisparr/base/deployment.yaml
@@ -78,6 +78,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+              add: ["SETGID", "SETUID"]
           livenessProbe:
             httpGet:
               path: /ping


### PR DESCRIPTION
## Problem

All 7 linuxserver-based apps crash with:
\`\`\`
s6-applyuidgid: fatal: unable to set supplementary group list: Operation not permitted
\`\`\`

## Root Cause

The wave 3 goldification added \`capabilities: drop: ALL\` to container securityContext.
s6-overlay v3 (used by all \`ghcr.io/linuxserver/*\` images) calls \`s6-applyuidgid\` to switch
from root (PID1) to the configured PUID/PGID. This requires:
- \`CAP_SETGID\` — needed for \`setgroups()\` to clear supplementary groups
- \`CAP_SETUID\` — needed for \`setuid()\` to drop to PUID

Both were removed by \`drop: ALL\`.

## Fix

Add \`capabilities: add: [SETGID, SETUID]\` alongside the existing \`drop: ALL\` for the
main container of each affected linuxserver app.

This is a standard pattern for rootless-ish containers that drop privileges at startup.

## Affected Apps

sonarr, radarr, prowlarr, lidarr, mylar, sabnzbd, whisparr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container security configurations for media services (Lidarr, Mylar, Prowlarr, Radarr, SABnzbd, Sonarr, and Whisparr).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->