### PR TITLE
fix(prometheus): ignore maxSurge:0 DaemonSet drift in ArgoCD

### DIFF
--- a/argocd/overlays/prod/apps/prometheus.yaml
+++ b/argocd/overlays/prod/apps/prometheus.yaml
@@ -36,3 +36,9 @@ spec:
     syncOptions:
       - CreateNamespace=false
       - ServerSideApply=true
+  ignoreDifferences:
+    - group: apps
+      kind: DaemonSet
+      name: prometheus-prometheus-node-exporter
+      jsonPointers:
+        - /spec/updateStrategy/rollingUpdate/maxSurge


### PR DESCRIPTION
## Summary

Permanent fix for the persistent `prometheus` app `OutOfSync` on the node-exporter DaemonSet.

## Root Cause

Kubernetes auto-defaults `updateStrategy.rollingUpdate.maxSurge: 0` on all DaemonSets. The `prometheus-node-exporter` Helm chart does **not** emit this field — it only sets `maxUnavailable: 1`. This means:

- **Desired state** (Helm template): no `maxSurge` field
- **Live state** (K8s): `maxSurge: 0` (auto-added by K8s defaulting)

ArgoCD detects this as a perpetual diff, causing `OutOfSync` that can never be resolved by re-syncing.

## Fix

Added `ignoreDifferences` for the specific jsonPointer `/spec/updateStrategy/rollingUpdate/maxSurge` on the `prometheus-prometheus-node-exporter` DaemonSet.

This is the canonical ArgoCD solution for K8s-defaulted fields that aren't in the Helm chart template. See: [ArgoCD docs — ignoreDifferences](https://argo-cd.readthedocs.io/en/stable/user-guide/diffing/#application-level-configuration)

`ServerSideApply=true` (added in PR #1890) is kept — it benefits other resources in the app.

## Testing

- yamllint: clean
- No functional change to the workload