### PR TITLE
fix(kyverno): disable check-servicemonitor background scan to prevent spurious errors

### DIFF
--- a/apps/00-infra/kyverno/base/policies/check-servicemonitor.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-servicemonitor.yaml
@@ -15,7 +15,7 @@ metadata:
       (prometheus-operator-crds) to be installed. Evaluated for all scraped apps (Gold tier).
 spec:
   validationFailureAction: Audit
-  background: true
+  background: false  # API context uses request.object — unavailable in background scans
   rules:
     - name: check-servicemonitor-exists
       match:


### PR DESCRIPTION
## Problem

`check-servicemonitor` policy uses `request.object` in preconditions and context
API calls. In background scan mode, `request.object` is not available, causing:

```
error: failed to check deny conditions: failed to substitute variables in condition key
```

This error is treated as a Gold tier failure by the maturity controller, incorrectly
blocking apps with proper ServiceMonitors from reaching gold tier.

## Fix

Set `background: false` on the policy. The check is enforced at admission time only,
which is the correct behavior for this API-call-based context check.

Apps already deployed retain their existing policy reports. On next sync/restart,
they will be evaluated correctly at admission time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the service monitor validation policy configuration to evaluate policies in foreground context instead of background mode. This ensures the policy can access the necessary request information required for validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->