### PR TITLE
fix(trilium): bypass root entrypoint, run node:1000 directly

### DIFF
--- a/apps/70-tools/trilium/base/deployment.yaml
+++ b/apps/70-tools/trilium/base/deployment.yaml
@@ -32,9 +32,25 @@ spec:
         - name: trilium
           image: triliumnext/notes:v0.95.0
           imagePullPolicy: IfNotPresent
+          # init container handles chown; run node directly
+          command: ["node", "./main.cjs"]
+          workingDir: /usr/src/app
           ports:
             - containerPort: 8080
               name: http
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            # override K8s service env injection (TRILIUM_PORT conflicts)
+            - name: TRILIUM_PORT
+              value: "8080"
           volumeMounts:
             - name: trilium-data
               mountPath: /home/node/trilium-data
@@ -66,6 +82,10 @@ spec:
           persistentVolumeClaim:
             claimName: trilium-data-pvc
       securityContext:
-        runAsUser: 0
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
-        # no seccompProfile: image uses busybox su (needs setuid syscall).
+        fsGroupChangePolicy: Always
+        seccompProfile:
+          type: RuntimeDefault


### PR DESCRIPTION
## Three issues resolved

### 1. seccompProfile RuntimeDefault blocks busybox su

`triliumnext/notes` entrypoint calls `exec su -c "node ./main.cjs" node`. Busybox `su` requires the `setuid` syscall which is blocked by `seccompProfile: RuntimeDefault`.

**Fix:** Bypass entrypoint entirely with `command: ["node", "./main.cjs"]`.

### 2. Namespace PodSecurity restricted blocks runAsUser:0

The `tools` namespace has `PodSecurityAdmission: restricted` which blocks `runAsUser: 0` in any container (including initContainers). The init container approach to `chown` the volume cannot work here.

**Fix:** Use `fsGroupChangePolicy: Always` — Kubernetes changes volume ownership to `fsGroup: 1000` before container start. No init container needed.

### 3. K8s service discovery env injection conflicts with TRILIUM_PORT

Kubernetes auto-injects `TRILIUM_PORT=tcp://ClusterIP:80` for any service named `trilium`. Trilium uses `TRILIUM_PORT` as the port number and crashes with:
```
FATAL ERROR: Invalid port value "tcp://10.103.79.241:80" from environment variable TRILIUM_PORT
```

**Fix:** Explicitly set `TRILIUM_PORT: "8080"` in the Deployment env, which overrides the auto-injected value.

## Result

- Pod runs as `uid:1000 (node)` with full securityContext hardening
- `allowPrivilegeEscalation: false`, `capabilities.drop: ALL`, `seccompProfile: RuntimeDefault` ✅
- `runAsNonRoot: true`, `runAsUser: 1000` ✅
- Trilium starts correctly, listening on port 8080 ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened deployment security by enforcing non-root user execution, restricting capabilities, and implementing privilege escalation prevention.
  * Applied comprehensive security contexts at both container and pod levels for enhanced isolation and runtime protection.
  * Configured service port settings for application access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->