### PR TITLE
fix(maturity): accept secrets.infisical.com/version annotation in Silver Infisical check

### DIFF
--- a/apps/00-infra/kyverno/base/policies/check-infisical-secrets.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-infisical-secrets.yaml
@@ -32,7 +32,7 @@ spec:
               - name: secret_data
                 apiCall:
                   urlPath: "/api/v1/namespaces/{{request.namespace}}/secrets/{{element.name}}"
-                  jmesPath: "metadata.annotations.\"infisical.com/managed\" || metadata.labels.\"app.kubernetes.io/managed-by\" == 'infisical-operator' || 'false'"
+                  jmesPath: "metadata.annotations.\"infisical.com/managed\" || metadata.labels.\"app.kubernetes.io/managed-by\" == 'infisical-operator' || metadata.annotations.\"secrets.infisical.com/version\" || 'false'"
             deny:
               conditions:
                 all:


### PR DESCRIPTION
## Problem

\`check-infisical-secrets\` (Maturity Silver) was blocking all apps from reaching Silver tier.

The policy jmesPath checked for:
- \`metadata.annotations."infisical.com/managed"\`
- \`metadata.labels."app.kubernetes.io/managed-by" == 'infisical-operator'\`

But the actual Infisical operator sets:
- \`metadata.annotations."secrets.infisical.com/version"\`

All secrets correctly managed by Infisical were failing this Silver check.

## Fix

Add \`|| metadata.annotations."secrets.infisical.com/version"\` to the jmesPath.

## Impact

All apps using Infisical-managed secrets (virtually all apps) can now reach Silver tier once the maturity-controller CronJob runs.