### PR TITLE
feat(maturity): wave 12 — silver→gold metrics for argocd, kyverno, cert-manager, authentik, external-dns

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/argocd/overlays/prod/kustomization.yaml
@@ -78,5 +78,109 @@ patches:
     target:
       kind: StatefulSet
 
+  # Prometheus metrics annotations — each ArgoCD component exposes metrics on a dedicated port
+  - patch: |
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: argocd-application-controller
+      spec:
+        template:
+          metadata:
+            annotations:
+              prometheus.io/scrape: "true"
+              prometheus.io/port: "8082"
+              prometheus.io/path: "/metrics"
+    target:
+      kind: StatefulSet
+      name: argocd-application-controller
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: argocd-applicationset-controller
+      spec:
+        template:
+          metadata:
+            annotations:
+              prometheus.io/scrape: "true"
+              prometheus.io/port: "8080"
+              prometheus.io/path: "/metrics"
+    target:
+      kind: Deployment
+      name: argocd-applicationset-controller
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: argocd-dex-server
+      spec:
+        template:
+          metadata:
+            annotations:
+              prometheus.io/scrape: "true"
+              prometheus.io/port: "5558"
+              prometheus.io/path: "/metrics"
+    target:
+      kind: Deployment
+      name: argocd-dex-server
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: argocd-notifications-controller
+      spec:
+        template:
+          metadata:
+            annotations:
+              prometheus.io/scrape: "true"
+              prometheus.io/port: "9001"
+              prometheus.io/path: "/metrics"
+    target:
+      kind: Deployment
+      name: argocd-notifications-controller
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: argocd-repo-server
+      spec:
+        template:
+          metadata:
+            annotations:
+              prometheus.io/scrape: "true"
+              prometheus.io/port: "8084"
+              prometheus.io/path: "/metrics"
+    target:
+      kind: Deployment
+      name: argocd-repo-server
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: argocd-server
+      spec:
+        template:
+          metadata:
+            annotations:
+              prometheus.io/scrape: "true"
+              prometheus.io/port: "8083"
+              prometheus.io/path: "/metrics"
+    target:
+      kind: Deployment
+      name: argocd-server
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: argocd-redis
+      spec:
+        template:
+          metadata:
+            annotations:
+              vixens.io/nometrics: "true"
+    target:
+      kind: Deployment
+      name: argocd-redis
 components:
   - ../../../../_shared/components/revision-history-limit

--- a/apps/00-infra/cert-manager/values/common.yaml
+++ b/apps/00-infra/cert-manager/values/common.yaml
@@ -29,6 +29,9 @@ podLabels:
 podAnnotations:
   vixens.io/fast-start: "true"
   vixens.io/service-binding: "false"
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "9402"
+  prometheus.io/path: "/metrics"
 # Webhook component
 webhook:
   tolerations:
@@ -40,6 +43,7 @@ webhook:
   podAnnotations:
     vixens.io/fast-start: "true"
     vixens.io/service-binding: "false"
+    vixens.io/nometrics: "true"  # cert-manager webhook has no Prometheus metrics endpoint
 # CA Injector component
 cainjector:
   tolerations:
@@ -51,6 +55,7 @@ cainjector:
   podAnnotations:
     vixens.io/fast-start: "true"
     vixens.io/service-binding: "false"
+    vixens.io/nometrics: "true"  # cainjector has no Prometheus metrics endpoint
 # Startup API check tolerations
 startupapicheck:
   tolerations:

--- a/apps/03-security/authentik/base/deployment-server.yaml
+++ b/apps/03-security/authentik/base/deployment-server.yaml
@@ -21,6 +21,9 @@ spec:
       annotations:
         reloader.stakater.com/auto: "true"
         vixens.io/fast-start: "true"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9300"
+        prometheus.io/path: "/metrics"
     spec:
       priorityClassName: vixens-critical
       tolerations:

--- a/apps/03-security/authentik/base/deployment-worker.yaml
+++ b/apps/03-security/authentik/base/deployment-worker.yaml
@@ -22,6 +22,7 @@ spec:
       annotations:
         reloader.stakater.com/auto: "true"
         vixens.io/service-binding: "false"
+        vixens.io/nometrics: "true"  # authentik-worker has no Prometheus metrics endpoint
     spec:
       priorityClassName: vixens-critical
       containers:

