### PR TITLE
fix(cert-manager-webhook-gandi): use strategic merge patch for pod annotations

### DIFF
--- a/apps/00-infra/cert-manager-webhook-gandi/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/overlays/prod/kustomization.yaml
@@ -2,27 +2,36 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cert-manager
-# gold-maturity annotations are applied via JSON patches below
-  # (component cannot patch Helm resources, only Git-defined resources)
+# gold-maturity annotations are applied via strategic merge patches below.
+# The SINTEF chart (v0.5.2) does not render any annotations in spec.template.metadata,
+# so JSON6902 op:add on individual annotation keys fails silently when the parent
+# /spec/template/metadata/annotations path does not exist.
+# Strategic merge patches handle the absent-parent case correctly.
 
 patches:
   - path: gandi-infisical-secret-patch.yaml
     target:
       kind: InfisicalSecret
       name: gandi-credentials-sync
+  # Patch 1: pod-level annotations (strategic merge — works even when annotations map is absent)
+  # JSON6902 op:add fails silently here because the chart renders no spec.template.metadata.annotations
   - patch: |-
-      - op: add
-        path: /spec/template/metadata/annotations/vixens.io~1fast-start
-        value: "true"
-      - op: add
-        path: /spec/template/metadata/annotations/vixens.io~1service-binding
-        value: "false"
-      - op: add
-        path: /spec/template/metadata/annotations/vixens.io~1nometrics
-        value: "true"
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: cert-manager-webhook-gandi
+        namespace: cert-manager
+      spec:
+        template:
+          metadata:
+            annotations:
+              vixens.io/fast-start: "true"
+              vixens.io/service-binding: "false"
+              vixens.io/nometrics: "true"
     target:
       kind: Deployment
       name: cert-manager-webhook-gandi
+  # Patch 2: Deployment-level annotations (ArgoCD wave, Goldilocks VPA)
   - patch: |-
       - op: add
         path: /metadata/annotations/argocd.argoproj.io~1sync-wave


### PR DESCRIPTION
## Problem

The SINTEF `cert-manager-webhook-gandi` chart v0.5.2 Deployment template renders **zero annotations** in `spec.template.metadata`. The JSON6902 `op: add` on individual keys (e.g. `/spec/template/metadata/annotations/vixens.io~1nometrics`) fails silently when the parent `/spec/template/metadata/annotations` path does not exist — it cannot add a key to a non-existent object.

Result: `vixens.io/nometrics: "true"` was never applied despite being in the overlay for months. Confirmed by inspecting the live cluster after a force sync — the annotation was absent.

`vixens.io/fast-start` and `vixens.io/service-binding` were present only because they survived from a previous `kubectl rollout restart` (which sets `kubectl.kubernetes.io/restartedAt` and creates the `annotations` map as a side effect), then ArgoCD 3-way merge preserved them on subsequent syncs.

## Fix

Replace the three `op: add` JSON6902 operations with a single **strategic merge patch** that specifies the full `spec.template.metadata.annotations` block. Kustomize strategic merge handles the absent-parent case correctly — it creates the annotations map if missing, then merges keys.

## Verification

```bash
# After sync, should return all three annotations
kubectl get deployment -n cert-manager cert-manager-webhook-gandi \
  -o jsonpath='{.spec.template.metadata.annotations}'
# Expected: {"vixens.io/fast-start":"true","vixens.io/service-binding":"false","vixens.io/nometrics":"true"}
```

## Root Cause Note

This is a general pattern: any chart that renders `spec.template.metadata` **without** an `annotations` field is incompatible with JSON6902 `op: add` on annotation keys. Strategic merge patches should be preferred for pod template annotations on such charts.