### PR TITLE
fix(kyverno): add missing validationFailureAction to mutate-revision-history-limit

### DIFF
--- a/apps/00-infra/kyverno/base/policies/mutate-revision-history-limit.yaml
+++ b/apps/00-infra/kyverno/base/policies/mutate-revision-history-limit.yaml
@@ -15,6 +15,7 @@ metadata:
       ignoreDifferences to prevent drift detection on Helm-managed charts that do not
       support this value natively.
 spec:
+  validationFailureAction: Audit
   background: true
   rules:
     - name: set-revision-history-limit-deployment


### PR DESCRIPTION
## Problem

`kyverno` ArgoCD app is `OutOfSync` on `ClusterPolicy/mutate-revision-history-limit`.

## Root Cause

All other ClusterPolicies in this repo explicitly set `validationFailureAction: Audit`. `mutate-revision-history-limit.yaml` was missing it. Kyverno defaults `validationFailureAction: Audit` on the cluster, creating a diff that ArgoCD detects.

## Fix

Add `validationFailureAction: Audit` to `mutate-revision-history-limit.yaml`, consistent with all other policies.

## Expected Result

`kyverno` ArgoCD app goes `Synced Healthy`.