--- a/apps/40-network/external-dns-gandi/values/prod.yaml
+++ b/apps/40-network/external-dns-gandi/values/prod.yaml
@@ -36,3 +36,6 @@ podLabels:
 podAnnotations:
   vixens.io/fast-start: "true"
   vixens.io/service-binding: "false"
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "7979"
+  prometheus.io/path: "/metrics"

--- a/apps/40-network/external-dns-unifi/values/prod.yaml
+++ b/apps/40-network/external-dns-unifi/values/prod.yaml
@@ -14,3 +14,6 @@ resources:
 podAnnotations:
   vixens.io/fast-start: "true"
   vixens.io/service-binding: "false"
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "7979"
+  prometheus.io/path: "/metrics"

--- a/argocd/overlays/prod/apps/kyverno.yaml
+++ b/argocd/overlays/prod/apps/kyverno.yaml
@@ -34,6 +34,10 @@ spec:
               limits:
                 cpu: "1"
                 memory: 1Gi
+            podAnnotations:
+              prometheus.io/scrape: "true"
+              prometheus.io/port: "8000"
+              prometheus.io/path: "/metrics"
             rbac:
               clusterRole:
                 extraResources:
@@ -54,6 +58,10 @@ spec:
               limits:
                 cpu: 200m
                 memory: 256Mi
+            podAnnotations:
+              prometheus.io/scrape: "true"
+              prometheus.io/port: "8000"
+              prometheus.io/path: "/metrics"
 
           cleanupController:
             replicas: 1
@@ -77,6 +85,10 @@ spec:
               limits:
                 cpu: 200m
                 memory: 256Mi
+            podAnnotations:
+              prometheus.io/scrape: "true"
+              prometheus.io/port: "8000"
+              prometheus.io/path: "/metrics"
 
           reportsController:
             replicas: 1
@@ -91,6 +103,10 @@ spec:
               limits:
                 cpu: 200m
                 memory: 256Mi
+            podAnnotations:
+              prometheus.io/scrape: "true"
+              prometheus.io/port: "8000"
+              prometheus.io/path: "/metrics"
 
           webhooksCleanup:
             enabled: true


### PR DESCRIPTION
## Résumé

Vague metrics (silver→gold) : ajout des annotations `prometheus.io/scrape` sur les pods de tous les composants infra critiques.

## Composants modifiés

| Composant | Action | Port |
|-----------|--------|------|
| argocd-application-controller | `scrape: true` | 8082 |
| argocd-applicationset-controller | `scrape: true` | 8080 |
| argocd-dex-server | `scrape: true` | 5558 |
| argocd-notifications-controller | `scrape: true` | 9001 |
| argocd-repo-server | `scrape: true` | 8084 |
| argocd-server | `scrape: true` | 8083 |
| argocd-redis | `nometrics: true` | — |
| kyverno (4 controllers) | `scrape: true` | 8000 |
| cert-manager controller | `scrape: true` | 9402 |
| cert-manager webhook | `nometrics: true` | — |
| cert-manager cainjector | `nometrics: true` | — |
| authentik-server | `scrape: true` | 9300 |
| authentik-worker | `nometrics: true` | — |
| external-dns-gandi | `scrape: true` | 7979 |
| external-dns-unifi | `scrape: true` | 7979 |

## Impact

Ces modifications permettent à la policy `check-metrics` (Gold) de passer pour les apps listées ci-dessus, faisant passer ces workloads de silver → gold après sync ArgoCD + re-run du maturity-controller.

## Notes

- kyverno.yaml est un Application CRD (non géré par ArgoCD) — il faudra un `kubectl apply -f argocd/overlays/prod/apps/kyverno.yaml` manuel post-merge
- Warnings yamllint line-too-long sur les fichiers modifiés sont pre-existants (commentaires ou URLs longues) — pas bloquants

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled Prometheus metrics scraping annotations across infrastructure components including ArgoCD, Cert-manager, Authentik server, Kyverno controllers, and External DNS services.
  * Configured metrics endpoints with designated ports and collection paths.
  * Marked specific components (Authentik worker, ArgoCD Redis, Cert-manager webhook, and cainjector) to exclude from metrics collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->