### PR TITLE
fix(maturity): add kyverno admission controller ClusterRole for secrets

### DIFF
--- a/apps/00-infra/kyverno/base/policies/rbac-secrets.yaml
+++ b/apps/00-infra/kyverno/base/policies/rbac-secrets.yaml
@@ -1,0 +1,24 @@
+---
+# Grant Kyverno admission controller read access to secrets
+# Required for check-infisical-secrets policy APICall evaluation
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:admission-controller:secrets
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kyverno:admission-controller:secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kyverno:admission-controller:secrets
+subjects:
+  - kind: ServiceAccount
+    name: kyverno-admission-controller
+    namespace: kyverno


### PR DESCRIPTION
## Problem

`check-infisical-secrets` Silver policy makes an APICall to read secrets during pod admission. The admission controller lacks `get` permission on `secrets`, causing every policy evaluation to error.

## Fix

Standalone `ClusterRole` + `ClusterRoleBinding` that grants `kyverno-admission-controller` service account read (`get`) access to secrets.

**Already applied manually to cluster** — this PR persists it in git so ArgoCD manages the lifecycle.

## Expected Outcome

After ArgoCD syncs kyverno policies, the admission controller can properly evaluate `check-infisical-secrets`. New pods with Infisical-managed secrets will generate passing reports, unblocking Silver tier.