### PR TITLE
fix(synology-csi): set namespace to privileged PSS level

### DIFF
--- a/apps/01-storage/synology-csi/base/namespace.yaml
+++ b/apps/01-storage/synology-csi/base/namespace.yaml
@@ -6,6 +6,6 @@ metadata:
   name: synology-csi
   labels:
     goldilocks.fairwinds.com/enabled: "true"
-    pod-security.kubernetes.io/enforce: baseline
-    pod-security.kubernetes.io/audit: baseline
-    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
## Summary
- Change synology-csi namespace from `baseline` to `privileged` Pod Security Standard

## Problem
After the Kyverno bypass annotation was applied, the DaemonSet still couldn't create pods on peach:
```
violates PodSecurity "baseline:latest": host namespaces (hostNetwork=true, hostPID=true), 
hostPath volumes (...), privileged (containers "..." must not set securityContext.privileged=true)
```

## Solution
CSI drivers legitimately require privileged access for:
- `hostNetwork` - for node driver registration with kubelet
- `hostPID` - for iSCSI daemon operations  
- `hostPath` volumes - for device and kubelet directory access
- `privileged` containers - for mount operations

Changed namespace PSS level to `privileged` which is standard for CSI namespaces.

## Testing
- [ ] CSI node pod on peach creates successfully
- [ ] mosquitto, birdnet-go, mealie recover from Init:0/2

## Related
Part of Diamond W4 incident recovery (follows #1920, #1921)