### PR TITLE
fix(s6-overlay): add explicitly-allow-root bypass to linuxserver apps

### DIFF
--- a/apps/10-home/mealie/base/deployment.yaml
+++ b/apps/10-home/mealie/base/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         prometheus.io/port: "9000"
         prometheus.io/path: "/metrics"
         vixens.io/no-long-connections: "true"
+        vixens.io/explicitly-allow-root: "true"
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane

--- a/apps/20-media/lazylibrarian/base/deployment.yaml
+++ b/apps/20-media/lazylibrarian/base/deployment.yaml
@@ -33,6 +33,7 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/path: "/metrics"
         vixens.io/no-long-connections: "true"
+        vixens.io/explicitly-allow-root: "true"
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane

--- a/apps/20-media/pyload/base/deployment.yaml
+++ b/apps/20-media/pyload/base/deployment.yaml
@@ -23,6 +23,7 @@ spec:
       annotations:
         vixens.io/service-binding: "false"
         vixens.io/no-long-connections: "true"
+        vixens.io/explicitly-allow-root: "true"
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane

--- a/apps/20-media/qbittorrent/base/deployment.yaml
+++ b/apps/20-media/qbittorrent/base/deployment.yaml
@@ -23,6 +23,7 @@ spec:
       annotations:
         vixens.io/service-binding: "false"
         vixens.io/no-long-connections: "true"
+        vixens.io/explicitly-allow-root: "true"
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
## Problem

The Kyverno \`mutate-security-context\` policy adds \`allowPrivilegeEscalation: false\` to all containers. LinuxServer.io images (and similar) use \`s6-overlay\` to switch from root to a service user during startup. With privilege escalation disabled:

```
s6-applyuidgid: fatal: unable to set supplementary group list: Operation not permitted
error: failed switching to "911": operation not permitted
```

Affected apps (all running in CrashLoopBackOff since Diamond W4 policy deployment):
| App | Namespace | Restarts |
|-----|-----------|---------|
| mealie | mealie | 40+ |
| lazylibrarian | media | 11+ |
| qbittorrent | media | 3+ |
| pyload | downloads | 3+ |

## Fix

Add \`vixens.io/explicitly-allow-root: "true"\` to each app's pod template annotations. This is the documented bypass for apps that genuinely require privilege escalation (s6-overlay user switching, suid binaries, etc.).

## Part of

Diamond W4 incident recovery 2026-03-07. See also: #1910-#1916