### PR TITLE
fix(kyverno): fix null initContainers precondition crashing webhook

### DIFF
--- a/apps/00-infra/kyverno/base/policies/mutate-security-context.yaml
+++ b/apps/00-infra/kyverno/base/policies/mutate-security-context.yaml
@@ -82,7 +82,7 @@ spec:
                 vixens.io/explicitly-allow-root: "true"
       preconditions:
         all:
-          - key: "{{ request.object.spec.initContainers[] | length(@) }}"
+          - key: '{{ length(request.object.spec.initContainers || `[]`) }}'
             operator: GreaterThanOrEquals
             value: 1
       mutate:


### PR DESCRIPTION
## Problem

The rule-level precondition in `inject-initcontainers-securitycontext`:

```yaml
key: "{{ request.object.spec.initContainers[] | length(@) }}"
```

fails with:
```
JMESPath query failed: Invalid type for: <nil>, expected: []jmespath.JpType{"string", "array", "object"}
```

when `spec.initContainers` is **null** (pods without init containers). Since the Kyverno mutating webhook has `failurePolicy: Fail` (`svc-fail`), this error causes the **entire pod creation to be denied**, blocking deployments for all apps without init containers:

- jellyfin, traefik, trivy, qbittorrent, pyload, redis-shared sidecars, penpot, netbox, and more

These deployments entered `ProgressDeadlineExceeded` state from 2026-03-07T16:29Z (when Diamond W4 Kyverno policy was first deployed).

## Fix

Use the null-safe JMESPath fallback pattern:

```yaml
key: '{{ length(request.object.spec.initContainers || `[]`) }}'
```

This returns `0` when `initContainers` is null → precondition evaluates to `0 >= 1 = false` → rule is skipped cleanly, without throwing a type error.

## Part of

Diamond W4 incident recovery 2026-03-07.
See also: #1910, #1911, #1912, #1913, #1914