### PR TITLE
fix(synology-csi): use individual annotation patches to preserve base annotations

### DIFF
--- a/apps/01-storage/synology-csi/overlays/prod/kustomization.yaml
+++ b/apps/01-storage/synology-csi/overlays/prod/kustomization.yaml
@@ -32,19 +32,21 @@ patches:
       name: synelia-iscsi-delete
   - patch: |-
       - op: add
-        path: /spec/template/metadata/annotations
-        value:
-          vixens.io/fast-start: "true"
-          vixens.io/service-binding: "false"
+        path: /spec/template/metadata/annotations/vixens.io~1fast-start
+        value: "true"
+      - op: add
+        path: /spec/template/metadata/annotations/vixens.io~1service-binding
+        value: "false"
     target:
       kind: StatefulSet
       name: synology-csi-controller
   - patch: |-
       - op: add
-        path: /spec/template/metadata/annotations
-        value:
-          vixens.io/fast-start: "true"
-          vixens.io/service-binding: "false"
+        path: /spec/template/metadata/annotations/vixens.io~1fast-start
+        value: "true"
+      - op: add
+        path: /spec/template/metadata/annotations/vixens.io~1service-binding
+        value: "false"
     target:
       kind: DaemonSet
       name: synology-csi-node


### PR DESCRIPTION
## Summary
- Changed prod overlay patches from object-level to individual annotation patches
- This preserves base annotations like `explicitly-allow-root` added in #1920

## Problem
The overlay was using:
```yaml
- op: add
  path: /spec/template/metadata/annotations
  value:
    vixens.io/fast-start: "true"
```

This **replaces** all annotations from base instead of merging them.

## Solution
Changed to individual patches with JSON pointer escaping (`~1` for `/`):
```yaml
- op: add
  path: /spec/template/metadata/annotations/vixens.io~1fast-start
  value: "true"
```

This preserves base annotations while adding overlay-specific ones.

## Testing
- [x] kustomize build shows explicitly-allow-root annotation
- [ ] CSI pod on peach creates successfully
- [ ] mosquitto, birdnet-go, mealie recover

## Related
Follow-up to #1920