### PR TITLE
fix(skills): migrate to proper OpenCode SKILL.md format

### DIFF
--- a/.opencode/skills/vixens-cluster/SKILL.md
+++ b/.opencode/skills/vixens-cluster/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: vixens-cluster
 description: >-
   Vixens Kubernetes cluster operations expert. ALWAYS USE for: kubectl commands,
   ArgoCD sync/refresh, Talos operations, pod debugging, deployment issues, GitOps workflow,

--- a/.opencode/skills/vixens-gitops/SKILL.md
+++ b/.opencode/skills/vixens-gitops/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: vixens-gitops
 description: >-
   Vixens GitOps workflow expert. ALWAYS USE for: creating PRs, merging, pushing changes,
   promoting to production, updating prod-stable tag, branch protection, GitHub Actions,

--- a/.opencode/skills/vixens-maturity/SKILL.md
+++ b/.opencode/skills/vixens-maturity/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: vixens-maturity
 description: >-
   Vixens 7-Tier Maturity System expert (ADR-023). ALWAYS USE for: maturity labels,
   Bronze/Silver/Gold/Platinum/Emerald/Diamond/Orichalcum upgrades, policy violations,

--- a/.opencode/skills/vixens-troubleshoot/SKILL.md
+++ b/.opencode/skills/vixens-troubleshoot/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: vixens-troubleshoot
 description: >-
   Vixens cluster troubleshooting expert. ALWAYS USE when: apps broken, pods crashing,
   CrashLoopBackOff, ImagePullBackOff, OOMKilled, deployments failing, service not accessible,


### PR DESCRIPTION
## Summary
- Restructure skills from `.opencode/skill/<name>.md` to `.opencode/skills/<name>/SKILL.md`
- Add required `name` field to frontmatter per OpenCode docs
- Skills now properly discoverable by OpenCode

## Structure
```
.opencode/skills/
├── vixens-cluster/SKILL.md
├── vixens-gitops/SKILL.md
├── vixens-maturity/SKILL.md
└── vixens-troubleshoot/SKILL.md
```