### PR TITLE
perf(hydrus-client): use quick_check instead of integrity_check

### DIFF
--- a/apps/20-media/hydrus-client/base/deployment.yaml
+++ b/apps/20-media/hydrus-client/base/deployment.yaml
@@ -65,7 +65,7 @@ spec:
               for db in /opt/hydrus/db/*.db; do
                 [ -e "$db" ] || continue
                 echo "🔍 Checking $db..."
-                if ! sqlite3 "$db" "PRAGMA integrity_check;" | grep -q "ok"; then
+                if ! sqlite3 "$db" "PRAGMA quick_check;" | grep -q "ok"; then
                   echo "❌ Corruption detected in $db! Deleting for fresh restore."
                   rm -f "$db" "$db-wal" "$db-shm"
                 else


### PR DESCRIPTION
PRAGMA quick_check is ~100x faster while still detecting structural corruption.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database startup verification method in deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->