### PR TITLE
fix(s6-overlay): add explicitly-allow-root bypass to vaultwarden, amule, birdnet-go

### DIFF
--- a/apps/20-media/amule/base/deployment.yaml
+++ b/apps/20-media/amule/base/deployment.yaml
@@ -24,6 +24,7 @@ spec:
       annotations:
         vixens.io/service-binding: "false"
         vixens.io/no-long-connections: "true"
+        vixens.io/explicitly-allow-root: "true"
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane

--- a/apps/20-media/birdnet-go/base/deployment.yaml
+++ b/apps/20-media/birdnet-go/base/deployment.yaml
@@ -29,6 +29,7 @@ spec:
         vixens.io/fast-start: "true"
         reloader.stakater.com/auto: "true"
         vixens.io/no-long-connections: "true"
+        vixens.io/explicitly-allow-root: "true"
     spec:
       priorityClassName: vixens-medium
       tolerations:

--- a/apps/60-services/vaultwarden/base/deployment.yaml
+++ b/apps/60-services/vaultwarden/base/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/path: "/metrics"
         vixens.io/no-long-connections: "true"
+        vixens.io/explicitly-allow-root: "true"
     spec:
       priorityClassName: vixens-medium
       tolerations:


### PR DESCRIPTION
## Problème

Ces 3 apps utilisent s6-overlay ou un init system similaire qui nécessite privilege escalation :

| App | Namespace | Erreur |
|-----|-----------|--------|
| vaultwarden | services | `chown: /data: Operation not permitted` |
| amule | downloads | `chown: /home/amule: Operation not permitted` |
| birdnet-go | birdnet-go | `fix-permissions` init container CrashLoop |

## Fix

Ajout de `vixens.io/explicitly-allow-root: "true"` pour bypasser la mutation Kyverno.

## Contexte

Suite de l'incident Diamond W4, même pattern que PR #1916, #1917.