### PR TITLE
fix(kyverno): add scheduling.k8s.io/priorityclasses GET to RBAC

### DIFF
--- a/argocd/overlays/prod/apps/kyverno.yaml
+++ b/argocd/overlays/prod/apps/kyverno.yaml
@@ -44,6 +44,9 @@ spec:
                   - apiGroups: [""]
                     resources: ["secrets"]
                     verbs: ["get"]
+                  - apiGroups: ["scheduling.k8s.io"]
+                    resources: ["priorityclasses"]
+                    verbs: ["get"]
 
           backgroundController:
             replicas: 1


### PR DESCRIPTION
## Bug critique

Les règles Kyverno \`mutate-priority-class\` (rules 2, 3, 5) utilisent \`context.apiCall\` pour lire la valeur de \`PriorityClass/vixens-critical\` dynamiquement. Mais le SA \`kyverno:kyverno-admission-controller\` n'a pas de permission GET sur \`scheduling.k8s.io/priorityclasses\` :

\`\`\`
Error: priorityclasses.scheduling.k8s.io is forbidden: User "system:serviceaccount:kyverno:kyverno-admission-controller" cannot get resource "priorityclasses" in API group "scheduling.k8s.io" at the cluster scope
\`\`\`

Conséquence : apiCall → 403 → context initialization fail → **règle silencieusement skippée** → pods admis sans \`priorityClassName\`/\`priority\` → injection broken.

**Régression** : goldilocks-controller fonctionnait avec le hardcode \`priority: 100000\` (PR #1896). Converti vers apiCall (PR #1900) sans RBAC → cassé.

## Fix

Ajout de \`scheduling.k8s.io/priorityclasses: get\` dans \`extraResources\` du ClusterRole Kyverno :

\`\`\`yaml
rbac:
  clusterRole:
    extraResources:
      - apiGroups: ["scheduling.k8s.io"]
        resources: ["priorityclasses"]
        verbs: ["get"]
\`\`\`

PriorityClasses sont une ressource de configuration non-sensible. Accès minimal et justifié.

## Validation post-merge

Après \`kubectl apply --server-side --force-conflicts -k argocd/overlays/prod/\` et resync kyverno :
1. \`kubectl auth can-i get priorityclasses --as=system:serviceaccount:kyverno:kyverno-admission-controller\` → **yes**
2. Restart d'un pod concerné → vérifier \`spec.priorityClassName\` et \`spec.priority\` injectés correctement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kyverno permissions to access Kubernetes priority class configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->