### PR TITLE
feat(trilium): deploy Trilium Notes on notes.truxonline.com

### DIFF
--- a/apps/70-tools/trilium/base/deployment.yaml
+++ b/apps/70-tools/trilium/base/deployment.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trilium
+  labels:
+    app.kubernetes.io/name: trilium
+    vixens.io/sizing-v2: "true"
+    vixens.io/vpa-mode: Auto
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: trilium
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: trilium
+        vixens.io/sizing.trilium: G-small
+        vixens.io/backup-profile: relaxed
+      annotations:
+        vixens.io/service-binding: "false"
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      priorityClassName: vixens-low
+      containers:
+        - name: trilium
+          image: triliumnext/notes:v0.95.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: trilium-data
+              mountPath: /home/node/trilium-data
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+      volumes:
+        - name: trilium-data
+          persistentVolumeClaim:
+            claimName: trilium-data-pvc
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault

--- a/apps/70-tools/trilium/base/ingress.yaml
+++ b/apps/70-tools/trilium/base/ingress.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: trilium
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - notes.dev.truxonline.com
+      secretName: trilium-tls
+  rules:
+    - host: notes.dev.truxonline.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: trilium
+                port:
+                  number: 80

--- a/apps/70-tools/trilium/base/kustomization.yaml
+++ b/apps/70-tools/trilium/base/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: tools
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - trilium-pvc.yaml

--- a/apps/70-tools/trilium/base/service.yaml
+++ b/apps/70-tools/trilium/base/service.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: trilium
+spec:
+  selector:
+    app.kubernetes.io/name: trilium
+  ports:
+    - port: 80
+      targetPort: http
+      name: http

--- a/apps/70-tools/trilium/base/trilium-pvc.yaml
+++ b/apps/70-tools/trilium/base/trilium-pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: trilium-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: synelia-iscsi-retain
+  resources:
+    requests:
+      storage: 5Gi

--- a/apps/70-tools/trilium/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/trilium/overlays/prod/kustomization.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+components:
+  - ../../../../_shared/components/gold-maturity
+  - ../../../../_shared/components/nometrics
+
+patches:
+  - target:
+      kind: Ingress
+      name: trilium
+    patch: |-
+      - op: replace
+        path: /metadata/annotations/cert-manager.io~1cluster-issuer
+        value: letsencrypt-prod
+      - op: replace
+        path: /spec/rules/0/host
+        value: notes.truxonline.com
+      - op: replace
+        path: /spec/tls/0/hosts/0
+        value: notes.truxonline.com
+      - op: replace
+        path: /spec/tls/0/secretName
+        value: trilium-tls-prod

--- a/argocd/overlays/prod/apps/trilium.yaml
+++ b/argocd/overlays/prod/apps/trilium.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: trilium
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: prod-stable
+    path: apps/70-tools/trilium/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tools
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary

- Deploy **Trilium Notes** (`triliumnext/notes:v0.95.0`) on `notes.truxonline.com`
- Namespace `tools`, port 8080, SQLite storage on 5Gi iSCSI PVC (`synelia-iscsi-retain`)
- Follows standard kustomize pattern (base + prod overlay)

## Details

| Field | Value |
|-------|-------|
| Image | `triliumnext/notes:v0.95.0` |
| URL | `notes.truxonline.com` |
| Namespace | `tools` |
| Storage | 5Gi `synelia-iscsi-retain` |
| Sizing | `G-small` (Kyverno `sizing-v2-mutate`) |
| Priority | `vixens-low` |
| TLS | `letsencrypt-prod` |
| Auth | Trilium built-in |

## Kyverno compliance

- `gold-maturity` component ✅
- `nometrics` component ✅ (no Prometheus scraping)
- `vixens.io/service-binding: "false"` ✅
- `revisionHistoryLimit: 3` via gold-maturity ✅
- `priorityClassName: vixens-low` ✅
- `securityContext` non-root, seccomp RuntimeDefault ✅

## Checklist

- [x] `kustomize build overlays/prod` passes
- [x] `yamllint` passes
- [x] ArgoCD Application manifest added to `argocd/overlays/prod/apps/trilium.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Trilium notes application to the platform with persistent data storage
  * Application is now accessible at notes.dev.truxonline.com (development) and notes.truxonline.com (production)
  * Configured automated deployment and continuous synchronization for production environment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->