### PR TITLE
fix(it-tools): restore ingress + remove it-tools-ingress duplicate ArgoCD app

### DIFF
--- a/apps/70-tools/it-tools/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/it-tools/overlays/prod/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 namespace: tools
 resources:
   - ../../base
+  - ingress.yaml
 
 components:
   - ../../../../_shared/components/revision-history-limit

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -81,7 +81,7 @@ resources:
   - apps/renovate.yaml
   - apps/stirling-pdf.yaml
   - apps/it-tools.yaml
-  - apps/it-tools-ingress.yaml
+  # apps/it-tools-ingress.yaml removed 2026-03-07 — ingress now managed by it-tools app directly (overlays/prod/kustomization.yaml)
   - apps/contacts.yaml
   - apps/external-dns-gandi.yaml
   - apps/external-dns-gandi-secrets.yaml


### PR DESCRIPTION
## Problem

`it-tools-ingress` ArgoCD app is `OutOfSync` with error:
```
Skipping sync attempt: auto-sync will wipe out all resources
```

`it-tools` app manages `ConfigMap`, `Service`, `Deployment` — but **no Ingress** exists in the cluster. `it-tools.truxonline.com` is unreachable.

## Root Cause

PR #1890 removed `ingress.yaml` from `it-tools/overlays/prod/kustomization.yaml` to fix double-ownership (both `it-tools` and `it-tools-ingress` apps pointing to same overlay path). But `ingress.yaml` was not re-added under a single owner → ingress disappeared entirely.

The `it-tools-ingress` ArgoCD app still points to the same overlay, now sees 0 resources → ArgoCD refuses auto-sync (would prune everything).

## Fix

1. **Re-add `ingress.yaml`** to `it-tools/overlays/prod/kustomization.yaml` — `it-tools` app is the single owner
2. **Remove `it-tools-ingress`** from `argocd/overlays/prod/kustomization.yaml` — eliminates the duplicate app
3. ArgoCD App-of-Apps will prune the `it-tools-ingress` Application CRD on next sync

## Expected Result

- `it-tools` app: `Synced Healthy` with Ingress included
- `it-tools-ingress` Application CRD deleted (pruned by App-of-Apps)
- `it-tools.truxonline.com` accessible again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized ingress configuration management—moved from centralized configuration to direct management within the it-tools application for improved modularity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->