### PR TITLE
fix(prometheus): ignore StatefulSet alertmanager K8s-defaulted fields

### DIFF
--- a/argocd/overlays/prod/apps/prometheus.yaml
+++ b/argocd/overlays/prod/apps/prometheus.yaml
@@ -42,3 +42,9 @@ spec:
       name: prometheus-prometheus-node-exporter
       jsonPointers:
         - /spec/updateStrategy/rollingUpdate/maxSurge
+    - group: apps
+      kind: StatefulSet
+      name: prometheus-alertmanager
+      jsonPointers:
+        - /spec/updateStrategy/rollingUpdate/partition
+        - /spec/persistentVolumeClaimRetentionPolicy


### PR DESCRIPTION
## Summary

Follow-up to #1891. Expands `ignoreDifferences` to cover the `prometheus-alertmanager` StatefulSet which has the same K8s-defaulting issue.

## Fields Ignored

- `/spec/updateStrategy/rollingUpdate/partition` — K8s auto-defaults to `0` on StatefulSets, not emitted by Helm chart
- `/spec/persistentVolumeClaimRetentionPolicy` — K8s auto-defaults to `{whenDeleted: Retain, whenScaled: Retain}`, not in Helm chart

These fields cause perpetual `OutOfSync` that cannot be resolved by syncing.

## Testing

- yamllint: clean
- No functional change to workloads