### PR TITLE
fix(authentik): update health probe path for authentik 2026.2

### DIFF
--- a/apps/03-security/authentik/base/deployment-server.yaml
+++ b/apps/03-security/authentik/base/deployment-server.yaml
@@ -112,21 +112,21 @@ spec:
               value: "true"
           startupProbe:
             httpGet:
-              path: /api/v3/-/health/live/
+              path: /-/health/live/
               port: http
             failureThreshold: 30
             periodSeconds: 10
             timeoutSeconds: 5
           livenessProbe:
             httpGet:
-              path: /api/v3/-/health/live/
+              path: /-/health/live/
               port: http
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /api/v3/-/health/live/
+              path: /-/health/live/
               port: http
             periodSeconds: 10
             timeoutSeconds: 3


### PR DESCRIPTION
## Problème

Authentik 2026.2 a déplacé l'endpoint health de `/api/v3/-/health/live/` vers `/-/health/live/`.

Les 3 probes (startupProbe, livenessProbe, readinessProbe) pointaient vers l'ancien path, causant des **CrashLoopBackOff** au rollout du pod `authentik-server`.

**Symptômes observés :**
```
Startup probe failed: HTTP probe failed with statuscode: 404
Container authentik-server failed startup probe, will be restarted
```

## Fix

Mise à jour des 3 probes vers `/-/health/live/` (validé manuellement depuis le pod).

## Urgence

🔴 **URGENT** — authentik-server est actuellement en CrashLoopBackOff en prod. Ce fix doit être mergé et promu immédiatement.