### PR TITLE
fix(ci): disable document-start yamllint rule

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -59,6 +59,8 @@ jobs:
           echo "  comments-indentation: disable" >> yamllint-config.yml
           echo "  brackets: disable" >> yamllint-config.yml
           echo "  truthy: disable" >> yamllint-config.yml
+          echo "  document-start: disable" >> yamllint-config.yml
+          echo "  empty-lines: disable" >> yamllint-config.yml
 
 
           # PR: valider uniquement les fichiers changés


### PR DESCRIPTION
Disable document-start and empty-lines rules to accept K8s manifests without leading ---