### PR TITLE
fix(gold): stirling-pdf — reduce memory request 512Mi→256Mi for scheduling

### DIFF
--- a/apps/70-tools/stirling-pdf/base/values.yaml
+++ b/apps/70-tools/stirling-pdf/base/values.yaml
@@ -9,11 +9,11 @@ image:
   pullPolicy: IfNotPresent
   tag: 2.7.0
 replicaCount: 1
-# Java+LibreOffice combo needs real memory — 512Mi req for scheduling, 3Gi limit for safety
+# Java+LibreOffice combo — low request for scheduling on tight nodes, 3Gi limit for safety
 resources:
   requests:
     cpu: 100m
-    memory: 512Mi
+    memory: 256Mi
   limits:
     cpu: "2"
     memory: 3Gi


### PR DESCRIPTION
Nodes at 97% memory allocation (powder has ~386Mi free). 512Mi from PR#1861 cannot schedule. Reduce to 256Mi to allow placement. Limit kept at 3Gi to prevent OOMKill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced application memory requirements to optimize deployment efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->