### PR TITLE
fix(birdnet-go): run as uid 1000 to fix readonly database error

### DIFF
--- a/apps/20-media/birdnet-go/base/deployment.yaml
+++ b/apps/20-media/birdnet-go/base/deployment.yaml
@@ -75,6 +75,8 @@ spec:
               protocol: TCP
           securityContext:
             allowPrivilegeEscalation: false
+            runAsUser: 1000
+            runAsGroup: 1000
             capabilities:
               drop: ["ALL"]
           env:


### PR DESCRIPTION
## Problem

birdnet-go container had no `runAsUser` set — running as root (uid 0).

After litestream restores `birdnet.db` as uid 1000 (correct), birdnet-go opens
the DB and creates WAL/SHM files as root. SQLite then sees a permission mismatch
and reports `attempt to write a readonly database`, crashing on startup.

## Fix

Add `runAsUser: 1000` + `runAsGroup: 1000` to the birdnet-go container's
`securityContext`, matching all other containers in the pod (litestream sidecar,
data-syncer, and litestream-restore init container).

## Evidence

```
birdnet.db       -rw-r--r--  1000:1000   (restored by litestream init)
birdnet.db-shm   -rw-r--r--  root:1000   (created by birdnet-go running as root) ← problem
birdnet.db-wal   -rw-r--r--  root:1000   (created by birdnet-go running as root) ← problem
```

Error log:
```
attempt to write a readonly database
Error: failed to auto-migrate SQLite database: attempt to write a readonly database
```