### PR TITLE
fix(prometheus): correct nodeExporter subchart key + fix resources/priority

### DIFF
--- a/apps/02-monitoring/prometheus/base/values.yaml
+++ b/apps/02-monitoring/prometheus/base/values.yaml
@@ -95,12 +95,15 @@ alertmanager:
           - api_url_file: /etc/alertmanager-secrets/DISCORD_WEBHOOK_URL
             channel: '#alerts'
             send_resolved: true
-# Node exporter
-nodeExporter:
+# Node exporter (prometheus-node-exporter subchart, chart 25.x)
+prometheus-node-exporter:
   enabled: true
   priorityClassName: vixens-critical
   podAnnotations:
     vixens.io/fast-start: "true"
+  # Silence ArgoCD drift on K8s-defaulted DaemonSet fields (maxSurge:0)
+  daemonsetAnnotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
   tolerations:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists

--- a/argocd/overlays/prod/apps/prometheus.yaml
+++ b/argocd/overlays/prod/apps/prometheus.yaml
@@ -37,11 +37,6 @@ spec:
       - CreateNamespace=false
   ignoreDifferences:
     - group: apps
-      kind: DaemonSet
-      name: prometheus-prometheus-node-exporter
-      jqPathExpressions:
-        - .spec.updateStrategy.rollingUpdate.maxSurge
-    - group: apps
       kind: StatefulSet
       name: prometheus-alertmanager
       jsonPointers:


### PR DESCRIPTION
## Summary

Two fixes in one:

### 1. Correct subchart key for node-exporter

The prometheus chart 25.x uses `prometheus-node-exporter:` (subchart key), not `nodeExporter:`. Our values.yaml had `nodeExporter:` which was **silently ignored** by Helm, leaving the node-exporter DaemonSet with:
- `resources: {}` (no limits/requests — unmanaged memory)
- No `priorityClassName: vixens-critical`
- No `vixens.io/fast-start: "true"` annotation

### 2. Fix ArgoCD DaemonSet OutOfSync (maxSurge drift)

Kubernetes auto-defaults `updateStrategy.rollingUpdate.maxSurge: 0` on DaemonSets but the chart doesn't emit it. This causes a perpetual `OutOfSync` that `ignoreDifferences` (jsonPointers + jqPathExpressions) couldn't catch.

**Fix**: Add `daemonsetAnnotations: { argocd.argoproj.io/compare-options: IgnoreExtraneous }` to the node-exporter subchart config. This annotation on the DaemonSet itself tells ArgoCD to ignore extra live fields not present in desired state.

The DaemonSet `ignoreDifferences` entry is removed from the ArgoCD Application — the annotation is cleaner.

## Testing

- yamllint: clean
- No workload disruption — DaemonSet will be updated with resources/priority on next sync