### PR TITLE
fix(gold): stirling-pdf — resources, priorityClassName, revisionHistoryLimit=3

### DIFF
--- a/apps/70-tools/stirling-pdf/base/values.yaml
+++ b/apps/70-tools/stirling-pdf/base/values.yaml
@@ -9,7 +9,15 @@ image:
   pullPolicy: IfNotPresent
   tag: 2.7.0
 replicaCount: 1
-# resources managed by Kyverno sizing (B-large: req=1Gi, lim=2Gi — Java+LibreOffice combo)
+# Java+LibreOffice combo needs real memory — 512Mi req for scheduling, 3Gi limit for safety
+resources:
+  requests:
+    cpu: 100m
+    memory: 512Mi
+  limits:
+    cpu: "2"
+    memory: 3Gi
+priorityClassName: vixens-low
 # Tolerations for control-plane nodes if needed
 tolerations:
   - key: node-role.kubernetes.io/control-plane

--- a/apps/70-tools/stirling-pdf/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/stirling-pdf/overlays/prod/kustomization.yaml
@@ -6,8 +6,8 @@ resources:
   - ../../base
   - ingress.yaml
 
-components:
-  - ../../../../_shared/components/revision-history-limit
+# Note: components: not used here as ArgoCD multi-source kustomize may not support it for Helm-rendered resources
+  # revisionHistoryLimit is hardcoded=10 in chart template — patched below
 
 patches:
   - patch: |-
@@ -34,6 +34,14 @@ patches:
       - op: add
         path: /metadata/annotations/vpa.kubernetes.io~1updateMode
         value: "Off"
+    target:
+      kind: Deployment
+      name: stirling-pdf-stirling-pdf-chart
+  # revisionHistoryLimit: chart hardcodes 10, patch to 3 (gold requirement)
+  - patch: |-
+      - op: replace
+        path: /spec/revisionHistoryLimit
+        value: 3
     target:
       kind: Deployment
       name: stirling-pdf-stirling-pdf-chart


### PR DESCRIPTION
## Summary

Fixes the last remaining **silver** app (`stirling-pdf`) to reach **gold** tier.

### Root causes of gold blockers

| Policy | Fail reason | Fix |
|--------|------------|-----|
| `require-resources` | `resources: {}` in Deployment (chart default) | Added `resources:` in `values.yaml` |
| `require-priority-class` | No `priorityClassName` set | Added `priorityClassName: vixens-low` in `values.yaml` |
| `require-revision-history-limit` | Chart hardcodes `revisionHistoryLimit: 10` | Kustomize patch → 3 in overlay |

### Resource changes

- **Memory request**: `1Gi` → `512Mi` — allows scheduling on saturated nodes (96-99% allocated)
- **Memory limit**: `2Gi` → `3Gi` — prevents OOMKill (pod was dying with exit code 137, Java+LibreOffice)
- **CPU**: unchanged at `100m` request / `2` limit

### Kustomize overlay cleanup

- Removed broken `components:` reference (`revision-history-limit`) — ArgoCD multi-source kustomize overlay only patches resources defined within it, not Helm-rendered resources via components
- Added direct `revisionHistoryLimit: 3` JSON patch to the Deployment target instead

### Expected result

After merge + ArgoCD sync + maturity run: `stirling-pdf` → **gold**, cluster at **100% gold+**