### PR TITLE
fix(kyverno): check-servicemonitor add app label precondition

### DIFF
--- a/apps/00-infra/kyverno/base/policies/check-servicemonitor.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-servicemonitor.yaml
@@ -25,6 +25,9 @@ spec:
           - key: "{{ request.object.metadata.annotations.\"prometheus.io/scrape\" || 'false' }}"
             operator: Equals
             value: "true"
+          - key: "{{ request.object.metadata.labels.app || '' }}"
+            operator: NotEquals
+            value: ""
       context:
         - name: sm_count
           apiCall:


### PR DESCRIPTION
Adds a precondition to check-servicemonitor: the pod must have an 'app' label before attempting the ServiceMonitor apiCall lookup. Without this, pods using app.kubernetes.io/name (ArgoCD, Kyverno components) cause JMESPath errors on background scan. These errors were propagating as Gold-tier failures in policyreports.