### PR TITLE
fix(gold): nometrics for Helm apps, exclude system namespaces from check-metrics, fix check-servicemonitor autogen errors

### DIFF
--- a/apps/00-infra/kyverno/base/policies/check-metrics.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-metrics.yaml
@@ -24,6 +24,12 @@ spec:
           - resources:
               annotations:
                 vixens.io/nometrics: "true"
+          # Exclude system namespaces managed by Talos/operators (no annotation control)
+          - resources:
+              namespaces:
+                - kube-system
+                - kyverno
+                - synology-csi
       validate:
         message: "Metrics annotations (prometheus.io/scrape) are required for maturity Level 3 (Gold)."
         anyPattern:

--- a/apps/00-infra/kyverno/base/policies/check-servicemonitor.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-servicemonitor.yaml
@@ -5,6 +5,9 @@ metadata:
   name: check-servicemonitor
   annotations:
     policies.kyverno.io/title: Verify ServiceMonitor Presence
+    # Disable autogen: the API context uses request.object which fails in background scans
+    # for Deployment/ReplicaSet/DaemonSet. Pods are the correct scope for this annotation check.
+    pod-policies.kyverno.io/autogen-controllers: none
     policies.kyverno.io/category: Maturity (Gold)
     policies.kyverno.io/description: >-
       Ensures that applications exposing Prometheus metrics (prometheus.io/scrape: "true")

--- a/apps/70-tools/it-tools/base/values.yaml
+++ b/apps/70-tools/it-tools/base/values.yaml
@@ -8,6 +8,7 @@ podLabels:
 podAnnotations:
   vixens.io/fast-start: "true"
   vixens.io/service-binding: "false"
+  vixens.io/nometrics: "true"
 image:
   repository: ghcr.io/corentinth/it-tools
   pullPolicy: IfNotPresent

--- a/apps/70-tools/it-tools/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/it-tools/overlays/prod/kustomization.yaml
@@ -24,11 +24,3 @@ patches:
     target:
       kind: Deployment
       name: it-tools
-  # nometrics: it-tools is a UI with no Prometheus /metrics endpoint
-  - patch: |-
-      - op: add
-        path: /spec/template/metadata/annotations/vixens.io~1nometrics
-        value: "true"
-    target:
-      kind: Deployment
-      name: it-tools

--- a/apps/70-tools/stirling-pdf/base/values.yaml
+++ b/apps/70-tools/stirling-pdf/base/values.yaml
@@ -54,3 +54,4 @@ podAnnotations:
   # fast-start: liveness probe confirms HTTP is ready within 30s; LibreOffice loads lazily
   vixens.io/fast-start: "true"
   vixens.io/service-binding: "false"
+  vixens.io/nometrics: "true"

--- a/apps/70-tools/stirling-pdf/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/stirling-pdf/overlays/prod/kustomization.yaml
@@ -37,11 +37,3 @@ patches:
     target:
       kind: Deployment
       name: stirling-pdf-stirling-pdf-chart
-  # nometrics: stirling-pdf is a document processing UI with no Prometheus /metrics endpoint
-  - patch: |-
-      - op: add
-        path: /spec/template/metadata/annotations/vixens.io~1nometrics
-        value: "true"
-    target:
-      kind: Deployment
-      name: stirling-pdf-stirling-pdf-chart


### PR DESCRIPTION
## Summary

Follow-up fixes after wave-18 gold tier deployment:

### Problems fixed

**1. nometrics not propagating to Helm apps (it-tools, stirling-pdf)**
- JSON patches in kustomize overlays don't apply to Helm-rendered Deployments
- Fix: moved `vixens.io/nometrics: "true"` to `values.yaml` under `podAnnotations`
- Removed the broken JSON patches from overlays

**2. check-metrics failing on system pods (kube-system, kyverno, synology-csi)**
- Cilium, CoreDNS, kube-apiserver, kube-scheduler etc. are managed by Talos/operators
- These pods can't be annotated via GitOps
- Fix: exclude `kube-system`, `kyverno`, `synology-csi` namespaces from check-metrics policy

**3. check-servicemonitor autogen errors blocking gold tier**
- Kyverno autogen generates Deployment/ReplicaSet rules for the Pod-scoped policy
- Background scans fail to substitute `request.object` variables → `error` result
- Maturity controller counts `error` as `fail` → blocks gold tier
- Fix: `pod-policies.kyverno.io/autogen-controllers: none` disables autogen for this policy