### PR TITLE
perf(hydrus-client): increase check-integrity sizing from G-nano to B-medium

### DIFF
--- a/apps/20-media/hydrus-client/base/deployment.yaml
+++ b/apps/20-media/hydrus-client/base/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         vixens.io/sizing.hydrus-client: V-large
         vixens.io/sizing.litestream: V-nano
         vixens.io/sizing.fix-permissions: G-nano
-        vixens.io/sizing.check-integrity: G-nano
+        vixens.io/sizing.check-integrity: B-medium
         vixens.io/sizing.restore-db: B-nano
         vixens.io/sizing.restore-mappings: B-nano
         vixens.io/sizing.restore-master: B-nano


### PR DESCRIPTION
## Summary

- Change `check-integrity` init container sizing from `G-nano` (5m CPU guaranteed) to `B-medium` (50m request, 500m burst)
- This dramatically reduces pod startup time from 90+ minutes to ~1 minute

## Problem

With `G-nano` sizing, the `PRAGMA quick_check` on the ~1GB hydrus database takes 90+ minutes because it's CPU-limited to 5 millicores. This causes:
- Gateway timeouts when accessing hydrus
- Long pod restart cycles
- Poor user experience

## Solution

`B-medium` provides:
- 50m CPU request (10x more than G-nano)
- 500m CPU burst capability (100x more than G-nano)
- Expected completion time: ~1 minute

## Part of

Diamond W4 incident recovery - final optimization for hydrus-client.

## Testing

After merge:
1. Update prod-stable tag
2. Delete hydrus-client pod to trigger restart
3. Verify check-integrity completes in ~1 minute
4. Verify hydrus WebUI is accessible without gateway timeout