### PR TITLE
fix(lint): enforce yamllint style rules and fix 79 warnings

### DIFF
--- a/apps/00-infra/argocd/overlays/dev/patches/argocd-params.yaml
+++ b/apps/00-infra/argocd/overlays/dev/patches/argocd-params.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/apps/00-infra/cert-manager/values/prod.yaml
+++ b/apps/00-infra/cert-manager/values/prod.yaml
@@ -39,7 +39,7 @@ replicaCount: 2
 # Production Monitoring
 # ============================================================================
 # Enable Prometheus metrics for production
-#prometheus:
+# prometheus:
 #  enabled: true
 #  servicemonitor:
 #    enabled: true

--- a/apps/00-infra/kyverno/base/policies/add-ttl-jobs.yaml
+++ b/apps/00-infra/kyverno/base/policies/add-ttl-jobs.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/apps/00-infra/kyverno/base/policies/cleanup-policies.yaml
+++ b/apps/00-infra/kyverno/base/policies/cleanup-policies.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kyverno.io/v2beta1
 kind: ClusterCleanupPolicy
 metadata:

--- a/apps/00-infra/kyverno/base/policies/require-storage-strategy.yaml
+++ b/apps/00-infra/kyverno/base/policies/require-storage-strategy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/apps/00-infra/velero/base/kustomization.yaml
+++ b/apps/00-infra/velero/base/kustomization.yaml
@@ -1,2 +1,3 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/apps/00-infra/velero/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/velero/overlays/prod/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 # NOTE: Velero est déployé via Helm pur (ArgoCD multi-source)
 # Cette kustomization n'est PAS utilisée - elle existe uniquement
 # pour d'éventuels patches futurs si nécessaire

--- a/apps/00-infra/velero/overlays/prod/node-agent-probes.yaml
+++ b/apps/00-infra/velero/overlays/prod/node-agent-probes.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/apps/00-infra/velero/values/common.yaml
+++ b/apps/00-infra/velero/values/common.yaml
@@ -1,3 +1,4 @@
+---
 # Velero - Final SOTA 2026 Configuration
 image:
   repository: velero/velero

--- a/apps/00-infra/velero/values/prod.yaml
+++ b/apps/00-infra/velero/values/prod.yaml
@@ -1,3 +1,4 @@
+---
 # Velero - Production Environment Values
 # All core configuration centralized in common.yaml to avoid Helm merge conflicts.
 

--- a/apps/00-infra/vpa/overlays/dev/resources-patch.yaml
+++ b/apps/00-infra/vpa/overlays/dev/resources-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/apps/02-monitoring/goldilocks/base/kustomization.yaml
+++ b/apps/02-monitoring/goldilocks/base/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/apps/02-monitoring/hubble-ui/base/vpa.yaml
+++ b/apps/02-monitoring/hubble-ui/base/vpa.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/apps/02-monitoring/prometheus/overlays/dev/patch-alertmanager-command.yaml
+++ b/apps/02-monitoring/prometheus/overlays/dev/patch-alertmanager-command.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/apps/03-security/authentik/overlays/dev/deployment-patch.yaml
+++ b/apps/03-security/authentik/overlays/dev/deployment-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/apps/03-security/authentik/overlays/dev/hibernate-patch.yaml
+++ b/apps/03-security/authentik/overlays/dev/hibernate-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/apps/03-security/trivy/overlays/dev/resources-patch.yaml
+++ b/apps/03-security/trivy/overlays/dev/resources-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/apps/04-databases/cloudnative-pg/overlays/dev/resources-patch.yaml
+++ b/apps/04-databases/cloudnative-pg/overlays/dev/resources-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/apps/04-databases/postgresql-shared/base/cluster.yaml
+++ b/apps/04-databases/postgresql-shared/base/cluster.yaml
@@ -36,11 +36,11 @@ spec:
         login: true
         passwordSecret:
           name: netbox-postgresql-credentials
-#      - name: authentik
-#        ensure: present
-#        login: true
-#        passwordSecret:
-#          name: authentik-postgresql-credentials
+      #      - name: authentik
+      #        ensure: present
+      #        login: true
+      #        passwordSecret:
+      #          name: authentik-postgresql-credentials
       - name: scanopy
         ensure: present
         login: true
