### PR TITLE
fix(kyverno): skip capability-drop mutation for root init containers

### DIFF
--- a/apps/00-infra/kyverno/base/policies/mutate-security-context.yaml
+++ b/apps/00-infra/kyverno/base/policies/mutate-security-context.yaml
@@ -5,9 +5,15 @@
 #   allowPrivilegeEscalation: false
 #   capabilities.drop: [ALL]
 #
-# This mutation ensures ALL containers (including sidecars and initContainers)
-# get the minimum required security posture, even for Helm-managed workloads
-# where Kustomize patches cannot be applied.
+# This mutation ensures ALL main containers AND non-root init containers
+# get the minimum required security posture.
+#
+# ROOT INIT CONTAINERS (fix-permissions, chown, etc.) are intentionally
+# excluded from the initContainer mutation rule: containers without an
+# explicit runAsUser (or with runAsUser=0) are skipped, so that chown
+# operations are not broken by the capability drop.
+# Per-app deployments that need CAP_CHOWN on init containers should set
+# capabilities.add: [CHOWN] explicitly (see HomeAssistant as reference).
 #
 # Bypass: set vixens.io/explicitly-allow-root: "true" on pod template
 # annotations for apps that genuinely require capabilities (e.g. gluetun NET_ADMIN,
@@ -82,6 +88,11 @@ spec:
       mutate:
         foreach:
           - list: "request.object.spec.initContainers"
+            preconditions:
+              all:
+                - key: "{{ element.securityContext.runAsUser || `0` }}"
+                  operator: NotEquals
+                  value: 0
             patchStrategicMerge:
               spec:
                 initContainers:


### PR DESCRIPTION
## Problem

The `mutate-security-context` Kyverno policy was blindly mutating **ALL** init containers to add `capabilities.drop: [ALL]`, including containers that run as root (no `runAsUser` set) to perform `chown` operations. This removed `CAP_CHOWN`, causing **10+ apps to crash**:

```
chown: /config: Operation not permitted
```

Affected apps (all showing `Init:CrashLoopBackOff`):
- `sonarr`, `radarr`, `lidarr`, `mylar`, `prowlarr`, `whisparr` — `fix-permissions` init container
- `homepage` — `copy-initial-config` init container  
- `lazylibrarian`, `booklore`, `vaultwarden`, `birdnet-go`

## Root Cause

The policy's `inject-initcontainers-securitycontext` rule iterated over ALL init containers without distinguishing between root init containers (for setup/chown) and non-root ones. `chown` requires `CAP_CHOWN`, which is dropped by `capabilities.drop: [ALL]`.

## Fix

Add a `preconditions` block to the `foreach` loop: **only mutate init containers with explicit `runAsUser != 0`**.

```yaml
foreach:
  - list: "request.object.spec.initContainers"
    preconditions:
      all:
        - key: "{{ element.securityContext.runAsUser || `0` }}"
          operator: NotEquals
          value: 0
    patchStrategicMerge: ...
```

- Init containers **without** `runAsUser` (default = root) → **skipped**, chown works ✅  
- Init containers with `runAsUser: 1000` → **mutated**, drop ALL capabilities ✅  
- Apps that need `CAP_CHOWN` explicitly can follow the HomeAssistant pattern (PR #1911): add `capabilities.add: [CHOWN]` in the deployment YAML

## Scope

This fixes the regression introduced when `mutate-security-context` was deployed today (2026-03-07T16:27:54Z). Main containers rule is unchanged — it already correctly targets running app containers.

## Testing

After merge + ArgoCD sync, affected pods will restart with corrected mutation. Pods with explicit `runAsUser: 1000` init containers continue to get the full security context hardening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security context mutation policy to exclude root-privileged init containers from mutations while preserving standard container behavior. Non-root init containers continue to be processed as before. Policy documentation updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->