### PR TITLE
fix(maturity): wave 14b — gold patches directs pour 6 Helm apps restantes

### DIFF
--- a/apps/00-infra/cert-manager-webhook-gandi/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/overlays/prod/kustomization.yaml
@@ -2,8 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cert-manager
-components:
-  - ../../../../_shared/components/gold-maturity
+# gold-maturity annotations are applied via JSON patches below
+  # (component cannot patch Helm resources, only Git-defined resources)
 
 patches:
   - path: gandi-infisical-secret-patch.yaml
@@ -17,6 +17,19 @@ patches:
       - op: add
         path: /spec/template/metadata/annotations/vixens.io~1service-binding
         value: "false"
+    target:
+      kind: Deployment
+      name: cert-manager-webhook-gandi
+  - patch: |-
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1sync-wave
+        value: "10"
+      - op: add
+        path: /metadata/annotations/goldilocks.fairwinds.com~1enabled
+        value: "true"
+      - op: add
+        path: /metadata/annotations/vpa.kubernetes.io~1updateMode
+        value: "Off"
     target:
       kind: Deployment
       name: cert-manager-webhook-gandi

--- a/apps/00-infra/infisical-operator/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/infisical-operator/overlays/prod/kustomization.yaml
@@ -2,8 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources: []
-components:
-  - ../../../../_shared/components/gold-maturity
+# gold-maturity annotations are applied via JSON patches below
+  # (component cannot patch Helm resources, only Git-defined resources)
 
 patches:
   - patch: |-
@@ -13,6 +13,19 @@ patches:
       - op: add
         path: /spec/template/metadata/annotations/vixens.io~1service-binding
         value: "false"
+    target:
+      kind: Deployment
+      name: infisical-opera-controller-manager
+  - patch: |-
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1sync-wave
+        value: "10"
+      - op: add
+        path: /metadata/annotations/goldilocks.fairwinds.com~1enabled
+        value: "true"
+      - op: add
+        path: /metadata/annotations/vpa.kubernetes.io~1updateMode
+        value: "Off"
     target:
       kind: Deployment
       name: infisical-opera-controller-manager

--- a/apps/02-monitoring/prometheus/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/prometheus/overlays/prod/kustomization.yaml
@@ -4,8 +4,8 @@ commonLabels:
   environment: prod
 kind: Kustomization
 namespace: monitoring
-components:
-  - ../../../../_shared/components/gold-maturity
+# gold-maturity annotations via direct JSON patches (SSA for Helm chart resources)
+  # The component targets only kustomize-defined resources, not Helm-rendered ones
 
 patches:
   - path: patch-alertmanager-command.yaml
@@ -20,5 +20,18 @@ patches:
     target:
       kind: InfisicalSecret
       name: alertmanager-secrets-sync
+  - patch: |-
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1sync-wave
+        value: "10"
+      - op: add
+        path: /metadata/annotations/goldilocks.fairwinds.com~1enabled
+        value: "true"
+      - op: add
+        path: /metadata/annotations/vpa.kubernetes.io~1updateMode
+        value: "Off"
+    target:
+      kind: StatefulSet
+      name: prometheus-alertmanager
 resources:
   - ../../base

--- a/apps/04-databases/cloudnative-pg/overlays/prod/kustomization.yaml
+++ b/apps/04-databases/cloudnative-pg/overlays/prod/kustomization.yaml
@@ -10,3 +10,16 @@ labels:
     includeSelectors: false
 
 patches:
+  - patch: |-
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1sync-wave
+        value: "10"
+      - op: add
+        path: /metadata/annotations/goldilocks.fairwinds.com~1enabled
+        value: "true"
+      - op: add
+        path: /metadata/annotations/vpa.kubernetes.io~1updateMode
+        value: "Off"
+    target:
+      kind: Deployment
+      name: cloudnative-pg

--- a/apps/70-tools/it-tools/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/it-tools/overlays/prod/kustomization.yaml
@@ -7,7 +7,20 @@ resources:
   - ingress.yaml
 
 components:
-  - ../../../../_shared/components/gold-maturity
   - ../../../../_shared/components/revision-history-limit
 
 patches:
+  # gold-maturity annotations via direct JSON patches (Helm chart doesn't support deploymentAnnotations)
+  - patch: |-
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1sync-wave
+        value: "10"
+      - op: add
+        path: /metadata/annotations/goldilocks.fairwinds.com~1enabled
+        value: "true"
+      - op: add
+        path: /metadata/annotations/vpa.kubernetes.io~1updateMode
+        value: "Off"
+    target:
+      kind: Deployment
+      name: it-tools

--- a/apps/70-tools/stirling-pdf/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/stirling-pdf/overlays/prod/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - ingress.yaml
 
 components:
-  - ../../../../_shared/components/gold-maturity
   - ../../../../_shared/components/revision-history-limit
 
 patches:
@@ -21,6 +20,20 @@ patches:
       - op: add
         path: /spec/template/metadata/labels/vixens.io~1sizing-v2
         value: "true"
+    target:
+      kind: Deployment
+      name: stirling-pdf-stirling-pdf-chart
+  # gold-maturity annotations via direct JSON patches (Helm chart lacks deploymentAnnotations support)
+  - patch: |-
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1sync-wave
+        value: "10"
+      - op: add
+        path: /metadata/annotations/goldilocks.fairwinds.com~1enabled
+        value: "true"
+      - op: add
+        path: /metadata/annotations/vpa.kubernetes.io~1updateMode
+        value: "Off"
     target:
       kind: Deployment
       name: stirling-pdf-stirling-pdf-chart


### PR DESCRIPTION
## Summary

- 6 Deployments/StatefulSets n'avaient pas reçu les annotations gold-maturity après la wave 14 car le composant kustomize ne peut patcher que des ressources définies dans son scope Git (pas les ressources rendues par Helm)
- Solution : JSON patches directs `op: add` sur `/metadata/annotations` dans les overlays prod
- Apps corrigées : cert-manager-webhook-gandi, infisical-operator, prometheus-alertmanager, cloudnative-pg, it-tools, stirling-pdf
- Fix bug YAML sur it-tools/stirling-pdf (comment placé avant une clé YAML causait syntax error)