### PR TITLE
fix(birdnet-go): set HOME env var to fix config directory lookup

### DIFF
--- a/apps/20-media/birdnet-go/base/deployment.yaml
+++ b/apps/20-media/birdnet-go/base/deployment.yaml
@@ -84,6 +84,8 @@ spec:
               value: Europe/Paris
             - name: WEB_PORT
               value: "8080"
+            - name: HOME
+              value: /home/birdnet
           volumeMounts:
             - name: config
               mountPath: /home/birdnet/.config/birdnet-go


### PR DESCRIPTION
## Problem

After fixing runAsUser=1000 (PR #1882), birdnet-go now fails with:
\`\`\`
Error loading settings: error initializing viper: error creating directories for config file: mkdir /.config: permission denied
\`\`\`

The app resolves config path as \`$HOME/.config/birdnet-go\`. When running as uid 1000 without a HOME env var, it defaults to \`/\` which is read-only.

## Fix

Add \`HOME=/home/birdnet\` to the container env. The config PVC is already mounted at \`/home/birdnet/.config/birdnet-go\` — this just tells the process where to find it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment configuration for the birdnet application deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->