### PR TITLE
feat(maturity): wave 15 — revisionHistoryLimit: 3 sur toutes les apps (Gold tier)

### DIFF
--- a/apps/00-infra/cert-manager/values/common.yaml
+++ b/apps/00-infra/cert-manager/values/common.yaml
@@ -36,6 +36,7 @@ deploymentAnnotations:  # Deployment metadata annotations (Gold maturity: sync-w
   argocd.argoproj.io/sync-wave: "0"
   goldilocks.fairwinds.com/enabled: "true"
   vpa.kubernetes.io/updateMode: "Off"
+revisionHistoryLimit: 3
 # Webhook component
 webhook:
   tolerations:
@@ -52,6 +53,7 @@ webhook:
     argocd.argoproj.io/sync-wave: "0"
     goldilocks.fairwinds.com/enabled: "true"
     vpa.kubernetes.io/updateMode: "Off"
+  revisionHistoryLimit: 3
 # CA Injector component
 cainjector:
   tolerations:
@@ -68,6 +70,7 @@ cainjector:
     argocd.argoproj.io/sync-wave: "0"
     goldilocks.fairwinds.com/enabled: "true"
     vpa.kubernetes.io/updateMode: "Off"
+  revisionHistoryLimit: 3
 # Startup API check tolerations
 startupapicheck:
   tolerations:

--- a/apps/00-infra/traefik/values/common.yaml
+++ b/apps/00-infra/traefik/values/common.yaml
@@ -126,3 +126,4 @@ deployment:
     argocd.argoproj.io/sync-wave: "5"
     goldilocks.fairwinds.com/enabled: "true"
     vpa.kubernetes.io/updateMode: "Off"
+  revisionHistoryLimit: 3

--- a/apps/00-infra/velero/values/common.yaml
+++ b/apps/00-infra/velero/values/common.yaml
@@ -89,6 +89,7 @@ annotations:  # Deployment metadata (Gold maturity: sync-wave + goldilocks)
   argocd.argoproj.io/sync-wave: "10"
   goldilocks.fairwinds.com/enabled: "true"
   vpa.kubernetes.io/updateMode: "Off"
+revisionHistoryLimit: 3
 
 resources:
   requests:

--- a/apps/02-monitoring/goldilocks/values/common.yaml
+++ b/apps/02-monitoring/goldilocks/values/common.yaml
@@ -23,6 +23,7 @@ controller:
       argocd.argoproj.io/sync-wave: "10"
       goldilocks.fairwinds.com/enabled: "true"
       vpa.kubernetes.io/updateMode: "Off"
+  revisionHistoryLimit: 3
 
 dashboard:
   tolerations:
@@ -48,3 +49,4 @@ dashboard:
       argocd.argoproj.io/sync-wave: "10"
       goldilocks.fairwinds.com/enabled: "true"
       vpa.kubernetes.io/updateMode: "Off"
+  revisionHistoryLimit: 3

--- a/apps/02-monitoring/grafana/base/values.yaml
+++ b/apps/02-monitoring/grafana/base/values.yaml
@@ -59,6 +59,7 @@ annotations:  # Deployment metadata annotations (Gold maturity: sync-wave + gold
   argocd.argoproj.io/sync-wave: "10"
   goldilocks.fairwinds.com/enabled: "true"
   vpa.kubernetes.io/updateMode: "Off"
+revisionHistoryLimit: 3
 # Tolerations for control-plane nodes
 tolerations:
   - key: node-role.kubernetes.io/control-plane

--- a/apps/02-monitoring/prometheus/base/values.yaml
+++ b/apps/02-monitoring/prometheus/base/values.yaml
@@ -12,6 +12,7 @@ server:
     argocd.argoproj.io/sync-wave: "10"
     goldilocks.fairwinds.com/enabled: "true"
     vpa.kubernetes.io/updateMode: "Off"
+  revisionHistoryLimit: 3
   tolerations:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists
@@ -38,6 +39,7 @@ alertmanager:
   priorityClassName: vixens-critical
   podAnnotations:
     vixens.io/fast-start: "true"
+  revisionHistoryLimit: 3
   tolerations:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists
@@ -118,6 +120,7 @@ kube-state-metrics:
     argocd.argoproj.io/sync-wave: "10"
     goldilocks.fairwinds.com/enabled: "true"
     vpa.kubernetes.io/updateMode: "Off"
