### PR TITLE
fix(goldilocks): use correct Helm key controller.deployment.podAnnotations

### DIFF
--- a/apps/02-monitoring/goldilocks/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/goldilocks/overlays/prod/kustomization.yaml
@@ -18,18 +18,6 @@ patches:
     target:
       kind: Deployment
       name: goldilocks-dashboard
-  - patch: |
-      apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        name: placeholder
-      spec:
-        template:
-          metadata:
-            annotations:
-              vixens.io/fast-start: "true"
-    target:
-      kind: Deployment
 resources:
   - ingress.yaml
   - ../../base

--- a/apps/02-monitoring/goldilocks/values/common.yaml
+++ b/apps/02-monitoring/goldilocks/values/common.yaml
@@ -16,8 +16,9 @@ controller:
     readOnlyRootFilesystem: true
   podLabels:
     vixens.io/sizing.goldilocks-controller: G-nano
-  podAnnotations:
-    vixens.io/fast-start: "true"
+  deployment:
+    podAnnotations:
+      vixens.io/fast-start: "true"
 
 dashboard:
   tolerations:
@@ -36,5 +37,6 @@ dashboard:
     readOnlyRootFilesystem: true
   podLabels:
     vixens.io/sizing.goldilocks-dashboard: V-small
-  podAnnotations:
-    vixens.io/fast-start: "true"
+  deployment:
+    podAnnotations:
+      vixens.io/fast-start: "true"


### PR DESCRIPTION
Fix: goldilocks chart requires `controller.deployment.podAnnotations` (not `controller.podAnnotations`). Both controller and dashboard fixed. Also removes the ineffective Kustomize patch approach added in wave 9.