### PR TITLE
fix: kyverno priority apiCall + cert-manager-secrets ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,7 @@ Before closing a task, EVERY agent MUST complete this checklist:
 [ ] 1. Code changes made
 [ ] 2. yamllint passed (just lint)
 [ ] 3. Kustomize build OK (kustomize build apps/<app>/overlays/dev)
+[ ] 3b. Kustomize kinds diff OK: after any kustomization.yaml change, compare `kustomize build` output kinds before/after — a missing kind means a resource was silently dropped (regression like it-tools ingress removal)
 [ ] 4. Git committed to dev branch
 [ ] 5. Pushed to remote (git push origin main)
 [ ] 6. ArgoCD synced (verify in cluster)
@@ -272,6 +273,12 @@ Before closing a task, EVERY agent MUST complete this checklist:
 ```
 
 **⭐ CRITICAL:** Steps 8-9 (documentation) are NOT optional. If you deployed it, document it.
+
+**⭐ KUSTOMIZE DIFF RULE:** After any `kustomization.yaml` change (add/remove resources, patches, components), run:
+```bash
+kustomize build apps/<app>/overlays/<env> | grep '^kind:' | sort
+```
+Compare kinds before/after. A missing `kind` means a resource was silently dropped. This catches regressions like accidental ingress/secret removal that yamllint cannot detect.
 
 ---
 

--- a/apps/00-infra/cert-manager-webhook-gandi/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/overlays/prod/kustomization.yaml
@@ -2,6 +2,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cert-manager
+# NOTE: This overlay is used by ArgoCD app 'cert-manager-webhook-gandi' (wave 1, Helm multi-source).
+# It patches the Helm-rendered Deployment with ArgoCD sync-wave + Goldilocks VPA annotations.
+#
 # Cert-manager-webhook-gandi (SINTEF v0.5.2) does not support podAnnotations/podLabels in chart.
 # Pod annotations (vixens.io/fast-start, nometrics, service-binding) are injected via:
 #   → mutate-pod-annotations Kyverno policy (match: app.kubernetes.io/name=cert-manager-webhook-gandi)
@@ -9,8 +12,12 @@ namespace: cert-manager
 #   → mutate-priority-class Kyverno policy (chart match on cert-manager namespace)
 # NOTE: strategic merge patch on spec.template.metadata.annotations is dead code in ArgoCD multi-source.
 #
+# The InfisicalSecret (gandi-credentials-sync) is managed by a SEPARATE ArgoCD app:
+#   cert-manager-secrets → apps/00-infra/cert-manager-webhook-gandi/secrets/prod
+# Do NOT add resources: ../../base here (was causing SharedResourceWarning double ownership).
+#
 patches:
-  # Patch 2: Deployment-level annotations (ArgoCD wave, Goldilocks VPA)
+  # Patch: Deployment-level annotations (ArgoCD wave, Goldilocks VPA)
   - patch: |-
       - op: add
         path: /metadata/annotations/argocd.argoproj.io~1sync-wave
@@ -24,5 +31,3 @@ patches:
     target:
       kind: Deployment
       name: cert-manager-webhook-gandi
-resources:
-  - ../../base

--- a/apps/00-infra/cert-manager-webhook-gandi/secrets/prod/gandi-infisical-secret-patch.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/secrets/prod/gandi-infisical-secret-patch.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: gandi-credentials-sync
+  namespace: cert-manager
+spec:
+  authentication:
+    universalAuth:
+      secretsScope:
+        envSlug: prod # Changed from 'dev' to 'prod'
+  managedSecretReference:
+    secretNamespace: cert-manager

--- a/apps/00-infra/cert-manager-webhook-gandi/secrets/prod/kustomization.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/secrets/prod/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cert-manager
+resources:
+  - ../../base
+patches:
+  - path: gandi-infisical-secret-patch.yaml

--- a/apps/00-infra/kyverno/base/policies/mutate-priority-class.yaml
+++ b/apps/00-infra/kyverno/base/policies/mutate-priority-class.yaml
@@ -1,7 +1,7 @@
 ---
 # Kyverno Policy: Mutate Priority Class
 #
-# Injects spec.priorityClassName into pods based on a pod label.
+# Injects spec.priorityClassName (and spec.priority) into pods based on a pod label.
 #
 # Generic rule (works for charts that support podLabels):
 #   Add label to pod template:  vixens.io/priority-class: vixens-critical
@@ -20,6 +20,11 @@
 #   K8s defaults priority: 0 BEFORE the webhook runs. The PriorityAdmission controller then sees
 #   both priority: 0 and priorityClassName → conflict → 403 Forbidden.
 #   Fix: also patch priority: <value> explicitly so it matches the PriorityClass value.
+#
+# Why apiCall for priority value (DRY):
+#   The numeric priority value is read from the PriorityClass object (source of truth).
+#   This keeps rules consistent with _shared/priority-classes/ definitions.
+#   Fallback value (100000) is used if the apiCall fails (e.g. during cluster bootstrap).
 #
 # Why this approach:
 #   In ArgoCD multi-source, kustomize source 2 cannot patch resources rendered by
@@ -43,6 +48,9 @@ spec:
   rules:
     # Rule 1: Generic — inject priorityClassName from pod label vixens.io/priority-class
     # Context variable extracts the label value (avoids JMESPath escaped quotes in patchesJson6902).
+    # WARNING: This generic rule does NOT patch spec.priority. It is only safe for PriorityClasses
+    # with value=0 (e.g. vixens-low), which match the K8s default priority and cause no conflict.
+    # For non-zero PriorityClasses, create a dedicated rule with apiCall (see rules 2, 3, 5).
     - name: inject-priority-class-from-label
       match:
         any:
@@ -67,6 +75,8 @@ spec:
 
     # Rule 2: infisical-operator — chart has no podLabels support
     # Match on existing chart label: control-plane=controller-manager in infisical-operator-system
+    # Reads priority value from PriorityClass API (DRY — source of truth: _shared/priority-classes/).
+    # Fallback: 100000 if apiCall fails (e.g. bootstrap ordering).
     - name: inject-priority-class-infisical-operator
       match:
         any:
@@ -78,6 +88,11 @@ spec:
               selector:
                 matchLabels:
                   control-plane: controller-manager
+      context:
+        - name: priorityValue
+          apiCall:
+            urlPath: "/apis/scheduling.k8s.io/v1/priorityclasses/vixens-critical"
+            jmesPath: "value || `100000`"
       preconditions:
         all:
           # Only inject if not already set (idempotent)
@@ -89,9 +104,14 @@ spec:
           - op: add
             path: /spec/priorityClassName
             value: "vixens-critical"
+          - op: add
+            path: /spec/priority
+            value: "{{ priorityValue }}"
 
     # Rule 3: goldilocks controller — chart (v10.2.x) ignores controller.podLabels
     # Match on chart-native labels: app.kubernetes.io/name + app.kubernetes.io/component
+    # Reads priority value from PriorityClass API (DRY — source of truth: _shared/priority-classes/).
+    # Fallback: 100000 if apiCall fails (e.g. bootstrap ordering).
     - name: inject-priority-class-goldilocks-controller
       match:
         any:
@@ -104,6 +124,11 @@ spec:
                 matchLabels:
                   app.kubernetes.io/name: goldilocks
                   app.kubernetes.io/component: controller
+      context:
+        - name: priorityValue
+          apiCall:
+            urlPath: "/apis/scheduling.k8s.io/v1/priorityclasses/vixens-critical"
+            jmesPath: "value || `100000`"
       preconditions:
         all:
           - key: "{{ request.object.spec.priorityClassName || '' }}"
@@ -114,14 +139,12 @@ spec:
           - op: add
             path: /spec/priorityClassName
             value: "vixens-critical"
-          # K8s defaults priority: 0 before webhook runs; must set explicit value to avoid
-          # PriorityAdmission conflict: "integer value of priority (0) must not be provided
-          # when priorityClassName is set" → 403 Forbidden.
           - op: add
             path: /spec/priority
-            value: 100000
+            value: "{{ priorityValue }}"
 
     # Rule 4: goldilocks dashboard — chart (v10.2.x) ignores dashboard.podLabels
+    # vixens-low = value 0 = K8s default → no PriorityAdmission conflict, no need to patch priority.
     - name: inject-priority-class-goldilocks-dashboard
       match:
         any:
@@ -147,6 +170,8 @@ spec:
 
     # Rule 5: cert-manager-webhook-gandi (SINTEF v0.5.x) — no podLabels/podAnnotations in chart
     # Match on chart-native label: app.kubernetes.io/name in cert-manager namespace
+    # Reads priority value from PriorityClass API (DRY — source of truth: _shared/priority-classes/).
+    # Fallback: 100000 if apiCall fails (e.g. bootstrap ordering).
     - name: inject-priority-class-cert-manager-webhook-gandi
       match:
         any:
@@ -158,6 +183,11 @@ spec:
               selector:
                 matchLabels:
                   app.kubernetes.io/name: cert-manager-webhook-gandi
+      context:
+        - name: priorityValue
+          apiCall:
+            urlPath: "/apis/scheduling.k8s.io/v1/priorityclasses/vixens-critical"
+            jmesPath: "value || `100000`"
       preconditions:
         all:
           - key: "{{ request.object.spec.priorityClassName || '' }}"
@@ -168,3 +198,6 @@ spec:
           - op: add
             path: /spec/priorityClassName
             value: "vixens-critical"
+          - op: add
+            path: /spec/priority
+            value: "{{ priorityValue }}"

--- a/argocd/overlays/prod/apps/cert-manager-secrets.yaml
+++ b/argocd/overlays/prod/apps/cert-manager-secrets.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     repoURL: https://github.com/charchess/vixens.git
     targetRevision: prod-stable
-    path: apps/00-infra/cert-manager-webhook-gandi/overlays/prod
+    path: apps/00-infra/cert-manager-webhook-gandi/secrets/prod
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Summary

Clôture les 4 items de l'audit post-stabilisation cluster prod.

### Item 1+2+goldilocks — Kyverno: priority dynamique via apiCall (DRY)

**Problème:** Les rules Kyverno qui injectent `priorityClassName` sans patcher `priority` causent un conflit 403 (`PriorityAdmission: integer value of priority (0) must not be provided when priorityClassName is set`). De plus, la valeur numérique était hardcodée, pas liée aux définitions `_shared/priority-classes/`.

**Fix:**
- Rules 2, 3, 5 (`infisical-operator`, `goldilocks-controller`, `cert-manager-webhook-gandi`): ajout `context.apiCall` qui lit `value` depuis `PriorityClass/vixens-critical` (source de vérité). Fallback `100000` si apiCall échoue au bootstrap.
- Rule 3 (goldilocks-controller, déjà corrigée en PR #1896 avec hardcode): convertie vers apiCall pour cohérence.
- Rule 1 (générique): commentaire WARNING ajouté — safe uniquement pour classes de valeur 0.
- Rule 4 (goldilocks-dashboard, vixens-low=0): pas de changement nécessaire.

### Item 3 — cert-manager-secrets double ownership (SharedResourceWarning)

**Problème:** Deux ArgoCD apps pointaient vers le même overlay et produisaient le même `InfisicalSecret/gandi-credentials-sync` → `SharedResourceWarning` → risque de prune accidentel du secret TLS.

**Fix:**
- Création de `apps/00-infra/cert-manager-webhook-gandi/secrets/prod/` avec overlay dédié (InfisicalSecret uniquement).
- `overlays/prod/` : retrait de `resources: ../../base` (ne gardait que les patches Deployment pour ArgoCD wave + Goldilocks VPA).
- ArgoCD app `cert-manager-secrets` redirigée vers `secrets/prod/`.

### Item 4 — CI validation gap (AGENTS.md)

**Problème:** La régression it-tools (ingress silencieusement supprimé après modification kustomization.yaml) n'aurait pas été détectée par yamllint.

**Fix:** Ajout dans AGENTS.md :
- Étape 3b au mandatory checklist : comparer les `kind:` produits par `kustomize build` avant/après toute modification de `kustomization.yaml`.
- Section KUSTOMIZE DIFF RULE avec commande concrète.

## Test plan

- `yamllint` : OK (warnings line-length sur commentaires uniquement)
- `kustomize build apps/00-infra/cert-manager-webhook-gandi/secrets/prod` : produit `InfisicalSecret` avec `envSlug: prod` ✅
- `kustomize build apps/00-infra/cert-manager-webhook-gandi/overlays/prod` : 0 resources (patches Deployment dead-code en multi-source, normal) ✅
- Après merge : ArgoCD `cert-manager-secrets` doit passer `Synced Healthy` sans `SharedResourceWarning`
- Kyverno rules 2, 3, 5 : au prochain pod restart, `spec.priority` sera injecté depuis l'API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new checklist item and guidance for validating deployment configuration changes.

* **New Features**
  * Implemented dynamic priority allocation for critical workloads with automatic fallback behavior.
  * Added secret management configuration for production environments.

* **Updates**
  * Enhanced deployment annotations for resource optimization and orchestration.
  * Updated application deployment path for improved configuration organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->