### PR TITLE
fix: mosquitto securityContext, birdnet-go litestream race, booklore OOM

### DIFF
--- a/apps/10-home/mosquitto/base/statefulset.yaml
+++ b/apps/10-home/mosquitto/base/statefulset.yaml
@@ -46,6 +46,8 @@ spec:
                 --exclude "*.log" \
                 --exclude "lost+found/**" \
                 || true
+              # Fix ownership so mosquitto (uid 1883) can write its data files
+              chown -R 1883:1883 /mosquitto/data 2>/dev/null || true
           envFrom:
             - secretRef:
                 name: mosquitto-password-file
@@ -116,6 +118,8 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+            runAsUser: 1883
+            runAsGroup: 1883
           livenessProbe:
             tcpSocket:
               port: 1883
@@ -162,6 +166,7 @@ spec:
           operator: Exists
           effect: NoSchedule
       securityContext:
+        fsGroup: 1883
         seccompProfile:
           type: RuntimeDefault
       volumes:

--- a/apps/20-media/birdnet-go/base/deployment.yaml
+++ b/apps/20-media/birdnet-go/base/deployment.yaml
@@ -45,6 +45,26 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+        - name: litestream-restore
+          image: litestream/litestream:0.5.9
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          args:
+            - restore
+            - -config
+            - /etc/litestream.yml
+            - -if-replica-exists
+            - /data/birdnet.db
+          envFrom:
+            - secretRef:
+                name: birdnet-go-secrets
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: litestream-config
+              mountPath: /etc/litestream.yml
+              subPath: litestream.yml
       containers:
         - name: birdnet-go
           image: ghcr.io/tphakala/birdnet-go:v0.6.3

--- a/apps/20-media/booklore/base/deployment.yaml
+++ b/apps/20-media/booklore/base/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         vixens.io/fast-start: "true"
       labels:
         app: booklore
-        vixens.io/sizing.booklore: B-medium
+        vixens.io/sizing.booklore: B-large
         vixens.io/sizing.config-syncer: V-nano
         vixens.io/sizing.restore-config: B-nano
     spec:


### PR DESCRIPTION
## 3 crashes résolus

### mosquitto (344 restarts, 29h)

**Root cause:** `allowPrivilegeEscalation: false` + `capabilities.drop: ALL` empêche mosquitto de faire `setuid/setgid` pour passer à l'utilisateur `mosquitto` (uid 1883) au démarrage.

```
Error setting groups whilst dropping privileges: Operation not permitted
chown: /mosquitto/config: Operation not permitted
```

**Fix:**
- `runAsUser: 1883` + `runAsGroup: 1883` sur le container — mosquitto démarre directement en tant qu'uid 1883, pas besoin de drop privileges
- `fsGroup: 1883` sur le pod — volumes accessibles au groupe 1883
- `chown -R 1883:1883 /mosquitto/data` dans l'init container restore-data — fichiers S3 restaurés avec la bonne ownership

### birdnet-go (49 restarts, `attempt to write a readonly database`)

**Root cause:** Race condition au démarrage — litestream sidecar restaure la DB depuis S3 **en même temps** que birdnet-go tente de l'ouvrir. SQLite voit une DB partiellement restaurée et échoue.

**Fix:** Init container `litestream-restore` qui restaure la DB AVANT que birdnet-go démarre (pattern standard litestream sidecar).

Ordre: `fix-permissions` → `litestream-restore` → containers (`birdnet-go` + `litestream` sidecar)

### booklore (85 restarts, OOMKill exit 137)

**Root cause:** Sizing `B-medium` = 512Mi req / 1Gi lim. VPA recommande ~990Mi request. App OOMKillée à 1Gi limit.

**Fix:** `vixens.io/sizing.booklore: B-medium` → `B-large` (1Gi req / 2Gi lim)

> Note: changedetection scalé à 0 temporairement (auto-sync désactivé) pour libérer ~832Mi de mémoire avant le rollout booklore. À ré-activer après validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Mosquitto service configuration with enhanced file permission and security context settings.
  * Added automatic data recovery process to Birdnet-go service initialization.
  * Increased resource allocation for Booklore service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->