### PR TITLE
fix(booklore): add explicitly-allow-root bypass for s6-overlay

### DIFF
--- a/apps/20-media/booklore/base/deployment.yaml
+++ b/apps/20-media/booklore/base/deployment.yaml
@@ -20,6 +20,7 @@ spec:
       annotations:
         vixens.io/fast-start: "true"
         vixens.io/no-long-connections: "true"
+        vixens.io/explicitly-allow-root: "true"
       labels:
         app: booklore
         vixens.io/sizing.booklore: B-large

--- a/apps/20-media/booklore/base/mariadb-deployment.yaml
+++ b/apps/20-media/booklore/base/mariadb-deployment.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         vixens.io/fast-start: "true"
+        vixens.io/explicitly-allow-root: "true"
       labels:
         app: booklore-mariadb
         vixens.io/sizing.mariadb: V-small


### PR DESCRIPTION
## Summary
- Add `vixens.io/explicitly-allow-root: "true"` to booklore and booklore-mariadb deployments

## Problem
Both apps use LinuxServer.io images with s6-overlay that require `allowPrivilegeEscalation` for user switching:
```
s6-applyuidgid: fatal: unable to set supplementary group list: Operation not permitted
adduser: /home/booklore: Operation not permitted
```

## Solution
Same bypass as homeassistant, mealie, vaultwarden, etc.

## Testing
- [ ] booklore pods recover from CrashLoopBackOff
- [ ] booklore-mariadb pods recover

## Related
Part of Diamond W4 incident recovery

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configurations to add security-related annotations for container management across multiple services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->