+  revisionHistoryLimit: 3
   enabled: true
   priorityClassName: vixens-critical
   podAnnotations:

--- a/apps/40-network/external-dns-gandi/values/prod.yaml
+++ b/apps/40-network/external-dns-gandi/values/prod.yaml
@@ -44,3 +44,4 @@ commonAnnotations:  # Deployment metadata annotations (Gold maturity: sync-wave 
   argocd.argoproj.io/sync-wave: "5"
   goldilocks.fairwinds.com/enabled: "true"
   vpa.kubernetes.io/updateMode: "Off"
+revisionHistoryLimit: 3

--- a/apps/40-network/external-dns-unifi/values/prod.yaml
+++ b/apps/40-network/external-dns-unifi/values/prod.yaml
@@ -22,3 +22,4 @@ commonAnnotations:  # Deployment metadata annotations (Gold maturity: sync-wave 
   argocd.argoproj.io/sync-wave: "5"
   goldilocks.fairwinds.com/enabled: "true"
   vpa.kubernetes.io/updateMode: "Off"
+revisionHistoryLimit: 3

--- a/apps/_shared/components/gold-maturity/kustomization.yaml
+++ b/apps/_shared/components/gold-maturity/kustomization.yaml
@@ -1,9 +1,12 @@
 # Kustomize Component: gold-maturity
 #
-# Adds Gold-tier maturity annotations to all Deployments and StatefulSets:
+# Adds Gold-tier maturity to all Deployments and StatefulSets:
+#   Metadata annotations:
 #   - argocd.argoproj.io/sync-wave: "10"  (satisfies check-sync-wave policy)
 #   - goldilocks.fairwinds.com/enabled: "true"  (satisfies require-goldilocks policy)
 #   - vpa.kubernetes.io/updateMode: "Off"  (satisfies require-goldilocks policy)
+#   Spec:
+#   - revisionHistoryLimit: 3  (satisfies require-revision-history-limit policy)
 #
 # Apps that need a specific sync-wave value should override this annotation
 # directly in their own overlay patch.
@@ -12,13 +15,14 @@
 #   components:
 #     - ../../../../_shared/components/gold-maturity
 #
-# Reference: Kyverno policies check-sync-wave, require-goldilocks (Maturity Gold)
+# Reference: Kyverno policies check-sync-wave, require-goldilocks,
+#            require-revision-history-limit (Maturity Gold)
 
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 patches:
-  # Apply gold-maturity annotations to all Deployments
+  # Apply gold-maturity annotations + revisionHistoryLimit to all Deployments
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment
@@ -28,10 +32,12 @@ patches:
           argocd.argoproj.io/sync-wave: "10"
           goldilocks.fairwinds.com/enabled: "true"
           vpa.kubernetes.io/updateMode: "Off"
+      spec:
+        revisionHistoryLimit: 3
     target:
       kind: Deployment
 
-  # Apply gold-maturity annotations to all StatefulSets
+  # Apply gold-maturity annotations + revisionHistoryLimit to all StatefulSets
   - patch: |-
       apiVersion: apps/v1
       kind: StatefulSet
@@ -41,5 +47,7 @@ patches:
           argocd.argoproj.io/sync-wave: "10"
           goldilocks.fairwinds.com/enabled: "true"
           vpa.kubernetes.io/updateMode: "Off"
+      spec:
+        revisionHistoryLimit: 3
     target:
       kind: StatefulSet

--- a/argocd/overlays/prod/apps/cert-manager-webhook-gandi.yaml
+++ b/argocd/overlays/prod/apps/cert-manager-webhook-gandi.yaml
@@ -44,3 +44,8 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 3m
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/revisionHistoryLimit

--- a/argocd/overlays/prod/apps/cloudnative-pg.yaml
+++ b/argocd/overlays/prod/apps/cloudnative-pg.yaml
@@ -41,6 +41,7 @@ spec:
 
         podAnnotations:
           vixens.io/service-binding: "false"
+        revisionHistoryLimit: 3
   destination:
     server: https://kubernetes.default.svc
     namespace: cnpg-system
@@ -57,3 +58,8 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 3m
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/revisionHistoryLimit

--- a/argocd/overlays/prod/apps/infisical-operator.yaml
+++ b/argocd/overlays/prod/apps/infisical-operator.yaml
@@ -66,3 +66,8 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 3m
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/revisionHistoryLimit

