### PR TITLE
fix(homeassistant): revert PSA baseline → privileged (hostNetwork required)

### DIFF
--- a/apps/10-home/homeassistant/base/namespace.yaml
+++ b/apps/10-home/homeassistant/base/namespace.yaml
@@ -4,7 +4,7 @@ kind: Namespace
 metadata:
   name: homeassistant
   labels:
-    pod-security.kubernetes.io/enforce: baseline
-    pod-security.kubernetes.io/audit: baseline
-    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
     goldilocks.fairwinds.com/enabled: "true"


### PR DESCRIPTION
## Problem

HomeAssistant is DOWN since W4 (PR #1906) which added `pod-security.kubernetes.io/enforce: baseline` to the `homeassistant` namespace.

HomeAssistant requires:
- `hostNetwork: true` (mDNS, Matter, Zeroconf discovery)
- `hostPorts` 5683 (CoAP/Matter), 8123 (HTTP), 9090 (metrics/litestream)

PSA `baseline` explicitly forbids both. All pod creation has been blocked since W4.

## Fix

Revert PSA labels from `baseline` → `privileged` on the homeassistant namespace.

The Diamond maturity label (`vixens.io/tier: "diamond"`) on the Deployment/Ingress documents security intent. The hostNetwork requirement is a legitimate HA constraint, not a security gap.

## Impact

- HomeAssistant pods will restart immediately after ArgoCD sync
- No config changes, no data risk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pod-security policy configuration for the homeassistant environment. Security settings have been transitioned from baseline to privileged access levels across enforcement, audit, and warning policy mechanisms, allowing expanded container capabilities within the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->