### PR TITLE
fix(trilium): health probes use /api/setup/status

### DIFF
--- a/apps/70-tools/trilium/base/deployment.yaml
+++ b/apps/70-tools/trilium/base/deployment.yaml
@@ -56,7 +56,7 @@ spec:
               mountPath: /home/node/trilium-data
           livenessProbe:
             httpGet:
-              path: /
+              path: /api/setup/status
               port: http
             initialDelaySeconds: 30
             periodSeconds: 20
@@ -64,7 +64,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /
+              path: /api/setup/status
               port: http
             initialDelaySeconds: 15
             periodSeconds: 10
@@ -72,7 +72,7 @@ spec:
             failureThreshold: 3
           startupProbe:
             httpGet:
-              path: /
+              path: /api/setup/status
               port: http
             failureThreshold: 15
             periodSeconds: 10


### PR DESCRIPTION
## Problem

Liveness/readiness probes on `GET /` killed Trilium before it could fully start.

When DB is not initialized, `GET /` returns HTTP 302 → `/setup`. The probe receives 302 which Kubernetes accepts (2xx-3xx passes), BUT the liveness probe was sending SIGTERM due to slow startup (fsGroupChangePolicy:Always chown).

## Fix

Use `/api/setup/status` which returns HTTP 200 in all states (pre- and post-initialization). This is a stable, lightweight endpoint.

Also confirmed locally: `GET /setup` → 200, `GET /api/setup/status` → 200 in DB-uninitialized mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated health check probes to use a dedicated setup status endpoint instead of the root path, enhancing container health verification during startup and runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->