### PR TITLE
fix(redis-shared): add missing ingress rules to NetworkPolicy

### DIFF
--- a/apps/04-databases/redis-shared/base/networkpolicy.yaml
+++ b/apps/04-databases/redis-shared/base/networkpolicy.yaml
@@ -10,7 +10,31 @@ spec:
   policyTypes:
     - Ingress
     - Egress
-  ingress: []
+  ingress:
+    # Allow connections from namespaces that use redis-shared:
+    # - auth (authentik)
+    # - tools (vikunja, netbox)
+    # - networking (netvisor)
+    - from:
+        - namespaceSelector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - auth
+                  - tools
+                  - networking
+      ports:
+        - port: 6379
+          protocol: TCP
+    # Allow Prometheus scraping from monitoring namespace
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: 6379
+          protocol: TCP
   egress:
     # Allow all egress (homelab: DNS, inter-app, external APIs)
     - {}


### PR DESCRIPTION
## Problem

Diamond W4 NetworkPolicy was applied with \`ingress: []\`, blocking **all** incoming connections to \`redis-shared\`. Apps that depend on Redis were failing:

- **vikunja** (tools): \`redis: connection pool: failed to dial ... i/o timeout\` → CrashLoopBackOff
- **netbox** (tools): Redis connection failures
- **authentik** (auth): Redis connection failures  
- **netvisor** (networking): Redis connection failures

## Fix

Add explicit ingress rules allowing port 6379 from the namespaces that consume redis-shared:
- \`auth\` — authentik (session caching)
- \`tools\` — vikunja, netbox
- \`networking\` — netvisor
- \`monitoring\` — Prometheus scraping

Using \`kubernetes.io/metadata.name\` namespace label selector (stable built-in label, available since Kubernetes 1.21).

## Part of

Incident recovery 2026-03-07 — Diamond W4 NetworkPolicy regressions.
See also: #1910, #1911, #1912, #1913