### PR TITLE
fix(kyverno): mutate-priority-class patchesJson6902 + goldilocks + cert-manager-webhook-gandi

### DIFF
--- a/apps/00-infra/kyverno/base/policies/mutate-priority-class.yaml
+++ b/apps/00-infra/kyverno/base/policies/mutate-priority-class.yaml
@@ -9,7 +9,13 @@
 #
 # Specific rules for charts without podLabels support:
 #   - infisical-operator (v0.10.x): match control-plane=controller-manager
-# NOTE: goldilocks chart ignores controller.podLabels — priorityClass applied via kubectl patch.
+#   - goldilocks (v10.2.x): chart ignores controller/dashboard.podLabels — match on component label
+#   - cert-manager-webhook-gandi (SINTEF v0.5.x): no podLabels/podAnnotations in chart
+#
+# Why patchesJson6902 (not patchStrategicMerge):
+#   patchStrategicMerge on spec.priorityClassName causes Go to include priority: 0 implicitly,
+#   which the PriorityAdmission controller rejects. patchesJson6902 with op: add sets only the
+#   requested field, no side effects.
 #
 # Why this approach:
 #   In ArgoCD multi-source, kustomize source 2 cannot patch resources rendered by
@@ -45,9 +51,10 @@ spec:
             operator: NotEquals
             value: ""
       mutate:
-        patchStrategicMerge:
-          spec:
-            priorityClassName: "{{ request.object.metadata.labels.\"vixens.io/priority-class\" }}"
+        patchesJson6902: |-
+          - op: add
+            path: /spec/priorityClassName
+            value: "{{ request.object.metadata.labels.\"vixens.io/priority-class\" }}"
 
     # Rule 2: infisical-operator — chart has no podLabels support
     # Match on existing chart label: control-plane=controller-manager in infisical-operator-system
@@ -69,6 +76,80 @@ spec:
             operator: Equals
             value: ""
       mutate:
-        patchStrategicMerge:
-          spec:
-            priorityClassName: vixens-critical
+        patchesJson6902: |-
+          - op: add
+            path: /spec/priorityClassName
+            value: "vixens-critical"
+
+    # Rule 3: goldilocks controller — chart (v10.2.x) ignores controller.podLabels
+    # Match on chart-native labels: app.kubernetes.io/name + app.kubernetes.io/component
+    - name: inject-priority-class-goldilocks-controller
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              namespaces:
+                - monitoring
+              selector:
+                matchLabels:
+                  app.kubernetes.io/name: goldilocks
+                  app.kubernetes.io/component: controller
+      preconditions:
+        all:
+          - key: "{{ request.object.spec.priorityClassName || '' }}"
+            operator: Equals
+            value: ""
+      mutate:
+        patchesJson6902: |-
+          - op: add
+            path: /spec/priorityClassName
+            value: "vixens-critical"
+
+    # Rule 4: goldilocks dashboard — chart (v10.2.x) ignores dashboard.podLabels
+    - name: inject-priority-class-goldilocks-dashboard
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              namespaces:
+                - monitoring
+              selector:
+                matchLabels:
+                  app.kubernetes.io/name: goldilocks
+                  app.kubernetes.io/component: dashboard
+      preconditions:
+        all:
+          - key: "{{ request.object.spec.priorityClassName || '' }}"
+            operator: Equals
+            value: ""
+      mutate:
+        patchesJson6902: |-
+          - op: add
+            path: /spec/priorityClassName
+            value: "vixens-low"
+
+    # Rule 5: cert-manager-webhook-gandi (SINTEF v0.5.x) — no podLabels/podAnnotations in chart
+    # Match on chart-native label: app.kubernetes.io/name in cert-manager namespace
+    - name: inject-priority-class-cert-manager-webhook-gandi
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              namespaces:
+                - cert-manager
+              selector:
+                matchLabels:
+                  app.kubernetes.io/name: cert-manager-webhook-gandi
+      preconditions:
+        all:
+          - key: "{{ request.object.spec.priorityClassName || '' }}"
+            operator: Equals
+            value: ""
+      mutate:
+        patchesJson6902: |-
+          - op: add
+            path: /spec/priorityClassName
+            value: "vixens-critical"

--- a/apps/02-monitoring/goldilocks/values/common.yaml
+++ b/apps/02-monitoring/goldilocks/values/common.yaml
@@ -16,7 +16,6 @@ controller:
     readOnlyRootFilesystem: true
   podLabels:
     vixens.io/sizing.goldilocks-controller: G-nano