@@ -57,10 +57,10 @@ spec:
         passwordSecret:
           name: nocodb-postgresql-credentials
       #      - name: penpot  # TODO: re-enable once Infisical vault has 'username: penpot' at
-        #        ensure: present  #       /apps/04-databases/postgresql-shared/penpot (prod env)
-        #        login: true  #       Without this key, CNPG loops on 'username key doesn't exist'
-        #        passwordSecret:  #       blocking the entire cluster from becoming Ready.
-          #          name: penpot-postgresql-credentials  # penpot role still exists in DB, app still connects.
+      #        ensure: present  #       /apps/04-databases/postgresql-shared/penpot (prod env)
+      #        login: true  #       Without this key, CNPG loops on 'username key doesn't exist'
+      #        passwordSecret:  #       blocking the entire cluster from becoming Ready.
+      #          name: penpot-postgresql-credentials  # penpot role still exists in DB, app still connects.
       - name: firefly
         ensure: present
         login: true

--- a/apps/10-home/homeassistant/base/vpa.yaml
+++ b/apps/10-home/homeassistant/base/vpa.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/apps/20-media/booklore/base/deployment.yaml
+++ b/apps/20-media/booklore/base/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: booklore
     vixens.io/sizing-v2: "true"
-    vixens.io/vpa-mode: Off
+    vixens.io/vpa-mode: "Off"
     vixens.io/tier: "diamond"
 spec:
   replicas: 1

--- a/apps/20-media/jellyseerr/base/deployment.yaml
+++ b/apps/20-media/jellyseerr/base/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: jellyseerr
     vixens.io/sizing-v2: "true"
-    vixens.io/vpa-mode: Off
+    vixens.io/vpa-mode: "Off"
     vixens.io/tier: "diamond"
 spec:
   replicas: 1

--- a/apps/20-media/whisparr/base/deployment.yaml
+++ b/apps/20-media/whisparr/base/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: whisparr
     vixens.io/sizing-v2: "true"
-    vixens.io/vpa-mode: Off
+    vixens.io/vpa-mode: "Off"
 spec:
   strategy:
     type: Recreate

--- a/apps/40-network/adguard-home/base/adguard-ss.yaml
+++ b/apps/40-network/adguard-home/base/adguard-ss.yaml
@@ -199,7 +199,7 @@ spec:
     - metadata:
         name: config
       spec:
-        accessModes: [ "ReadWriteOnce" ]
+        accessModes: ["ReadWriteOnce"]
         storageClassName: synelia-iscsi
         resources:
           requests:
@@ -207,7 +207,7 @@ spec:
     - metadata:
         name: data
       spec:
-        accessModes: [ "ReadWriteOnce" ]
+        accessModes: ["ReadWriteOnce"]
         storageClassName: synelia-iscsi
         resources:
           requests:

--- a/apps/40-network/adguard-home/base/networkpolicy.yaml
+++ b/apps/40-network/adguard-home/base/networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/apps/40-network/netbird/base/tolerations-patch.yaml
+++ b/apps/40-network/netbird/base/tolerations-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/apps/60-services/firefly-iii-importer/base/deployment.yaml
+++ b/apps/60-services/firefly-iii-importer/base/deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/apps/60-services/firefly-iii-importer/base/infisical-secret.yaml
+++ b/apps/60-services/firefly-iii-importer/base/infisical-secret.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:

--- a/apps/60-services/firefly-iii-importer/base/ingress.yaml
+++ b/apps/60-services/firefly-iii-importer/base/ingress.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/apps/60-services/firefly-iii-importer/base/service.yaml
+++ b/apps/60-services/firefly-iii-importer/base/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/apps/60-services/firefly-iii/base/vpa.yaml
+++ b/apps/60-services/firefly-iii/base/vpa.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/apps/70-tools/headlamp/base/vpa.yaml
+++ b/apps/70-tools/headlamp/base/vpa.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/apps/70-tools/netbox/base/deployment.yaml
+++ b/apps/70-tools/netbox/base/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: netbox
     vixens.io/sizing-v2: "true"
-    vixens.io/vpa-mode: Off
+    vixens.io/vpa-mode: "Off"
     vixens.io/tier: "diamond"
 spec:
   replicas: 1

