### PR TITLE
fix(kyverno): correct spec.priority type in apiCall rules (string → int32)

### DIFF
--- a/apps/00-infra/kyverno/base/policies/mutate-priority-class.yaml
+++ b/apps/00-infra/kyverno/base/policies/mutate-priority-class.yaml
@@ -24,7 +24,7 @@
 # Why apiCall for priority value (DRY):
 #   The numeric priority value is read from the PriorityClass object (source of truth).
 #   This keeps rules consistent with _shared/priority-classes/ definitions.
-#   Fallback value (100000) is used if the apiCall fails (e.g. during cluster bootstrap).
+#   Fallback value (100000) is used if the PriorityClass object exists but has no value field.
 #
 # Why this approach:
 #   In ArgoCD multi-source, kustomize source 2 cannot patch resources rendered by
@@ -76,7 +76,7 @@ spec:
     # Rule 2: infisical-operator — chart has no podLabels support
     # Match on existing chart label: control-plane=controller-manager in infisical-operator-system
     # Reads priority value from PriorityClass API (DRY — source of truth: _shared/priority-classes/).
-    # Fallback: 100000 if apiCall fails (e.g. bootstrap ordering).
+    # If the apiCall HTTP request fails, failurePolicy:Ignore on the Kyverno webhook admits the pod
     - name: inject-priority-class-infisical-operator
       match:
         any:
@@ -106,12 +106,12 @@ spec:
             value: "vixens-critical"
           - op: add
             path: /spec/priority
-            value: "{{ priorityValue }}"
+            value: {{ priorityValue }}
 
     # Rule 3: goldilocks controller — chart (v10.2.x) ignores controller.podLabels
     # Match on chart-native labels: app.kubernetes.io/name + app.kubernetes.io/component
     # Reads priority value from PriorityClass API (DRY — source of truth: _shared/priority-classes/).
-    # Fallback: 100000 if apiCall fails (e.g. bootstrap ordering).
+    # If the apiCall HTTP request fails, failurePolicy:Ignore on the Kyverno webhook admits the pod
     - name: inject-priority-class-goldilocks-controller
       match:
         any:
@@ -141,7 +141,7 @@ spec:
             value: "vixens-critical"
           - op: add
             path: /spec/priority
-            value: "{{ priorityValue }}"
+            value: {{ priorityValue }}
 
     # Rule 4: goldilocks dashboard — chart (v10.2.x) ignores dashboard.podLabels
     # vixens-low = value 0 = K8s default → no PriorityAdmission conflict, no need to patch priority.
@@ -171,7 +171,7 @@ spec:
     # Rule 5: cert-manager-webhook-gandi (SINTEF v0.5.x) — no podLabels/podAnnotations in chart
     # Match on chart-native label: app.kubernetes.io/name in cert-manager namespace
     # Reads priority value from PriorityClass API (DRY — source of truth: _shared/priority-classes/).
-    # Fallback: 100000 if apiCall fails (e.g. bootstrap ordering).
+    # If the apiCall HTTP request fails, failurePolicy:Ignore on the Kyverno webhook admits the pod
     - name: inject-priority-class-cert-manager-webhook-gandi
       match:
         any:
@@ -200,4 +200,4 @@ spec:
             value: "vixens-critical"
           - op: add
             path: /spec/priority
-            value: "{{ priorityValue }}"
+            value: {{ priorityValue }}


### PR DESCRIPTION
## Bug

Dans les rules Kyverno avec apiCall introduites en #1899, le patch \`spec.priority\` utilisait des guillemets autour de la variable JMESPath :

\`\`\`yaml
- op: add
  path: /spec/priority
  value: "{{ priorityValue }}"   # ← YAML string après substitution
\`\`\`

Après substitution par Kyverno, ça produit \`value: "100000"\` → YAML parse ça comme une **string**. Kubernetes rejette le champ \`spec.priority\` (int32) si la valeur est une string → **403 Forbidden** au prochain pod restart — exactement le problème qu'on voulait corriger.

## Fix

\`\`\`yaml
- op: add
  path: /spec/priority
  value: {{ priorityValue }}     # ← YAML integer après substitution
\`\`\`

Sans guillemets. Kyverno fait la substitution texte *avant* le parsing YAML du bloc \`|-\`. Résultat : \`value: 100000\` → YAML integer → compatible \`int32\`.

Les guillemets restent corrects pour \`spec.priorityClassName\` (string field).

## Également corrigé

Commentaire trompeur : \`|| \`100000\`\` en JMESPath gère le cas où le champ \`value\` est absent dans la réponse API — pas l'échec HTTP du call. Les échecs HTTP sont gérés par \`failurePolicy:Ignore\` au niveau de l'installation Kyverno.

## Règles concernées

- Rule 2: inject-priority-class-infisical-operator  
- Rule 3: inject-priority-class-goldilocks-controller  
- Rule 5: inject-priority-class-cert-manager-webhook-gandi

## Référence

Bug détecté lors d'un audit post-#1899. Aucun pod n'a encore redémarré donc pas d'impact en production observé — correction préventive.