### PR TITLE
chore(stirling-pdf): scale to 0 until OOMKill fixed

### DIFF
--- a/apps/70-tools/stirling-pdf/base/values.yaml
+++ b/apps/70-tools/stirling-pdf/base/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: stirlingtools/stirling-pdf
   pullPolicy: IfNotPresent
   tag: 2.7.0
-replicaCount: 1
+replicaCount: 0
 # revisionHistoryLimit: chart template hardcodes 10; kustomize patch on Helm multi-source
 # does not apply to /spec/revisionHistoryLimit. Accepted as known limitation.
 # revisionHistoryLimit: 3  # would require chart support or ArgoCD server-side apply


### PR DESCRIPTION
Disables stirling-pdf (replicaCount: 0) until memory issue is addressed. App was crashing with exit code 137 (OOMKill) — Java + LibreOffice exceeds the 2Gi container limit.