### PR TITLE
fix(netbird-dashboard): add CHOWN/SETUID/SETGID caps for nginx startup

### DIFF
--- a/apps/40-network/netbird/base/dashboard.yaml
+++ b/apps/40-network/netbird/base/dashboard.yaml
@@ -47,7 +47,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
-              add: ["NET_BIND_SERVICE"]
+              add: ["NET_BIND_SERVICE", "CHOWN", "SETUID", "SETGID"]
               drop: ["ALL"]
           livenessProbe:
             tcpSocket:


### PR DESCRIPTION
nginx chowns /var/lib/nginx/tmp to uid 100 at startup. Without CAP_CHOWN, this fails with 'Operation not permitted'. SETUID/SETGID needed for master→worker user switching. Builds on emptyDir fix from #1887.