### PR TITLE
feat(maturity): fast-start wave 9 — goldilocks, mosquitto, velero, infisical-operator

### DIFF
--- a/apps/00-infra/velero/values/common.yaml
+++ b/apps/00-infra/velero/values/common.yaml
@@ -83,6 +83,9 @@ kubectl:
       cpu: 100m
       memory: 256Mi
 
+podAnnotations:
+  vixens.io/fast-start: "true"
+
 resources:
   requests:
     cpu: 100m
@@ -96,6 +99,8 @@ deployNodeAgent: true
 nodeAgent:
   uploaderType: kopia
   priorityClassName: vixens-critical
+  podAnnotations:
+    vixens.io/fast-start: "true"
   tolerations:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists

--- a/apps/02-monitoring/goldilocks/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/goldilocks/overlays/prod/kustomization.yaml
@@ -18,6 +18,18 @@ patches:
     target:
       kind: Deployment
       name: goldilocks-dashboard
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: placeholder
+      spec:
+        template:
+          metadata:
+            annotations:
+              vixens.io/fast-start: "true"
+    target:
+      kind: Deployment
 resources:
   - ingress.yaml
   - ../../base

--- a/apps/10-home/mosquitto/base/statefulset.yaml
+++ b/apps/10-home/mosquitto/base/statefulset.yaml
@@ -25,6 +25,8 @@ spec:
         vixens.io/sizing.create-mosquitto-users: G-nano
         vixens.io/sizing.mosquitto: V-small
         vixens.io/sizing.config-syncer: V-nano
+      annotations:
+        vixens.io/fast-start: "true"
     spec:
       initContainers:
         - name: restore-data

--- a/argocd/overlays/prod/apps/infisical-operator.yaml
+++ b/argocd/overlays/prod/apps/infisical-operator.yaml
@@ -46,6 +46,7 @@ spec:
               operator: Exists
               effect: NoSchedule
           podAnnotations:
+            vixens.io/fast-start: "true"
             vixens.io/service-binding: "false"
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
## Summary

Applies `vixens.io/fast-start: "true"` to remaining apps with `check-startup-probe` failures blocking Silver tier.

| App | Change | Rationale |
|---|---|---|
| goldilocks-controller/dashboard | Kustomize patch (Helm podAnnotations not propagated by chart) | Goldilocks starts in <2s |
| mosquitto | StatefulSet pod template annotations | Eclipse Mosquitto starts in <1s |
| velero | `podAnnotations` + `nodeAgent.podAnnotations` Helm values | Velero starts in <5s |
| infisical-operator | `controllerManager.podAnnotations` (fast-start + service-binding bypass) | Operator starts in <3s |

## Dependency

Follows wave 8 (PR #1833) which added `service-binding` bypass. This wave completes the Bronze → Silver unlock for these apps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configurations for Velero, Goldilocks, Mosquitto, and Infisical Operator deployments with optimization annotations across infrastructure services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->