-    vixens.io/priority-class: vixens-critical
   deployment:
     podAnnotations:
       vixens.io/fast-start: "true"
@@ -44,7 +43,6 @@ dashboard:
     readOnlyRootFilesystem: true
   podLabels:
     vixens.io/sizing.goldilocks-dashboard: V-small
-    vixens.io/priority-class: vixens-low
   deployment:
     podAnnotations:
       vixens.io/fast-start: "true"

--- a/argocd/overlays/prod/apps/goldilocks.yaml
+++ b/argocd/overlays/prod/apps/goldilocks.yaml
@@ -36,19 +36,3 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-  ignoreDifferences:
-    # goldilocks chart (v10.2.0) does not support controller/dashboard.podLabels.
-    # priorityClassName injected via kubectl patch on Deployment (not in Helm output).
-    # ignoreDifferences prevents ArgoCD from removing the field on re-sync.
-    - group: apps
-      kind: Deployment
-      name: goldilocks-controller
-      namespace: monitoring
-      jsonPointers:
-        - /spec/template/spec/priorityClassName
-    - group: apps
-      kind: Deployment
-      name: goldilocks-dashboard
-      namespace: monitoring
-      jsonPointers:
-        - /spec/template/spec/priorityClassName


### PR DESCRIPTION
## Summary

Complète le nettoyage de la gestion des `priorityClassName` pour avoir une approche uniforme et rebuild-safe via Kyverno sur toutes les apps.

### Problème corrigé

`patchStrategicMerge` sur `spec.priorityClassName` cause Go à inclure `priority: 0` implicitement → rejeté par le PriorityAdmission controller avec:
```
the integer value of priority (0) must not be provided in pod spec
```

### Changements

**`mutate-priority-class.yaml`**
- Rule 1 (generic `vixens.io/priority-class` label): `patchStrategicMerge` → `patchesJson6902`
- Rule 2 (infisical-operator): `patchStrategicMerge` → `patchesJson6902`
- Rule 3 (NEW): goldilocks controller → match `app.kubernetes.io/component: controller` → `vixens-critical`
- Rule 4 (NEW): goldilocks dashboard → match `app.kubernetes.io/component: dashboard` → `vixens-low`
- Rule 5 (NEW): cert-manager-webhook-gandi → match `app.kubernetes.io/name: cert-manager-webhook-gandi` → `vixens-critical`

**`goldilocks/values/common.yaml`**
- Suppression de `vixens.io/priority-class` dans `controller.podLabels` et `dashboard.podLabels`
- Ces labels étaient du dead config: le chart goldilocks v10.2.x ignore `controller/dashboard.podLabels`

**`argocd/overlays/prod/apps/goldilocks.yaml`**
- Suppression du bloc `ignoreDifferences` (workaround kubectl patch)
- Kyverno gère désormais l'injection de priorityClassName de façon propre

### Résultat

Toutes les apps ont désormais `priorityClassName` géré de façon uniforme:
- Charts qui supportent `podLabels` → label `vixens.io/priority-class: X` + Rule 1 Kyverno
- Charts sans support → règle Kyverno spécifique matchant les labels natifs du chart
- Zero `kubectl patch` manuel requis, rebuild-safe, idempotent

### Test post-merge

```bash
# Appliquer la policy en cluster
kubectl apply -f apps/00-infra/kyverno/base/policies/mutate-priority-class.yaml

# Rollout restart pour déclencher les nouvelles rules
kubectl rollout restart deployment/goldilocks-controller deployment/goldilocks-dashboard -n monitoring
kubectl rollout restart deployment/cert-manager-webhook-gandi -n cert-manager

# Vérifier injection
kubectl get pod -n monitoring -l app.kubernetes.io/name=goldilocks -o jsonpath='{range .items[*]}{.metadata.name}: {.spec.priorityClassName}{"\n"}{end}'
kubectl get pod -n cert-manager -l app.kubernetes.io/name=cert-manager-webhook-gandi -o jsonpath='{range .items[*]}{.metadata.name}: {.spec.priorityClassName}{"\n"}{end}'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured priority class assignment mechanism for system components to use automatic policy-based injection instead of configuration labels.
  * Simplified synchronization configuration to reflect updated priority class management approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->