--- a/apps/70-tools/netbox/overlays/dev/deployment-patch.yaml
+++ b/apps/70-tools/netbox/overlays/dev/deployment-patch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -8,7 +8,7 @@ metadata:
     app: penpot-backend
     component: backend
     vixens.io/sizing-v2: "true"
-    vixens.io/vpa-mode: Off
+    vixens.io/vpa-mode: "Off"
     vixens.io/tier: "diamond"
 spec:
   replicas: 1

--- a/apps/_shared/components/base/kustomization.yaml
+++ b/apps/_shared/components/base/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 #
 # Kustomize Component: Base Requirements
 #

--- a/apps/_shared/components/gold-maturity/kustomization.yaml
+++ b/apps/_shared/components/gold-maturity/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 # Kustomize Component: gold-maturity
 #
 # Adds Gold-tier maturity to all Deployments and StatefulSets:

--- a/apps/_shared/components/metrics/kustomization.yaml
+++ b/apps/_shared/components/metrics/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 #
 # Kustomize Component: Application Metrics
 #

--- a/apps/_shared/components/nometrics/kustomization.yaml
+++ b/apps/_shared/components/nometrics/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 #
 # Kustomize Component: No Metrics (nometrics)
 #

--- a/apps/_shared/components/poddisruptionbudget/0/kustomization.yaml
+++ b/apps/_shared/components/poddisruptionbudget/0/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 # Component: PodDisruptionBudget - 0 (Zero Disruption Budget)
 #
 # This component sets minAvailable: 0 on PodDisruptionBudget resources.

--- a/apps/_shared/components/poddisruptionbudget/1/kustomization.yaml
+++ b/apps/_shared/components/poddisruptionbudget/1/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 # Component: PodDisruptionBudget - 1 (Single Pod Budget)
 #
 # This component sets minAvailable: 1 on PodDisruptionBudget resources.

--- a/apps/_shared/components/poddisruptionbudget/50percent/kustomization.yaml
+++ b/apps/_shared/components/poddisruptionbudget/50percent/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 # Component: PodDisruptionBudget - 50percent (High Availability Budget)
 #
 # This component sets minAvailable: 50% on PodDisruptionBudget resources.

--- a/apps/_shared/components/priority/high/kustomization.yaml
+++ b/apps/_shared/components/priority/high/kustomization.yaml
@@ -1,4 +1,4 @@
-
+---
 # Kustomize Component: High Priority
 #
 # High priority class for critical applications
@@ -22,4 +22,3 @@ patches:
         template:
           spec:
             priorityClassName: vixens-high
-

--- a/apps/_shared/components/priority/high/priority.yaml
+++ b/apps/_shared/components/priority/high/priority.yaml
@@ -1,4 +1,4 @@
-
+---
 # Priority class for high priority applications
 apiVersion: apps/v1
 kind: Deployment
@@ -8,4 +8,3 @@ spec:
   template:
     spec:
       priorityClassName: high-priority
-

--- a/apps/_shared/components/priority/low/kustomization.yaml
+++ b/apps/_shared/components/priority/low/kustomization.yaml
@@ -1,4 +1,4 @@
-
+---
 # Kustomize Component: Low Priority
 #
 # Low priority class for non-critical applications
@@ -22,4 +22,3 @@ patches:
         template:
           spec:
             priorityClassName: vixens-low
-

--- a/apps/_shared/components/priority/low/priority.yaml
+++ b/apps/_shared/components/priority/low/priority.yaml
@@ -1,4 +1,4 @@
-
+---
 # Priority class for low priority applications
 apiVersion: apps/v1
 kind: Deployment
@@ -8,4 +8,3 @@ spec:
   template:
     spec:
       priorityClassName: low-priority
-

--- a/apps/_shared/components/priority/medium/kustomization.yaml
+++ b/apps/_shared/components/priority/medium/kustomization.yaml
@@ -1,4 +1,4 @@
-
+---
 # Kustomize Component: Medium Priority
 #
 # Medium priority class for standard applications
@@ -22,4 +22,3 @@ patches:
         template:
           spec:
             priorityClassName: vixens-medium
-

--- a/apps/_shared/components/probes/advanced/kustomization.yaml
+++ b/apps/_shared/components/probes/advanced/kustomization.yaml
@@ -1,4 +1,4 @@
-
+---
 # Kustomize Component: Advanced Probes
 #
 # Advanced health check configuration for critical applications
