### PR TITLE
fix(prometheus): use jqPathExpressions for DaemonSet maxSurge ignoreDifferences

### DIFF
--- a/argocd/overlays/prod/apps/prometheus.yaml
+++ b/argocd/overlays/prod/apps/prometheus.yaml
@@ -39,8 +39,8 @@ spec:
     - group: apps
       kind: DaemonSet
       name: prometheus-prometheus-node-exporter
-      jsonPointers:
-        - /spec/updateStrategy/rollingUpdate/maxSurge
+      jqPathExpressions:
+        - .spec.updateStrategy.rollingUpdate.maxSurge
     - group: apps
       kind: StatefulSet
       name: prometheus-alertmanager


### PR DESCRIPTION
jsonPointers didn't catch the DaemonSet maxSurge drift (IntOrString type). Switching to jqPathExpressions which handles absent-vs-zero correctly.