### PR TITLE
fix(trilium): remove seccompProfile - busybox su needs setuid syscall

### DIFF
--- a/apps/70-tools/trilium/base/deployment.yaml
+++ b/apps/70-tools/trilium/base/deployment.yaml
@@ -68,5 +68,4 @@ spec:
       securityContext:
         runAsUser: 0
         fsGroup: 1000
-        seccompProfile:
-          type: RuntimeDefault
+        # no seccompProfile: image uses busybox su (needs setuid syscall).


### PR DESCRIPTION
## Root cause

`seccompProfile: RuntimeDefault` blocks the `setuid`/`seteuid` syscalls.

The `triliumnext/notes` entrypoint (`start-docker.sh`) does:
1. `chown -R node:node /home/node`
2. `exec su -c "node ./main.cjs" node`

Step 2 requires `su` (busybox implementation) which needs the `setuid` syscall to switch from uid 0 → 1000. `RuntimeDefault` blocks this, causing `su: must be suid to work properly`.

Confirmed locally: works fine with `--security-opt seccomp=unconfined`.

## Fix

Remove `seccompProfile` from pod securityContext. Keep:
- `runAsUser: 0` (image runs as root initially, drops to node:1000)
- `fsGroup: 1000` (volume files writable by node group)

## Trade-off

`seccompProfile: RuntimeDefault` is standard practice. This image requires an exception. The process **does** drop to uid 1000 after startup. Trade-off is documented in a code comment.