### PR TITLE
fix(maturity): wave 15b — ignoreDifferences revisionHistoryLimit cert-manager & prometheus

### DIFF
--- a/argocd/overlays/prod/apps/cert-manager.yaml
+++ b/argocd/overlays/prod/apps/cert-manager.yaml
@@ -41,3 +41,8 @@ spec:
         maxDuration: 3m
     syncOptions:
       - CreateNamespace=true
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/revisionHistoryLimit

--- a/argocd/overlays/prod/apps/prometheus.yaml
+++ b/argocd/overlays/prod/apps/prometheus.yaml
@@ -35,3 +35,8 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=false
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/revisionHistoryLimit


### PR DESCRIPTION
## Summary

- Ajoute `ignoreDifferences` sur les ArgoCD Application CRDs `cert-manager` et `prometheus` pour le champ `/spec/revisionHistoryLimit`
- Permet d'appliquer `revisionHistoryLimit: 3` via `kubectl patch` sans que `selfHeal` ne reverte la valeur
- Complète wave 15 pour les charts Helm sans support natif de `revisionHistoryLimit` dans leurs values

## Context

Ces 2 charts Helm ne supportent pas la clé `revisionHistoryLimit` dans leurs values (pas de template). La seule approche viable est `kubectl patch` + `ignoreDifferences` dans l'ArgoCD app.

## Apps concernées
- `cert-manager` : 3 Deployments (cert-manager, cert-manager-cainjector, cert-manager-webhook)
- `prometheus` : 2 Deployments (prometheus-server, prometheus-kube-state-metrics)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Argo CD production configurations for the cert-manager and Prometheus applications. These changes refine synchronization behavior to prevent false drift detection during deployments, allowing Argo CD to proceed reliably without flagging expected field variations, resulting in smoother automated deployments with fewer manual interventions required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->