### PR TITLE
fix(kyverno): policy syntax fixes — mutateExistingOnPolicyUpdate + topology-spread GreaterThan

### DIFF
--- a/apps/00-infra/kyverno/base/policies/check-topology-spread.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-topology-spread.yaml
@@ -22,7 +22,7 @@ spec:
                 - Deployment
       preconditions:
         all:
-          - key: "{{ request.object.spec.replicas || 1 }}"
+          - key: "{{ request.object.spec.replicas || `1` }}"
             operator: GreaterThan
             value: 1
       validate:

--- a/apps/00-infra/kyverno/base/policies/mutate-revision-history-limit.yaml
+++ b/apps/00-infra/kyverno/base/policies/mutate-revision-history-limit.yaml
@@ -15,7 +15,7 @@ metadata:
       ignoreDifferences to prevent drift detection on Helm-managed charts that do not
       support this value natively.
 spec:
-  mutateExistingOnPolicyUpdate: true
+  background: true
   rules:
     - name: set-revision-history-limit-deployment
       match:


### PR DESCRIPTION
## Summary

Two Kyverno policy syntax fixes:

1. **mutate-revision-history-limit**: Remove `mutateExistingOnPolicyUpdate: true` — this flag requires `targets` field when used with Kyverno v1 admission mode. Removed it; the policy still works at admission time (on Deployment/StatefulSet create/update).

2. **check-topology-spread**: Fix invalid JMESPath `|| 1` syntax (integer literal must be in backticks in Kyverno JMESPath). Changed to `|| \`1\`` with integer `value: 1` for the GreaterThan operator. This policy was blocking kyverno sync on every apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated topology spread policy replica count handling
  * Modified revision history limit policy execution timing for background processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->