### PR TITLE
fix(maturity): add secret read RBAC to kyverno admission controller

### DIFF
--- a/argocd/overlays/prod/apps/kyverno.yaml
+++ b/argocd/overlays/prod/apps/kyverno.yaml
@@ -34,6 +34,12 @@ spec:
               limits:
                 cpu: "1"
                 memory: 1Gi
+            rbac:
+              clusterRole:
+                extraResources:
+                  - apiGroups: [""]
+                    resources: ["secrets"]
+                    verbs: ["get"]
 
           backgroundController:
             replicas: 1


### PR DESCRIPTION
## Problem

The \`check-infisical-secrets\` Silver policy makes an APICall to \`GET /api/v1/namespaces/{ns}/secrets/{name}\` to verify if a secret is managed by Infisical.

The Kyverno admission controller lacks \`get\` permission on \`secrets\`, causing the policy to return \`error\` for every pod admission evaluation — even for pods that correctly use Infisical secrets.

**Error message:**
\`\`\`
failed to fetch data for APICall: failed to GET resource:
/api/v1/namespaces/media/secrets/sonarr-secrets: unknown
\`\`\`

## Fix

Add \`secrets: get\` to \`admissionController.rbac.clusterRole.extraResources\` in the Kyverno Helm values. This follows the same pattern already used for \`cleanupController\`.

## Expected Outcome

After Kyverno helm chart re-applies, the admission controller can GET secrets during policy evaluation. New pods will generate passing \`check-infisical-secrets\` reports if their secrets are Infisical-managed, unblocking Silver tier for ~30+ apps.

## Security Note

Read-only (\`get\`) access to secrets is the minimum required. Kyverno is already a highly trusted component in the cluster. The policy only reads secrets to check their labels/annotations.