### PR TITLE
fix(stirling-pdf+birdnet): JVM heap cap for OOMKill, birdnet image v0.6.4→v0.6.3

### DIFF
--- a/apps/20-media/birdnet-go/base/deployment.yaml
+++ b/apps/20-media/birdnet-go/base/deployment.yaml
@@ -47,7 +47,7 @@ spec:
               mountPath: /data
       containers:
         - name: birdnet-go
-          image: ghcr.io/tphakala/birdnet-go:v0.6.4
+          image: ghcr.io/tphakala/birdnet-go:v0.6.3
           imagePullPolicy: Always
           ports:
             - name: http

--- a/apps/70-tools/stirling-pdf/base/values.yaml
+++ b/apps/70-tools/stirling-pdf/base/values.yaml
@@ -9,6 +9,9 @@ image:
   pullPolicy: IfNotPresent
   tag: 2.7.0
 replicaCount: 1
+# revisionHistoryLimit: chart template hardcodes 10; kustomize patch on Helm multi-source
+# does not apply to /spec/revisionHistoryLimit. Accepted as known limitation.
+# revisionHistoryLimit: 3  # would require chart support or ArgoCD server-side apply
 # SB-medium sizing: 512Mi req / 2Gi lim (Kyverno mutates resources via this label)
 # Note: resources below are for reference; Kyverno sizing-v2-mutate policy overrides them
 # SB-medium = 50m/500m cpu, 512Mi/2Gi mem — fits on saturated nodes, adequate for Java+LibreOffice
@@ -55,6 +58,10 @@ envs:
     value: /
   - name: SECURITY_ENABLELOGIN
     value: "false"
+  # JVM heap cap: 40% of 2Gi limit = ~820Mi heap + ~200Mi metaspace
+  # Leaves ~1Gi headroom for LibreOffice process within 2Gi container limit
+  - name: JAVA_TOOL_OPTIONS
+    value: "-XX:MaxRAMPercentage=40 -XX:MaxMetaspaceSize=200m -XX:+UseG1GC"
 securityContext:
   enabled: true
   fsGroup: 1000


### PR DESCRIPTION
## stirling-pdf — OOMKill root cause fix

### Root cause
`JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=65` allocates 65% of the 2Gi container limit = **~1.3Gi heap + metaspace**. LibreOffice (separate process) needs ~700Mi+. Total easily exceeds the 2Gi limit → OOMKill (exit 137).

### Fix
Added explicit `JAVA_TOOL_OPTIONS` env override:
```
-XX:MaxRAMPercentage=40 -XX:MaxMetaspaceSize=200m -XX:+UseG1GC
```
- JVM heap: 40% of 2Gi = **~820Mi**
- Metaspace: **200Mi** hard cap
- Remaining: **~1Gi** headroom for LibreOffice + OS overhead
- G1GC: better pause times and lower footprint than Parallel GC

### revisionHistoryLimit (P2 — documenting)
Chart template hardcodes `revisionHistoryLimit: 10`. kustomize patches on Helm-rendered resources in multi-source ArgoCD don't apply to `/spec/revisionHistoryLimit`. Documented as accepted limitation in values.yaml comment.

---

## birdnet-go — Image fix

`ghcr.io/tphakala/birdnet-go:v0.6.4` returns HTTP 404 (not pushed to ghcr.io). The pod was stuck in `ImagePullBackOff` while its 2 sidecars (litestream + rclone) were still running, wasting ~1Gi memory requests on `powder` node.

Downgraded to `v0.6.3` which is confirmed present on ghcr.io. This frees scheduling capacity for stirling-pdf.