### PR TITLE
fix(stirling-pdf): SB-medium→SB-large to stop OOMKill crashes

### DIFF
--- a/apps/70-tools/stirling-pdf/base/values.yaml
+++ b/apps/70-tools/stirling-pdf/base/values.yaml
@@ -12,16 +12,16 @@ replicaCount: 1
 # revisionHistoryLimit: chart template hardcodes 10; kustomize patch on Helm multi-source
 # does not apply to /spec/revisionHistoryLimit. Accepted as known limitation.
 # revisionHistoryLimit: 3  # would require chart support or ArgoCD server-side apply
-# SB-medium sizing: 512Mi req / 2Gi lim (Kyverno mutates resources via this label)
+# SB-large sizing: 1Gi req / 4Gi lim (Kyverno mutates resources via this label)
 # Note: resources below are for reference; Kyverno sizing-v2-mutate policy overrides them
-# SB-medium = 50m/500m cpu, 512Mi/2Gi mem — fits on saturated nodes, adequate for Java+LibreOffice
+# SB-large = 100m/1000m cpu, 1Gi/4Gi mem — Java+LibreOffice OOMKilled at SB-medium (2Gi)
 resources:
   requests:
     cpu: 50m
-    memory: 512Mi
+    memory: 1Gi
   limits:
     cpu: 500m
-    memory: 2Gi
+    memory: 4Gi
 priorityClassName: vixens-low
 # Tolerations for control-plane nodes if needed
 tolerations:
@@ -58,15 +58,15 @@ envs:
     value: /
   - name: SECURITY_ENABLELOGIN
     value: "false"
-  # JVM heap cap: 40% of 2Gi limit = ~820Mi heap + ~200Mi metaspace
-  # Leaves ~1Gi headroom for LibreOffice process within 2Gi container limit
+  # JVM heap cap: 50% of 4Gi limit = ~2Gi heap + ~200Mi metaspace
+  # Leaves ~1.8Gi headroom for LibreOffice process within 4Gi container limit
   - name: JAVA_TOOL_OPTIONS
-    value: "-XX:MaxRAMPercentage=40 -XX:MaxMetaspaceSize=200m -XX:+UseG1GC"
+    value: "-XX:MaxRAMPercentage=50 -XX:MaxMetaspaceSize=200m -XX:+UseG1GC"
 securityContext:
   enabled: true
   fsGroup: 1000
 podLabels:
-  vixens.io/sizing.stirling-pdf-chart: SB-medium
+  vixens.io/sizing.stirling-pdf-chart: SB-large
 podAnnotations:
   # fast-start: liveness probe confirms HTTP is ready within 30s; LibreOffice loads lazily
   vixens.io/fast-start: "true"


### PR DESCRIPTION
## Problem

stirling-pdf (Java 25 + Spring Boot 4 + LibreOffice/unoserver) consistently crashes with exit code 137 (OOMKill) within 1-2 minutes of startup.

- Current sizing: SB-medium = 512Mi request / 2Gi limit
- JVM: MaxRAMPercentage=40 → ~820Mi heap + 200Mi metaspace
- LibreOffice process adds ~800Mi-1Gi
- Total: easily exceeds 2Gi limit

## Fix

- **Sizing**: SB-medium → SB-large (1Gi request / 4Gi limit)
- **JVM**: MaxRAMPercentage 40→50 (50% of 4Gi = ~2Gi heap, comfortable)
- Two crashing pods free 2×512Mi = 1Gi of requests; new pod needs 1Gi → neutral cluster impact