### PR TITLE
fix(kyverno): resolve goldilocks-controller priority conflict (Degraded)

### DIFF
--- a/apps/00-infra/kyverno/base/policies/mutate-priority-class.yaml
+++ b/apps/00-infra/kyverno/base/policies/mutate-priority-class.yaml
@@ -16,6 +16,10 @@
 #   patchStrategicMerge on spec.priorityClassName causes Go to include priority: 0 implicitly,
 #   which the PriorityAdmission controller rejects. patchesJson6902 with op: add sets only the
 #   requested field, no side effects.
+#   Exception: for rules that inject priorityClassName via Kyverno mutation (not baked-in chart),
+#   K8s defaults priority: 0 BEFORE the webhook runs. The PriorityAdmission controller then sees
+#   both priority: 0 and priorityClassName → conflict → 403 Forbidden.
+#   Fix: also patch priority: <value> explicitly so it matches the PriorityClass value.
 #
 # Why this approach:
 #   In ArgoCD multi-source, kustomize source 2 cannot patch resources rendered by
@@ -110,6 +114,12 @@ spec:
           - op: add
             path: /spec/priorityClassName
             value: "vixens-critical"
+          # K8s defaults priority: 0 before webhook runs; must set explicit value to avoid
+          # PriorityAdmission conflict: "integer value of priority (0) must not be provided
+          # when priorityClassName is set" → 403 Forbidden.
+          - op: add
+            path: /spec/priority
+            value: 100000
 
     # Rule 4: goldilocks dashboard — chart (v10.2.x) ignores dashboard.podLabels
     - name: inject-priority-class-goldilocks-dashboard


### PR DESCRIPTION
## Problem

`goldilocks` ArgoCD app is `Synced Degraded`. The `goldilocks-controller` Deployment has a `ReplicaFailure`:

```
pods "goldilocks-controller-58bc586654-" is forbidden: the integer value of priority (0)
must not be provided in pod spec; priority admission controller computed 100000
from the given PriorityClass name
```

## Root Cause

K8s defaults `priority: 0` on pod admission **before** the Kyverno mutation webhook runs.

The Kyverno rule `inject-priority-class-goldilocks-controller` adds `priorityClassName: vixens-critical` via `patchesJson6902`. The PriorityAdmission controller then sees:
- `priority: 0` (K8s default)
- `priorityClassName: vixens-critical` (computed value: 100000)

These conflict → 403 Forbidden.

The old RS (revision 14) had `priorityClassName: vixens-critical` baked-in from ArgoCD sync (chart rendered it somehow), so Kyverno precondition was false → no conflict. New RS (revision 15) doesn't have it baked-in → Kyverno tries to inject → conflict.

## Fix

Also patch `/spec/priority: 100000` in the `patchesJson6902` for the goldilocks-controller rule. This ensures both `priority` and `priorityClassName` match the PriorityClass value → no conflict.

```yaml
mutate:
  patchesJson6902: |-
    - op: add
      path: /spec/priorityClassName
      value: "vixens-critical"
    - op: add
      path: /spec/priority
      value: 100000   # ← new: matches vixens-critical.value
```

## Files Changed

- `apps/00-infra/kyverno/base/policies/mutate-priority-class.yaml` — Rule 3 `inject-priority-class-goldilocks-controller`

## Expected Result

After ArgoCD syncs Kyverno policy:
- New goldilocks-controller pods can be created
- RS `58bc586654` becomes `1/1 Ready`
- `goldilocks` app goes `Synced Healthy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pod priority handling to prevent admission conflicts and ensure consistent priority value assignment in Kubernetes cluster scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->