### PR TITLE
fix(homeassistant): add explicitly-allow-root bypass for s6-overlay

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -40,6 +40,7 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/path: "/metrics"
         vixens.io/no-long-connections: "true"
+        vixens.io/explicitly-allow-root: "true"
     spec:
       securityContext:
         runAsUser: 1000


### PR DESCRIPTION
## Problem

The Kyverno `mutate-security-context` policy adds `allowPrivilegeEscalation: false` to ALL main containers, including `homeassistant`. HomeAssistant uses `s6-overlay` which uses a setuid `suexec` binary to gain root during startup and then drop to the service user.

With `allowPrivilegeEscalation: false`, `s6-overlay-suexec` cannot gain root privileges:

```
s6-overlay-suexec: warning: unable to gain root privileges (is the suid bit set?)
s6-overlay-suexec: fatal: child failed with exit code 111
```

This caused HomeAssistant to crash-loop after all init containers completed successfully.

## Fix

Add `vixens.io/explicitly-allow-root: "true"` to the pod template annotations. This is the documented bypass mechanism in `mutate-security-context` for apps that genuinely require privilege escalation or capabilities (hostNetwork, s6-overlay, GPU/hardware access, etc.).

## Context

- HomeAssistant already runs in a `privileged` PSA namespace (PR #1910) for `hostNetwork: true`
- The `explicitly-allow-root` bypass is consistent with how frigate/gluetun are handled
- Part of the incident recovery series: #1910, #1911, #1912, #1913, #1914, #1915

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration settings to ensure proper system access controls during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->