### PR TITLE
fix(hydrus-client): add explicitly-allow-root bypass

### DIFF
--- a/apps/20-media/hydrus-client/base/deployment.yaml
+++ b/apps/20-media/hydrus-client/base/deployment.yaml
@@ -34,6 +34,7 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/path: "/metrics"
         vixens.io/no-long-connections: "true"
+        vixens.io/explicitly-allow-root: "true"
     spec:
       priorityClassName: vixens-medium
       tolerations:


### PR DESCRIPTION
Same s6/supervisor issue as other apps. Part of Diamond W4 recovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration with explicit root access permission settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->