### PR TITLE
fix(gitleaks): remove unsupported lookahead regex

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -89,12 +89,17 @@ keywords = ["service_account"]
 [[rules]]
 id = "hardcoded-password-yaml"
 description = "Hardcoded password in YAML"
-regex = '''(?i)password\s*:\s*["\']?(?!REDACTED|placeholder|\$\{|\{\{)[^\s"\']{8,}'''
+# Note: Using simple regex + allowlist (Go regexp doesn't support lookahead)
+regex = '''(?i)password\s*:\s*["']?[^\s"']{8,}'''
 tags = ["password", "yaml"]
 
   [rules.allowlist]
   regexes = [
-      '''password:\s*["\']\s*["\']\s*$''',
+      '''password:\s*["']\s*["']\s*$''',
       '''password:\s*\$\{''',
       '''password:\s*\{\{''',
+      '''password:\s*["']?REDACTED''',
+      '''password:\s*["']?placeholder''',
+      '''password:\s*secretKeyRef''',
+      '''password:\s*valueFrom''',
   ]


### PR DESCRIPTION
## Summary

Fix gitleaks panic caused by unsupported regex syntax.

### Problem

Gitleaks uses Go's regexp engine which doesn't support Perl-style negative lookahead `(?!...)`. The `hardcoded-password-yaml` rule used:

```regex
(?i)password\s*:\s*["']?(?!REDACTED|placeholder|\$\{|\{\{)[^\s"']{8,}
```

This caused:
```
panic: regexp: Compile(...): error parsing regexp: bad perl operator: `(?!`
```

### Solution

Replaced lookahead with simple regex + expanded allowlist:

```regex
(?i)password\s*:\s*["']?[^\s"']{8,}
```

Plus allowlist patterns for:
- Empty passwords
- Template variables (`${...}`, `{{...}}`)
- Placeholder values (REDACTED, placeholder)
- Kubernetes references (secretKeyRef, valueFrom)