@@ -50,4 +50,3 @@ patches:
                   timeoutSeconds: 3
                   failureThreshold: 30
                   successThreshold: 1
-

--- a/apps/_shared/components/probes/advanced/probes.yaml
+++ b/apps/_shared/components/probes/advanced/probes.yaml
@@ -1,4 +1,4 @@
-
+---
 # Advanced health check configuration
 apiVersion: apps/v1
 kind: Deployment
@@ -36,4 +36,3 @@ spec:
             timeoutSeconds: 3
             failureThreshold: 30
             successThreshold: 1
-

--- a/apps/_shared/components/probes/basic/kustomization.yaml
+++ b/apps/_shared/components/probes/basic/kustomization.yaml
@@ -1,4 +1,4 @@
-
+---
 # Kustomize Component: Basic Probes
 #
 # Basic health check configuration for applications
@@ -39,4 +39,3 @@ patches:
                   periodSeconds: 5
                   timeoutSeconds: 3
                   failureThreshold: 1
-

--- a/apps/_shared/components/probes/basic/probes.yaml
+++ b/apps/_shared/components/probes/basic/probes.yaml
@@ -1,4 +1,4 @@
-
+---
 # Basic health check configuration
 apiVersion: apps/v1
 kind: Deployment
@@ -25,4 +25,3 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 3
             failureThreshold: 1
-

--- a/apps/_shared/components/resources/kustomization.yaml
+++ b/apps/_shared/components/resources/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 #
 # Kustomize Component: Resource Optimization
 #

--- a/apps/_shared/components/revision-history-limit/kustomization.yaml
+++ b/apps/_shared/components/revision-history-limit/kustomization.yaml
@@ -1,4 +1,4 @@
-
+---
 # Kustomize Component: revisionHistoryLimit
 #
 # Sets revisionHistoryLimit=3 on all Deployments and StatefulSets.

--- a/apps/_shared/namespaces/velero/base/kustomization.yaml
+++ b/apps/_shared/namespaces/velero/base/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/apps/_shared/namespaces/velero/base/namespace.yaml
+++ b/apps/_shared/namespaces/velero/base/namespace.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/test.yaml
+++ b/test.yaml
@@ -1,1 +1,0 @@
-password: TestSecret123

--- a/yamllint-config.yml
+++ b/yamllint-config.yml
@@ -29,13 +29,41 @@ rules:
 
   # ============ DÉSACTIVÉES (K8s-friendly) ============
   line-length: disable
-  trailing-spaces: disable
-  document-start: disable
-  empty-lines: disable
-  comments: disable
-  comments-indentation: disable
-  brackets: disable
-  truthy: disable
+
+  # ============ STYLE (homogénéité rédactionnelle) ============
+  trailing-spaces:
+    level: error
+
+  document-start:
+    level: warning
+    present: true
+
+  empty-lines:
+    max: 1
+    max-start: 0
+    max-end: 0
+    level: warning
+
+  comments:
+    require-starting-space: true
+    ignore-shebangs: true
+    min-spaces-from-content: 1
+    level: warning
+
+  comments-indentation:
+    level: warning
+
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: 0
+    max-spaces-inside-empty: 0
+    level: warning
+
+  truthy:
+    allowed-values: ['true', 'false', 'yes', 'no', 'on', 'off']
+    check-keys: false
+    level: warning
 
   # ============ WARNINGS ============
   new-lines:


### PR DESCRIPTION
## Summary
Re-enable yamllint style rules for editorial consistency and fix all 79 warnings.

## Rules Re-enabled
- `trailing-spaces`: error
- `document-start`: warning (require `---`)
- `empty-lines`: warning (max 1, none at start/end)
- `comments`: warning (space after `#`)
- `comments-indentation`: warning
- `brackets`: warning (no extra spaces)
- `truthy`: warning (quote `Off` values)

## Still Disabled
- `line-length`: K8s URLs, scripts, annotations are legitimately long

## Files Changed
- 57 files modified
- 99 insertions, 311 deletions (mostly blank line removals)

## Verification
```
yamllint -c yamllint-config.yml apps/
# 0 warnings ✅
```