### PR TITLE
fix(trilium): run as root (image requires su for node user handoff)

### DIFF
--- a/apps/70-tools/trilium/base/deployment.yaml
+++ b/apps/70-tools/trilium/base/deployment.yaml
@@ -35,10 +35,6 @@ spec:
           ports:
             - containerPort: 8080
               name: http
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
           volumeMounts:
             - name: trilium-data
               mountPath: /home/node/trilium-data
@@ -70,10 +66,7 @@ spec:
           persistentVolumeClaim:
             claimName: trilium-data-pvc
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 0
         fsGroup: 1000
-        fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault


### PR DESCRIPTION
## Problem

`triliumnext/notes` entrypoint runs as root and does:
1. `chown /home/node/trilium-data` to fix permissions
2. `su node` to drop to uid 1000 before starting the app

Our original `runAsNonRoot: true` + `allowPrivilegeEscalation: false` blocked both operations, causing `CrashLoopBackOff`.

## Fix

- Remove `runAsNonRoot: true`, `runAsUser: 1000`, `runAsGroup: 1000` from pod securityContext
- Set `runAsUser: 0` (explicit root, matches image design)
- Keep `fsGroup: 1000` (files owned by node group after su)
- Keep `seccompProfile: RuntimeDefault`
- Remove `allowPrivilegeEscalation: false` container securityContext (su requires it)

## Security note

This matches the upstream image design. The process drops to uid 1000 (node) after startup. `seccompProfile: RuntimeDefault` still applies syscall filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Trilium deployment configuration with modifications to security context and runtime privilege settings for container execution parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->