### PR TITLE
fix(homeassistant): skip lost+found on iSCSI volume in fix-perms

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -64,7 +64,7 @@ spec:
             - sh
             - -c
           args:
-            - mkdir -p /config/python_packages && chown -R 1000:1000 /config
+            - mkdir -p /config/python_packages && chown 1000:1000 /config && find /config -mindepth 1 -maxdepth 1 -not -name 'lost+found' -exec chown -R 1000:1000 {} +
           volumeMounts:
             - name: config
               mountPath: /config


### PR DESCRIPTION
## Problem

The `fix-perms` init container was crashing with:
```
chown: /config/lost+found: Permission denied
```

ext4-formatted iSCSI PVCs always contain a `lost+found` directory at the volume root. The recursive `chown -R 1000:1000 /config` fails on this directory (even as root/uid 0 with CAP_CHOWN in some iSCSI+Synology configurations), causing `CrashLoopBackOff` and preventing HomeAssistant from starting.

## Fix

Replace blanket recursive chown with an explicit two-step:
1. `chown 1000:1000 /config` — chown the volume root itself
2. `find /config -mindepth 1 -maxdepth 1 -not -name 'lost+found' -exec chown -R 1000:1000 {} +` — recursively chown all children except `lost+found`

This is consistent with the existing `restore-config` and `config-syncer` containers which already exclude `lost+found/**` from rclone operations.

## Context

- Discovered today during incident investigation after cluster restart
- `lost+found` is harmless and not needed by HomeAssistant
- Part of the broader iSCSI recovery work alongside PR #1910, #1911, #1912

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file permission handling in deployment initialization to properly exclude system directories from recursive permission changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->