### PR TITLE
fix(ci): add missing xargs command in yamllint workflow

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -82,6 +82,7 @@ jobs:
             ! -name "argocd-install.yaml" \
             ! -name "manifests.yaml" \
             ! -name "servicemonitors.yaml" | \
+            xargs yamllint -c yamllint-config.yml
           fi
 
   # 2️⃣ Validation spécifique ArgoCD


### PR DESCRIPTION
Fix bash syntax error - missing `xargs yamllint` command after find pipe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced YAML validation in the CI/CD pipeline to validate changed files during push events for improved code quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->