--- a/argocd/overlays/prod/apps/it-tools.yaml
+++ b/argocd/overlays/prod/apps/it-tools.yaml
@@ -34,3 +34,8 @@ spec:
     syncOptions:
       - ServerSideApply=true
       - CreateNamespace=true
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/revisionHistoryLimit

--- a/argocd/overlays/prod/apps/policy-reporter.yaml
+++ b/argocd/overlays/prod/apps/policy-reporter.yaml
@@ -41,6 +41,7 @@ spec:
             argocd.argoproj.io/sync-wave: "10"
             goldilocks.fairwinds.com/enabled: "true"
             vpa.kubernetes.io/updateMode: "Off"
+          revisionHistoryLimit: 3
 
           podLabels:
             vixens.io/sizing.policy-reporter: small
@@ -65,6 +66,7 @@ spec:
               argocd.argoproj.io/sync-wave: "10"
               goldilocks.fairwinds.com/enabled: "true"
               vpa.kubernetes.io/updateMode: "Off"
+            revisionHistoryLimit: 3
 
           ui:
             enabled: true
@@ -86,6 +88,7 @@ spec:
               argocd.argoproj.io/sync-wave: "10"
               goldilocks.fairwinds.com/enabled: "true"
               vpa.kubernetes.io/updateMode: "Off"
+              revisionHistoryLimit: 3
 
           rest:
             enabled: true

--- a/argocd/overlays/prod/apps/stirling-pdf.yaml
+++ b/argocd/overlays/prod/apps/stirling-pdf.yaml
@@ -33,3 +33,8 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/revisionHistoryLimit


### PR DESCRIPTION
## Summary

Add \`spec.revisionHistoryLimit=3\` to satisfy the \`require-revision-history-limit\` Kyverno policy (Maturity Gold) on all 47 failing Deployments/StatefulSets.

## Changes

### 🧩 gold-maturity component extended
- `apps/_shared/components/gold-maturity/kustomization.yaml` — adds \`spec.revisionHistoryLimit: 3\` to all Deployments and StatefulSets (covers 27 GitOps-managed apps)

### ⚙️ Helm values (permanent fix via chart values)
| App | Key |
|-----|-----|
| cert-manager (controller+webhook+cainjector) | \`revisionHistoryLimit\`, \`webhook.revisionHistoryLimit\`, \`cainjector.revisionHistoryLimit\` |
| traefik | \`deployment.revisionHistoryLimit\` |
| velero | \`revisionHistoryLimit\` |
| grafana | \`revisionHistoryLimit\` |
| prometheus (server+alertmanager+ksm) | \`server.revisionHistoryLimit\`, \`alertmanager.revisionHistoryLimit\`, \`kube-state-metrics.revisionHistoryLimit\` |
| goldilocks (controller+dashboard) | \`controller.revisionHistoryLimit\`, \`dashboard.revisionHistoryLimit\` |
| external-dns-gandi/unifi | \`revisionHistoryLimit\` |
| policy-reporter (reporter+plugin+ui) | \`revisionHistoryLimit\`, \`kyvernoPlugin.revisionHistoryLimit\`, \`ui.revisionHistoryLimit\` |

### 🔧 Helm apps without chart support (kubectl patched + ignoreDifferences)
- **cert-manager-webhook-gandi**: \`ignoreDifferences /spec/revisionHistoryLimit\`
- **cloudnative-pg**: inline \`revisionHistoryLimit: 3\` in ArgoCD app + \`ignoreDifferences\`
- **infisical-operator**: \`ignoreDifferences /spec/revisionHistoryLimit\`
- **it-tools**: \`ignoreDifferences /spec/revisionHistoryLimit\`
- **stirling-pdf**: \`ignoreDifferences /spec/revisionHistoryLimit\`

## Expected result

All 47 apps currently failing `require-revision-history-limit` should pass → ~40+ apps promoted from silver → platinum/diamond tier.

## Also in this session (pre-PR)

Fixed the 6 persistent `check-sync-wave` + `require-goldilocks` fails via `kubectl annotate` (annotations hadn't applied via SSA from wave 14b patches).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configurations across infrastructure and monitoring services (cert-manager, Traefik, Velero, Goldilocks, Grafana, Prometheus, External DNS, and others) to limit deployment revision history to 3 revisions.
  * Configured ArgoCD to ignore revision history limit differences during synchronization to prevent unnecessary reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->