### PR TITLE
fix(infisical-operator): upgrade chart 0.10.5→0.10.26, add priorityClassName via kustomize patch

### DIFF
--- a/apps/00-infra/infisical-operator/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/infisical-operator/overlays/prod/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
 
 
 patches:
+  # Patch 1: pod-level annotations + priorityClassName
+  # Chart does not support podAnnotations or priorityClassName natively — JSON6902 is the only option.
   - patch: |-
       - op: add
         path: /spec/template/metadata/annotations/vixens.io~1fast-start
@@ -25,9 +27,13 @@ patches:
       - op: add
         path: /spec/template/metadata/annotations/prometheus.io~1scheme
         value: "https"
+      - op: add
+        path: /spec/template/spec/priorityClassName
+        value: vixens-critical
     target:
       kind: Deployment
       name: infisical-opera-controller-manager
+  # Patch 2: Deployment-level annotations (ArgoCD wave, Goldilocks VPA)
   - patch: |-
       - op: add
         path: /metadata/annotations/argocd.argoproj.io~1sync-wave

--- a/argocd/overlays/prod/apps/infisical-operator.yaml
+++ b/argocd/overlays/prod/apps/infisical-operator.yaml
@@ -15,15 +15,15 @@ spec:
     # Helm chart
     - repoURL: https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/
       chart: secrets-operator
-      targetRevision: 0.10.5
+      targetRevision: 0.10.26
       helm:
         values: |
           controllerManager:
             manager:
               image:
                 repository: infisical/kubernetes-operator
-                tag: v0.10.1
-              priorityClassName: vixens-critical
+                tag: v0.10.26
+              # NOTE: chart does not support priorityClassName — applied via kustomize JSON6902 patch
               resources:
                 limits:
                   cpu: 500m
@@ -31,17 +31,6 @@ spec:
                 requests:
                   cpu: 10m
                   memory: 64Mi
-            kubeRbacProxy:
-              image:
-                repository: gcr.io/kubebuilder/kube-rbac-proxy
-                tag: v0.13.1
-              resources:
-                limits:
-                  cpu: 100m
-                  memory: 64Mi
-                requests:
-                  cpu: 5m
-                  memory: 16Mi
             tolerations:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists


### PR DESCRIPTION
## Summary

- Upgrade `secrets-operator` chart `0.10.5` → `0.10.26` (10 months behind)
- Upgrade operator image `v0.10.1` → `v0.10.26` (matches chart appVersion)
- Remove `kubeRbacProxy` config block from Helm values: the sidecar was dropped upstream in newer chart versions
- Fix `priorityClassName`: was silently ignored in Helm values (chart never supported this field). Now properly applied via JSON6902 kustomize patch, which is confirmed working for this multi-source ArgoCD setup (other patches already apply correctly)
- Add inline comment explaining why the kustomize patch approach is required

## Root Cause

The `secrets-operator` chart Deployment template has no `{{ .Values.controllerManager.manager.priorityClassName }}` interpolation. Setting `priorityClassName: vixens-critical` in Helm values had zero effect — confirmed by inspecting live cluster where the field was absent.

## Verification

```bash
# After sync, should return "vixens-critical"
kubectl get deployment -n infisical-operator-system infisical-opera-controller-manager \
  -o jsonpath='{.spec.template.spec.priorityClassName}'
```

## Changes

| File | Change |
|------|--------|
| `argocd/overlays/prod/apps/infisical-operator.yaml` | chart `0.10.5→0.10.26`, image `v0.10.1→v0.10.26`, remove kubeRbacProxy, comment priorityClassName |
| `apps/00-infra/infisical-operator/overlays/prod/kustomization.yaml` | Add JSON6902 op to set `/spec/template/spec/priorityClassName: vixens-critical` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Infisical operator and Helm chart to version 0.10.26
  * Enhanced pod scheduling configuration with priority class settings
  * Removed deprecated kubeRbacProxy component
  * Improved production environment monitoring integration with enhanced annotations and Prometheus metrics collection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->