### PR TITLE
fix(homeassistant): add CAP_CHOWN to init containers (Kyverno W1 drops ALL caps)

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -58,6 +58,8 @@ spec:
           image: busybox:1.37.0
           securityContext:
             runAsUser: 0
+            capabilities:
+              add: [CHOWN]
           command:
             - sh
             - -c
@@ -69,6 +71,8 @@ spec:
         - name: install-python-deps
           image: python:3.14.3-alpine
           securityContext:
+            capabilities:
+              add: [CHOWN]
             runAsUser: 0
           command:
             - sh
@@ -128,6 +132,9 @@ spec:
               subPath: litestream.yml
         - name: config-init
           image: busybox:1.37.0
+          securityContext:
+            capabilities:
+              add: [CHOWN]
           command:
             - sh
             - -c


### PR DESCRIPTION
## Problem

The Kyverno W1 mutation (`add-security-context`) drops ALL capabilities from every container, including init containers. The `fix-perms` and `config-init` init containers run as root (user 0) but use `chown`, which requires `CAP_CHOWN`.

Without `CAP_CHOWN`, even root cannot chown files it doesn't own → `Operation not permitted` → CrashLoopBackOff.

## Fix

Add `capabilities.add: [CHOWN]` to:
- `fix-perms` — runs `chown -R 1000:1000 /config`
- `install-python-deps` — runs as root, may need CHOWN for pip install
- `config-init` — runs `chown 1000:1000 /config/configuration.yaml`

This explicitly adds back the single capability needed, overriding the Kyverno mutation, following least-privilege principle (add only what's needed rather than running fully privileged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes deployment configuration to improve permission handling and enhance reliability during container startup and initialization processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->