### PR TITLE
fix(kyverno): check-service-binding — correct behavior for pods without app label

### DIFF
--- a/apps/00-infra/kyverno/base/policies/check-service-binding.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-service-binding.yaml
@@ -31,19 +31,20 @@ spec:
           - resources:
               annotations:
                 vixens.io/service-binding: "false"
-      preconditions:
-        all:
-          # Skip if pod has no 'app' label (prevents JMESPath Unknown key error in background scan)
-          - key: "{{ request.object.metadata.labels.app || '' }}"
-            operator: NotEquals
-            value: ""
       context:
+        # Safely read app label — returns '' if absent, avoiding JMESPath errors
+        - name: app_label
+          variable:
+            jmesPath: "request.object.metadata.labels.app || ''"
         - name: service_count
           apiCall:
             urlPath: "/api/v1/namespaces/{{request.namespace}}/services"
-            jmesPath: "items[?spec.selector.app == '{{request.object.metadata.labels.app}}'] | length(@)"
+            jmesPath: "items[?spec.selector.app == '{{app_label}}'] | length(@)"
       validate:
-        message: "No Service found targeting app={{request.object.metadata.labels.app}} in namespace {{request.namespace}}."
+        message: >-
+          No Service found targeting app={{app_label}} in namespace
+          {{request.namespace}}. Add vixens.io/service-binding: 'false'
+          to bypass (controllers/workers/daemons that don't receive traffic).
         deny:
           conditions:
             all:


### PR DESCRIPTION
## Problème avec le fix précédent (PR #1839)

La précondition `app label NotEquals ''` était **non conforme** : elle excluait silencieusement tous les pods sans label `app` de la vérification, sans qu'ils aient besoin de poser l'annotation bypass. C'était un angle mort.

## Comportement correct

| Cas | Résultat attendu |
|-----|-----------------|
| Pas de label `app`, pas d'annotation bypass | **FAIL** — doit ajouter le label ou poser le bypass |
| Label `app` + Service matching | **PASS** |
| Annotation `vixens.io/service-binding: false` (avec ou sans label `app`) | **SKIP** — bypass explicite |

## Implémentation

Introduire une variable de contexte `app_label` avec fallback `|| ''` pour éviter l'erreur JMESPath `Unknown key "app"` en background scan, **tout en continuant à évaluer la règle** :

- `app_label = ''` → l'API call cherche des Services avec `selector.app == ''` → `service_count = 0` → **FAIL** (comportement voulu)
- La précondition qui skippait est supprimée
- L'`exclude.resources.annotations` reste le seul mécanisme de bypass

## Impact

Les pods ArgoCD, infisical-operator, etc. qui n'ont pas de label `app` auront maintenant un FAIL Bronze jusqu'à ce qu'on leur pose explicitement `vixens.io/service-binding: "false"` — ce qui est déjà le cas pour la plupart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service binding policy to gracefully handle pods without app labels through fallback behavior.

* **Documentation**
  * Updated validation message with clearer guidance on bypassing the policy check using the appropriate annotation when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->