### PR TITLE
feat(maturity): wave 10 — fix missing service-binding annotations

### DIFF
--- a/apps/00-infra/cert-manager-webhook-gandi/values/common.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/values/common.yaml
@@ -19,3 +19,6 @@ tolerations:
 # Pod sizing labels
 podLabels:
   vixens.io/sizing.cert-manager-webhook-gandi: G-nano
+podAnnotations:
+  vixens.io/fast-start: "true"
+  vixens.io/service-binding: "false"

--- a/apps/00-infra/infisical-operator/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/infisical-operator/overlays/prod/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []
+patches:
+  - patch: |-
+      - op: add
+        path: /spec/template/metadata/annotations/vixens.io~1fast-start
+        value: "true"
+      - op: add
+        path: /spec/template/metadata/annotations/vixens.io~1service-binding
+        value: "false"
+    target:
+      kind: Deployment
+      name: infisical-opera-controller-manager

--- a/apps/40-network/netvisor/base/server-deployment.yaml
+++ b/apps/40-network/netvisor/base/server-deployment.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         vixens.io/fast-start: "true"
+        vixens.io/service-binding: "false"
       labels:
         app: netvisor-server
         vixens.io/sizing.server: V-small

--- a/apps/70-tools/stirling-pdf/base/values.yaml
+++ b/apps/70-tools/stirling-pdf/base/values.yaml
@@ -53,3 +53,4 @@ podLabels:
 podAnnotations:
   # fast-start: liveness probe confirms HTTP is ready within 30s; LibreOffice loads lazily
   vixens.io/fast-start: "true"
+  vixens.io/service-binding: "false"

--- a/argocd/overlays/prod/apps/infisical-operator.yaml
+++ b/argocd/overlays/prod/apps/infisical-operator.yaml
@@ -11,43 +11,46 @@ metadata:
     app.kubernetes.io/component: secrets-management
 spec:
   project: default
-  source:
-    repoURL: https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/
-    chart: secrets-operator
-    targetRevision: 0.10.5
-    helm:
-      values: |
-        controllerManager:
-          manager:
-            image:
-              repository: infisical/kubernetes-operator
-              tag: v0.10.1
-            priorityClassName: vixens-critical
-            resources:
-              limits:
-                cpu: 500m
-                memory: 256Mi
-              requests:
-                cpu: 10m
-                memory: 64Mi
-          kubeRbacProxy:
-            image:
-              repository: gcr.io/kubebuilder/kube-rbac-proxy
-              tag: v0.13.1
-            resources:
-              limits:
-                cpu: 100m
-                memory: 64Mi
-              requests:
-                cpu: 5m
-                memory: 16Mi
-          tolerations:
-            - key: node-role.kubernetes.io/control-plane
-              operator: Exists
-              effect: NoSchedule
-          podAnnotations:
-            vixens.io/fast-start: "true"
-            vixens.io/service-binding: "false"
+  sources:
+    # Helm chart
+    - repoURL: https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/
+      chart: secrets-operator
+      targetRevision: 0.10.5
+      helm:
+        values: |
+          controllerManager:
+            manager:
+              image:
+                repository: infisical/kubernetes-operator
+                tag: v0.10.1
+              priorityClassName: vixens-critical
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 256Mi
+                requests:
+                  cpu: 10m
+                  memory: 64Mi
+            kubeRbacProxy:
+              image:
+                repository: gcr.io/kubebuilder/kube-rbac-proxy
+                tag: v0.13.1
+              resources:
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+                requests:
+                  cpu: 5m
+                  memory: 16Mi
+            tolerations:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+                effect: NoSchedule
+    # Kustomize overlay for pod annotations (chart has no podAnnotations support)
+    - repoURL: https://github.com/charchess/vixens.git
+      targetRevision: prod-stable
+      path: apps/00-infra/infisical-operator/overlays/prod
+      kustomize: {}
   destination:
     server: https://kubernetes.default.svc
     namespace: infisical-operator-system


### PR DESCRIPTION
## Summary

- **cert-manager-webhook-gandi**: Add `vixens.io/fast-start: true` and `vixens.io/service-binding: false` to `podAnnotations` in `values/common.yaml` (was only restartedAt annotation in pods)
- **stirling-pdf**: Add `vixens.io/service-binding: false` to existing `podAnnotations` in `base/values.yaml`
- **netvisor-server**: Add `vixens.io/service-binding: false` to pod template annotations in base manifest
- **infisical-operator**: Convert from single-source Helm to multi-source (Helm + Kustomize). The `secrets-operator` Helm chart does not support `podAnnotations` at all, so a Kustomize overlay patches the Deployment with `vixens.io/fast-start: true` and `vixens.io/service-binding: false`. The invalid `controllerManager.podAnnotations` Helm value is removed.

## Context

Part of the ongoing goldification / maturity tier progression. These apps are currently stuck at `none` tier because their pods lack the required `vixens.io/service-binding: false` annotation for `check-service-binding` Bronze policy.