### PR TITLE
fix(hydrus-client): correct NetworkPolicy port

### DIFF
--- a/apps/20-media/hydrus-client/base/networkpolicy.yaml
+++ b/apps/20-media/hydrus-client/base/networkpolicy.yaml
@@ -17,6 +17,6 @@ spec:
               kubernetes.io/metadata.name: traefik
       ports:
         - protocol: TCP
-          port: 8080
+          port: 5800
   egress:
     - {}


### PR DESCRIPTION
Fix NetworkPolicy to allow port 5800 (hydrus) instead of 8080.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated hydrus-client service port configuration from 8080 to 5800.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->