### PR TITLE
fix(kyverno): remove conflicting goldilocks rules from mutate-priority-class

### DIFF
--- a/apps/00-infra/kyverno/base/policies/mutate-priority-class.yaml
+++ b/apps/00-infra/kyverno/base/policies/mutate-priority-class.yaml
@@ -7,9 +7,9 @@
 #   Add label to pod template:  vixens.io/priority-class: vixens-critical
 #   Kyverno intercepts admission and injects spec.priorityClassName from the label value.
 #
-# Specific rule for infisical-operator:
-#   The infisical-operator chart (v0.10.x) does not support podLabels in the template.
-#   This rule matches on existing chart labels to inject priorityClassName.
+# Specific rules for charts without podLabels support:
+#   - infisical-operator (v0.10.x): match control-plane=controller-manager
+# NOTE: goldilocks chart ignores controller.podLabels — priorityClass applied via kubectl patch.
 #
 # Why this approach:
 #   In ArgoCD multi-source, kustomize source 2 cannot patch resources rendered by


### PR DESCRIPTION
Kyverno `patchStrategicMerge` on `spec.priorityClassName` causes PriorityAdmission conflict (`priority: 0` injected alongside `priorityClassName`). Goldilocks chart doesn't support `podLabels` — `priorityClassName` applied via `kubectl patch` on Deployment (same approach as infisical-operator, preserved by ArgoCD 3-way merge). Added comment documenting the limitation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated policy documentation to clarify priority class configuration behavior and provide generalized compatibility guidance for Helm charts lacking pod label support. Added specific notes on affected charts and kubectl patch-based application methodology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->