### PR TITLE
fix(prometheus): remove ServerSideApply, keep ignoreDifferences

### DIFF
--- a/argocd/overlays/prod/apps/prometheus.yaml
+++ b/argocd/overlays/prod/apps/prometheus.yaml
@@ -35,7 +35,6 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=false
-      - ServerSideApply=true
   ignoreDifferences:
     - group: apps
       kind: DaemonSet


### PR DESCRIPTION
## Summary

SSA (`ServerSideApply=true`) combined with `jsonPointers`-based `ignoreDifferences` has conflicts in ArgoCD when the Helm chart doesn't own the defaulted fields.

Remove `ServerSideApply=true` from prometheus syncOptions. Keep `ignoreDifferences` for the K8s-defaulted fields (DaemonSet `maxSurge`, StatefulSet `partition` + `pvcRetentionPolicy`).

With standard apply mode, `ignoreDifferences` with `jsonPointers` works correctly and the app should show `Synced`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application synchronization configuration, which may affect how configuration patches are applied during deployments and how conflicts are resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->