### PR TITLE
fix(hydrus-client): remove SSO forward-auth

### DIFF
--- a/apps/20-media/hydrus-client/overlays/prod/ingress.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     gethomepage.dev/name: Hydrus Client
     gethomepage.dev/icon: hydrus.png
     gethomepage.dev/group: Media
-    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd, auth-authentik-forward-auth@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
 spec:
   ingressClassName: traefik
   rules:


### PR DESCRIPTION
Remove authentik forward-auth middleware - outpost config was lost. SSO to be reconfigured later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Removed authentication middleware from the production environment's request processing chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->