### PR TITLE
fix(traefik): move podAnnotations under deployment.podAnnotations

### DIFF
--- a/apps/00-infra/traefik/values/common.yaml
+++ b/apps/00-infra/traefik/values/common.yaml
@@ -118,5 +118,6 @@ securityContext:
 # ============================================================================
 # Fast-start bypass (traefik starts in < 10s)
 # ============================================================================
-podAnnotations:
-  vixens.io/fast-start: "true"
+deployment:
+  podAnnotations:
+    vixens.io/fast-start: "true"


### PR DESCRIPTION
## Problem

In wave 7, `vixens.io/fast-start: "true"` was added at the top-level `podAnnotations` key in `values/common.yaml`. However, Traefik v25 Helm chart requires pod annotations to be nested under `deployment.podAnnotations` — the top-level key has no effect.

## Fix

Move the annotation to the correct location:

```yaml
# Before (broken)
podAnnotations:
  vixens.io/fast-start: "true"

# After (correct)
deployment:
  podAnnotations:
    vixens.io/fast-start: "true"
```

The `prod.yaml` already has a `deployment:` block with `replicas: 2` and `podLabels` — Helm merges these YAML keys correctly, so no conflict.

## Impact

- Traefik pods will get `vixens.io/fast-start: "true"` after rollout
- `check-startup-probe` policy will pass for Traefik
- Traefik should reach Silver tier