### PR TITLE
fix(birdnet-go): delete existing DB before litestream restore

### DIFF
--- a/apps/20-media/birdnet-go/base/deployment.yaml
+++ b/apps/20-media/birdnet-go/base/deployment.yaml
@@ -41,7 +41,7 @@ spec:
             - -c
             - |
               chown -R 1000:1000 /data
-              rm -rf /data/*.db-litestream /data/.*-litestream
+              rm -rf /data/*.db-litestream /data/.*-litestream /data/birdnet.db /data/birdnet.db-wal /data/birdnet.db-shm
           volumeMounts:
             - name: data
               mountPath: /data


### PR DESCRIPTION
litestream restore fails with 'output path already exists' when birdnet.db is present. fix-permissions must also delete the DB + WAL/SHM files so litestream-restore can download a fresh copy from S3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment initialization to thoroughly clean up database artifacts during setup, ensuring a cleaner environment for fresh deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->