### PR TITLE
fix(argocd/kyverno): ignoreDifferences context[]? null-safe jq

### DIFF
--- a/argocd/overlays/prod/apps/kyverno.yaml
+++ b/argocd/overlays/prod/apps/kyverno.yaml
@@ -152,8 +152,8 @@ spec:
         - .spec.emitWarning
         - .spec.rules[].skipBackgroundRequests
         - .spec.rules[].validate.allowExistingViolations
-        - .spec.rules[].context[].apiCall.method
-        - .spec.rules[].validate.foreach[].context[].apiCall.method
+        - .spec.rules[].context[]?.apiCall.method
+        - .spec.rules[].validate.foreach[]?.context[]?.apiCall.method
         - .spec.rules[].match.any[].resources.group
         - .spec.rules[].match.any[].resources.namespaces
         - .spec.rules[].match.any[].resources.namespaceSelector


### PR DESCRIPTION
## Bug

La règle goldilocks-dashboard (\`inject-priority-class-goldilocks-dashboard\`) n'a pas de \`context:\` (pas d'apiCall). Les autres règles apiCall en ont.

Le jqPathExpression \`.spec.rules[].context[].apiCall.method\` échoue pour cette règle car \`.context\` est null → \`null | .[]\` lève une erreur en go-jq → l'expression est ignorée → \`method: GET\` ajouté par Kyverno **n'est pas ignoré** → \`mutate-priority-class\` OutOfSync permanent depuis #1900 (qui a introduit les apiCall contexts dans 3 règles).

Les autres policies avec apiCall (check-networkpolicy, etc.) sont Synced car TOUTES leurs règles ont un \`context\`. La présence d'une règle **sans** context dans la même policy casse l'expression jq pour toute la policy.

## Fix

\`[]?\` (optional iterator) en go-jq : \`null | .[]?\` retourne vide sans erreur.

\`\`\`yaml
# Before
- .spec.rules[].context[].apiCall.method
# After  
- .spec.rules[].context[]?.apiCall.method
\`\`\`

## Après merge

Nécessite \`kubectl apply --server-side --force-conflicts -k argocd/overlays/prod/\` pour mettre à jour l'Application CRD dans le cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing or absent nested policy fields to prevent errors and ensure more resilient policy validation and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->