### PR TITLE
fix(cert-manager-webhook-gandi): add pod annotations via Kustomize patch

### DIFF
--- a/apps/00-infra/cert-manager-webhook-gandi/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/overlays/prod/kustomization.yaml
@@ -7,5 +7,15 @@ patches:
     target:
       kind: InfisicalSecret
       name: gandi-credentials-sync
+  - patch: |-
+      - op: add
+        path: /spec/template/metadata/annotations/vixens.io~1fast-start
+        value: "true"
+      - op: add
+        path: /spec/template/metadata/annotations/vixens.io~1service-binding
+        value: "false"
+    target:
+      kind: Deployment
+      name: cert-manager-webhook-gandi
 resources:
   - ../../base

--- a/apps/00-infra/cert-manager-webhook-gandi/values/common.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/values/common.yaml
@@ -19,6 +19,4 @@ tolerations:
 # Pod sizing labels
 podLabels:
   vixens.io/sizing.cert-manager-webhook-gandi: G-nano
-podAnnotations:
-  vixens.io/fast-start: "true"
-  vixens.io/service-binding: "false"
+# podAnnotations not supported by this chart - handled via Kustomize overlay

--- a/argocd/overlays/prod/apps/cert-manager-webhook-gandi.yaml
+++ b/argocd/overlays/prod/apps/cert-manager-webhook-gandi.yaml
@@ -29,6 +29,11 @@ spec:
     - repoURL: https://github.com/charchess/vixens.git
       targetRevision: prod-stable
       ref: values
+    # Kustomize overlay for pod annotations (chart has no podAnnotations support)
+    - repoURL: https://github.com/charchess/vixens.git
+      targetRevision: prod-stable
+      path: apps/00-infra/cert-manager-webhook-gandi/overlays/prod
+      kustomize: {}
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Summary

The `cert-manager-webhook-gandi` Helm chart does not support `podAnnotations` in its values, similar to `infisical-operator`. The annotations added to `values/common.yaml` in wave 10 were silently ignored.

## Fix

- Add a JSON6902 Kustomize patch to `overlays/prod/kustomization.yaml` to inject `vixens.io/fast-start: "true"` and `vixens.io/service-binding: "false"` into the pod template
- Add the Kustomize overlay as a third source in the ArgoCD Application
- Remove the unsupported `podAnnotations` from `values/common.yaml` (replaced with a comment)