### PR TITLE
feat(maturity): wave 13 — gold sync-wave + goldilocks + fix kyverno ComparisonError

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/argocd/overlays/prod/kustomization.yaml
@@ -182,5 +182,28 @@ patches:
     target:
       kind: Deployment
       name: argocd-redis
+  # Gold maturity: sync-wave + goldilocks on all ArgoCD workloads (Deployment metadata, not pod template)
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: placeholder
+        annotations:
+          argocd.argoproj.io/sync-wave: "5"
+          goldilocks.fairwinds.com/enabled: "true"
+          vpa.kubernetes.io/updateMode: "Off"
+    target:
+      kind: Deployment
+  - patch: |
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: placeholder
+        annotations:
+          argocd.argoproj.io/sync-wave: "5"
+          goldilocks.fairwinds.com/enabled: "true"
+          vpa.kubernetes.io/updateMode: "Off"
+    target:
+      kind: StatefulSet
 components:
   - ../../../../_shared/components/revision-history-limit

--- a/apps/00-infra/cert-manager/values/common.yaml
+++ b/apps/00-infra/cert-manager/values/common.yaml
@@ -32,6 +32,10 @@ podAnnotations:
   prometheus.io/scrape: "true"
   prometheus.io/port: "9402"
   prometheus.io/path: "/metrics"
+deploymentAnnotations:  # Deployment metadata annotations (Gold maturity: sync-wave + goldilocks)
+  argocd.argoproj.io/sync-wave: "0"
+  goldilocks.fairwinds.com/enabled: "true"
+  vpa.kubernetes.io/updateMode: "Off"
 # Webhook component
 webhook:
   tolerations:
@@ -44,6 +48,10 @@ webhook:
     vixens.io/fast-start: "true"
     vixens.io/service-binding: "false"
     vixens.io/nometrics: "true"  # cert-manager webhook has no Prometheus metrics endpoint
+  deploymentAnnotations:
+    argocd.argoproj.io/sync-wave: "0"
+    goldilocks.fairwinds.com/enabled: "true"
+    vpa.kubernetes.io/updateMode: "Off"
 # CA Injector component
 cainjector:
   tolerations:
@@ -56,6 +64,10 @@ cainjector:
     vixens.io/fast-start: "true"
     vixens.io/service-binding: "false"
     vixens.io/nometrics: "true"  # cainjector has no Prometheus metrics endpoint
+  deploymentAnnotations:
+    argocd.argoproj.io/sync-wave: "0"
+    goldilocks.fairwinds.com/enabled: "true"
+    vpa.kubernetes.io/updateMode: "Off"
 # Startup API check tolerations
 startupapicheck:
   tolerations:

--- a/apps/03-security/authentik/base/deployment-server.yaml
+++ b/apps/03-security/authentik/base/deployment-server.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: auth
   labels:
     app: authentik-server
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    goldilocks.fairwinds.com/enabled: "true"
+    vpa.kubernetes.io/updateMode: "Off"
 spec:
   replicas: 1
   strategy:

--- a/apps/03-security/authentik/base/deployment-worker.yaml
+++ b/apps/03-security/authentik/base/deployment-worker.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: auth
   labels:
     app: authentik-worker
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    goldilocks.fairwinds.com/enabled: "true"
+    vpa.kubernetes.io/updateMode: "Off"
 spec:
   replicas: 1
   strategy:

--- a/apps/40-network/external-dns-gandi/values/prod.yaml
+++ b/apps/40-network/external-dns-gandi/values/prod.yaml
@@ -39,3 +39,8 @@ podAnnotations:
   prometheus.io/scrape: "true"
   prometheus.io/port: "7979"
   prometheus.io/path: "/metrics"
+
+commonAnnotations:  # Deployment metadata annotations (Gold maturity: sync-wave + goldilocks)
+  argocd.argoproj.io/sync-wave: "5"
+  goldilocks.fairwinds.com/enabled: "true"
+  vpa.kubernetes.io/updateMode: "Off"

--- a/apps/40-network/external-dns-unifi/values/prod.yaml
+++ b/apps/40-network/external-dns-unifi/values/prod.yaml
@@ -17,3 +17,8 @@ podAnnotations:
   prometheus.io/scrape: "true"
   prometheus.io/port: "7979"
   prometheus.io/path: "/metrics"
+
+commonAnnotations:  # Deployment metadata annotations (Gold maturity: sync-wave + goldilocks)
+  argocd.argoproj.io/sync-wave: "5"
+  goldilocks.fairwinds.com/enabled: "true"
+  vpa.kubernetes.io/updateMode: "Off"

--- a/argocd/overlays/prod/apps/kyverno.yaml
+++ b/argocd/overlays/prod/apps/kyverno.yaml
@@ -154,6 +154,11 @@ spec:
         - .spec.rules[].validate.allowExistingViolations
         - .spec.rules[].context[].apiCall.method
         - .spec.rules[].validate.foreach[].context[].apiCall.method
+        - .spec.rules[].match.any[].resources.group
+        - .spec.rules[].match.any[].resources.namespaces
+        - .spec.rules[].match.any[].resources.namespaceSelector
+        - .spec.rules[].match.all[].resources.group
+        - .spec.rules[].match.all[].resources.namespaces
       jsonPointers:
         - /status
   syncPolicy:


### PR DESCRIPTION
## Objectif

Résolution des 3 derniers fails Gold bloquant les apps infra : \`check-sync-wave\`, \`require-goldilocks\`, et le ComparisonError ArgoCD sur kyverno.

## Changements

### Gold maturity — sync-wave + goldilocks (Deployment metadata)

| Composant | Mécanisme | sync-wave |
|-----------|-----------|-----------|
| argocd (7 workloads) | Kustomize bulk patch | 5 |
| authentik-server/worker | YAML metadata.annotations | 10 |
| cert-manager (ctrl+webhook+cainjector) | `deploymentAnnotations` Helm | 0 |
| external-dns-gandi/unifi | `commonAnnotations` Helm | 5 |

**Annotations ajoutées sur les Deployment/StatefulSet metadata :**
- `argocd.argoproj.io/sync-wave` → passe `check-sync-wave` (Gold)
- `goldilocks.fairwinds.com/enabled: "true"` + `vpa.kubernetes.io/updateMode: "Off"` → passe `require-goldilocks` (Gold)

### Fix kyverno ComparisonError

Ajout de `.spec.rules[].match.any[].resources.group` (et variants) dans `ignoreDifferences` pour corriger l'erreur :
```
ComparisonError: .spec.rules[0].match.any[0].resources.group: field not declared in schema
```
Cela débloque le sync ArgoCD de kyverno, ce qui permettra à Helm d'appliquer les `podAnnotations` métriques (wave 12).

## Impact attendu post-sync

- argocd (6 Deployments + 1 StatefulSet) → **gold** ✅
- authentik (2 Deployments) → **gold** ✅
- cert-manager (3 Deployments) → **gold** ✅
- external-dns (2 Deployments) → **gold** ✅
- kyverno sync error résolu → pods rollout avec prometheus annotations → **gold** ✅

## Notes

- Le fix kyverno nécessite un `kubectl apply -f argocd/overlays/prod/apps/kyverno.yaml` post-merge
- `check-servicemonitor` reste le seul fail Gold résiduel pour les apps avec `prometheus.io/scrape: true` (wave future)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added deployment metadata annotations across infrastructure components to enable ArgoCD sync wave ordering, autoscaling hints, and vertical pod autoscaler configuration.
  * Updated Kyverno drift detection settings to exclude resource-related fields from change monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->