### PR TITLE
fix(netbird-dashboard): emptyDir /var/lib/nginx + initContainer (repl. #1886)

### DIFF
--- a/apps/40-network/netbird/base/dashboard.yaml
+++ b/apps/40-network/netbird/base/dashboard.yaml
@@ -29,17 +29,23 @@ spec:
           operator: "Exists"
           effect: "NoSchedule"
       securityContext:
-        fsGroup: 101
-        runAsUser: 101
-        runAsGroup: 101
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+        - name: fix-nginx-dirs
+          image: busybox:1.37.0
+          command:
+            - sh
+            - -c
+            - mkdir -p /var/lib/nginx/logs /var/lib/nginx/tmp && chmod -R 777 /var/lib/nginx
+          volumeMounts:
+            - name: nginx-tmp
+              mountPath: /var/lib/nginx
       containers:
         - name: dashboard
           image: netbirdio/dashboard:v2.33.0
           securityContext:
             allowPrivilegeEscalation: false
-            runAsNonRoot: true
             capabilities:
               add: ["NET_BIND_SERVICE"]
               drop: ["ALL"]
@@ -56,6 +62,12 @@ spec:
           ports:
             - containerPort: 80
               name: http
+          volumeMounts:
+            - name: nginx-tmp
+              mountPath: /var/lib/nginx
+      volumes:
+        - name: nginx-tmp
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Problem

PR #1886 (runAsUser: 101) failed: supervisord in the netbirdio/dashboard image requires root to manage processes.

## Root Cause

`/var/lib/nginx` in the container image has restrictive permissions. nginx cannot create logs/ or tmp/ directories at startup.

## Fix

- Mount **emptyDir** at `/var/lib/nginx` (clean writable dir per pod start)
- **busybox initContainer** pre-creates `logs/` and `tmp/` with `chmod 777`
- Container runs as root (required by supervisord), no extra capabilities needed

Supersedes #1886.