### PR TITLE
fix(synology-csi): add explicitly-allow-root bypass for Kyverno mutation

### DIFF
--- a/apps/01-storage/synology-csi/base/controller.yaml
+++ b/apps/01-storage/synology-csi/base/controller.yaml
@@ -11,11 +11,12 @@ spec:
       app: synology-csi-controller
   template:
     metadata:
+      annotations:
+        vixens.io/explicitly-allow-root: "true"
+        vixens.io/no-long-connections: "true"
       labels:
         app: synology-csi-controller
         vixens.io/backup-profile: "relaxed"
-      annotations:
-        vixens.io/no-long-connections: "true"
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane

--- a/apps/01-storage/synology-csi/base/node.yaml
+++ b/apps/01-storage/synology-csi/base/node.yaml
@@ -9,6 +9,8 @@ spec:
       app: synology-csi-node
   template:
     metadata:
+      annotations:
+        vixens.io/explicitly-allow-root: "true"
       labels:
         app: synology-csi-node
     spec:


### PR DESCRIPTION
## Summary
- Add `vixens.io/explicitly-allow-root: "true"` annotation to synology-csi DaemonSet and StatefulSet pods
- CSI containers use `privileged: true` for iSCSI mount operations
- Kyverno's `mutate-security-context` policy was adding `allowPrivilegeEscalation: false`, which K8s rejects when combined with `privileged: true`

## Problem
```
Error creating: Pod "synology-csi-node-xxx" is invalid: 
spec.containers[0].securityContext: Invalid value: cannot set `allowPrivilegeEscalation` to false and `privileged` to true
```

This blocked CSI node pods from being created on node `peach`, which in turn blocked all iSCSI PVC mounts for:
- mosquitto
- birdnet-go  
- mealie
- booklore
- amule

## Solution
The `explicitly-allow-root` annotation bypasses Kyverno's security context mutation for these infrastructure pods that legitimately require privileged access.

## Testing
- [ ] CSI DaemonSet pods restart successfully on all nodes
- [ ] mosquitto, birdnet-go, mealie recover from Init:0/2 state
- [ ] iSCSI PVCs mount correctly

## Related
Part of Diamond W4 incident recovery (#1918)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated pod configuration metadata for Synology CSI storage components to align with platform requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->