### PR TITLE
fix(netbird-dashboard): run as nginx uid 101 to fix permission crash

### DIFF
--- a/apps/40-network/netbird/base/dashboard.yaml
+++ b/apps/40-network/netbird/base/dashboard.yaml
@@ -29,6 +29,9 @@ spec:
           operator: "Exists"
           effect: "NoSchedule"
       securityContext:
+        fsGroup: 101
+        runAsUser: 101
+        runAsGroup: 101
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -36,6 +39,7 @@ spec:
           image: netbirdio/dashboard:v2.33.0
           securityContext:
             allowPrivilegeEscalation: false
+            runAsNonRoot: true
             capabilities:
               add: ["NET_BIND_SERVICE"]
               drop: ["ALL"]


### PR DESCRIPTION
## Problem

netbird-dashboard (nginx:alpine based) crashes on startup:
```
nginx: [alert] could not open error log file: open() "/var/lib/nginx/logs/error.log" failed (13: Permission denied)
mkdir() "/var/lib/nginx/tmp/client_body" failed (13: Permission denied)
```

The wave-18 nometrics annotation triggered a new Deployment rollout. Old RS pods masked the issue (still Running on pearl). New RS pods consistently fail because nginx expects to run as uid 101 (the nginx user in alpine images).

## Fix

Set pod-level `securityContext.runAsUser/runAsGroup/fsGroup: 101` (nginx uid in alpine). Directories are then pre-owned by uid 101, and the nginx process can write to them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security configuration for the dashboard deployment with hardened privilege restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->