### PR TITLE
feat(hydrus-client): expose API via Traefik

### DIFF
--- a/apps/20-media/hydrus-client/base/networkpolicy.yaml
+++ b/apps/20-media/hydrus-client/base/networkpolicy.yaml
@@ -18,5 +18,7 @@ spec:
       ports:
         - protocol: TCP
           port: 5800
+        - protocol: TCP
+          port: 45869
   egress:
     - {}

--- a/apps/20-media/hydrus-client/base/service.yaml
+++ b/apps/20-media/hydrus-client/base/service.yaml
@@ -17,3 +17,7 @@ spec:
       protocol: TCP
       port: 9090
       targetPort: 9090
+    - name: api
+      protocol: TCP
+      port: 45869
+      targetPort: 45869

--- a/apps/20-media/hydrus-client/overlays/prod/ingress-api.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/ingress-api.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hydrus-client-api-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: hydrus-api.truxonline.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: hydrus-client
+                port:
+                  number: 45869
+  tls:
+    - hosts:
+        - hydrus-api.truxonline.com
+      secretName: hydrus-client-api-tls

--- a/apps/20-media/hydrus-client/overlays/prod/kustomization.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/kustomization.yaml
@@ -11,6 +11,7 @@ patchesStrategicMerge:
 resources:
   - ../../base
   - ingress.yaml
+  - ingress-api.yaml
 
 components:
   - ../../../../_shared/components/gold-maturity


### PR DESCRIPTION
## Summary

- Add API port (45869) to hydrus-client service
- Create dedicated ingress at `hydrus-api.truxonline.com`
- Update NetworkPolicy to allow API traffic from Traefik

## Usage

```bash
curl -H "Hydrus-Client-API-Access-Key: <key>" https://hydrus-api.truxonline.com/api_version
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New API endpoint is now available with automatic HTTPS support for secure communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->