### PR TITLE
fix(kyverno): use context variable in Rule 1 for patchesJson6902 compatibility

### DIFF
--- a/apps/00-infra/kyverno/base/policies/mutate-priority-class.yaml
+++ b/apps/00-infra/kyverno/base/policies/mutate-priority-class.yaml
@@ -37,24 +37,29 @@ spec:
   validationFailureAction: Audit
   background: false
   rules:
-    # Rule 1: Generic — inject priorityClassName from pod label
+    # Rule 1: Generic — inject priorityClassName from pod label vixens.io/priority-class
+    # Context variable extracts the label value (avoids JMESPath escaped quotes in patchesJson6902).
     - name: inject-priority-class-from-label
       match:
         any:
           - resources:
               kinds:
                 - Pod
+      context:
+        - name: priorityClassLabel
+          variable:
+            value: "{{ request.object.metadata.labels.\"vixens.io/priority-class\" || '' }}"
       preconditions:
         all:
           # Only act when the label is present
-          - key: "{{ request.object.metadata.labels.\"vixens.io/priority-class\" || '' }}"
+          - key: "{{ priorityClassLabel }}"
             operator: NotEquals
             value: ""
       mutate:
         patchesJson6902: |-
           - op: add
             path: /spec/priorityClassName
-            value: "{{ request.object.metadata.labels.\"vixens.io/priority-class\" }}"
+            value: "{{ priorityClassLabel }}"
 
     # Rule 2: infisical-operator — chart has no podLabels support
     # Match on existing chart label: control-plane=controller-manager in infisical-operator-system


### PR DESCRIPTION
## Problème

PR #1878 mergée avec succès sauf que le webhook Kyverno rejetait l'apply direct de la policy:

```
admission webhook "validate-policy.kyverno.svc" denied the request:
variable substitution failed for rule inject-priority-class-from-label:
failed to resolve request.object.metadata.labels.\"vixens.io/priority-class\"
at path /mutate/patchesJson6902: invalid JMESPath query: SyntaxError: Unknown char: '\\'
```

## Cause

Le champ `value` dans `patchesJson6902` ne supporte pas les guillemets JMESPath escapés inline (`\"`). Contrairement à `patchStrategicMerge` qui les accepte.

## Fix

Extraire la valeur du label dans une **context variable nommée** avant le patch, puis référencer la variable — même pattern que `sizing-v2-mutate.yaml`.

```yaml
context:
  - name: priorityClassLabel
    variable:
      value: "{{ request.object.metadata.labels.\"vixens.io/priority-class\" || '' }}"
preconditions:
  - key: "{{ priorityClassLabel }}"
    ...
mutate:
  patchesJson6902: |-
    - op: add
      path: /spec/priorityClassName
      value: "{{ priorityClassLabel }}"
```

## Validation

Policy appliquée et acceptée par le webhook Kyverno en cluster prod. Injection vérifiée:
- `goldilocks-controller`: `vixens-critical` ✅
- `goldilocks-dashboard`: `vixens-low` ✅
- `cert-manager-webhook-gandi`: `vixens-critical` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kyverno policy configuration to refactor priority class injection logic through improved context variable handling and label extraction processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->