### PR TITLE
fix(ci): use repo yamllint-config.yml and add pre-commit style check

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -25,43 +25,7 @@ jobs:
       - name: Validate YAML syntax
         run: |
           echo "🔍 Validation YAML syntax"
-
-          # Création du fichier ligne par ligne
-          echo "---" > yamllint-config.yml
-          echo "extends: default" >> yamllint-config.yml
-          echo "" >> yamllint-config.yml
-          echo "yaml-files:" >> yamllint-config.yml
-          echo "  - '*.yaml'" >> yamllint-config.yml
-          echo "  - '*.yml'" >> yamllint-config.yml
-          echo "  - '.yamllint'" >> yamllint-config.yml
-          echo "" >> yamllint-config.yml
-          echo "rules:" >> yamllint-config.yml
-          echo "  # ============ ERREURS CRITIQUES ============" >> yamllint-config.yml
-          echo "  indentation:" >> yamllint-config.yml
-          echo "    spaces: 2" >> yamllint-config.yml
-          echo "    indent-sequences: whatever" >> yamllint-config.yml
-          echo "    check-multi-line-strings: false" >> yamllint-config.yml
-          echo "    level: error" >> yamllint-config.yml
-          echo "" >> yamllint-config.yml
-          echo "  key-duplicates:" >> yamllint-config.yml
-          echo "    level: error" >> yamllint-config.yml
-          echo "" >> yamllint-config.yml
-          echo "  # ============ WARNINGS ============" >> yamllint-config.yml
-          echo "  line-length: disable" >> yamllint-config.yml
-          echo "  trailing-spaces: disable" >> yamllint-config.yml
-          echo "" >> yamllint-config.yml
-          echo "  new-lines:" >> yamllint-config.yml
-          echo "    type: unix" >> yamllint-config.yml
-          echo "    level: warning" >> yamllint-config.yml
-          echo "" >> yamllint-config.yml
-          echo "  # ============ DÉSACTIVÉES ============" >> yamllint-config.yml
-          echo "  comments: disable" >> yamllint-config.yml
-          echo "  comments-indentation: disable" >> yamllint-config.yml
-          echo "  brackets: disable" >> yamllint-config.yml
-          echo "  truthy: disable" >> yamllint-config.yml
-          echo "  document-start: disable" >> yamllint-config.yml
-          echo "  empty-lines: disable" >> yamllint-config.yml
-
+          echo "📋 Using repo yamllint-config.yml (strict style enforcement)"
 
           # PR: valider uniquement les fichiers changés
           # Push: valider tous les fichiers
@@ -75,16 +39,16 @@ jobs:
               xargs -r yamllint -c yamllint-config.yml || true
           else
             echo "📋 Push Mode: Validating all files"
-          find apps argocd \( -name "*.yaml" -o -name "*.yml" \) \
-            ! -path "*/crds/*" \
-            ! -path "*/charts/*" \
-            ! -name "upstream.yaml" \
-            ! -name "poolers.yaml" \
-            ! -name "argocd-crds.yaml" \
-            ! -name "argocd-install.yaml" \
-            ! -name "manifests.yaml" \
-            ! -name "servicemonitors.yaml" | \
-            xargs yamllint -c yamllint-config.yml
+            find apps argocd \( -name "*.yaml" -o -name "*.yml" \) \
+              ! -path "*/crds/*" \
+              ! -path "*/charts/*" \
+              ! -name "upstream.yaml" \
+              ! -name "poolers.yaml" \
+              ! -name "argocd-crds.yaml" \
+              ! -name "argocd-install.yaml" \
+              ! -name "manifests.yaml" \
+              ! -name "servicemonitors.yaml" | \
+              xargs yamllint -c yamllint-config.yml
           fi
 
   # 2️⃣ Validation spécifique ArgoCD

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,8 @@
 # Install: pipx install pre-commit && pre-commit install
 # Run manually: pre-commit run --all-files
 #
-# Philosophy: Fast feedback on critical issues only
-# Full validation (yamllint strict, kubeconform) is done by CI
+# Philosophy: Block bad code BEFORE commit
+# Secrets, style violations, and syntax errors caught here (not in CI)
 ---
 repos:
   # ══════════════════════════════════════════════════════════════
@@ -39,5 +39,28 @@ repos:
             apps/00-infra/argocd/base/argocd-crds\.yaml
           )$
 
-  # NOTE: Full validation (yamllint strict, kubeconform, kustomize build)
-  # is handled by CI (GitHub Actions). Pre-commit = fast critical checks only.
+  # ════════════════════════════════════════════════════════════════
+  # YAML STYLE (enforces editorial consistency)
+  # ════════════════════════════════════════════════════════════════
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        name: 📝 YAML style check
+        args: [-c, yamllint-config.yml]
+        exclude: |
+          (?x)^(
+            \.beads/.*|
+            \.bmad-core/.*|
+            \.bmad-infrastructure-devops/.*|
+            \.serena/.*|
+            .*/charts/.*|
+            .*/crds/.*|
+            .*/templates/.*|
+            apps/00-infra/argocd/base/argocd-crds\.yaml|
+            apps/00-infra/argocd/base/argocd-install\.yaml|
+            apps/.*/manifests\.yaml|
+            apps/.*/servicemonitors\.yaml|
+            apps/.*/upstream\.yaml|
+            apps/.*/poolers\.yaml
+          )$

--- a/argocd/base/apps/robusta.yaml
+++ b/argocd/base/apps/robusta.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/argocd/overlays/prod/apps/firefly-iii-importer.yaml
+++ b/argocd/overlays/prod/apps/firefly-iii-importer.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/argocd/overlays/prod/apps/nocodb.yaml
+++ b/argocd/overlays/prod/apps/nocodb.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:


### PR DESCRIPTION
## Summary

- **CI now uses the repo's `yamllint-config.yml`** instead of a hardcoded inline config (removes 35 lines of duplication)
- **Added `yamllint` hook to pre-commit** — bad YAML style is now blocked BEFORE commit, not just in CI
- Excluded tool directories from yamllint: `.beads/`, `.bmad-core/`, `.bmad-infrastructure-devops/`, `.serena/`
- Fixed missing `---` document-start in argocd files

## Quality Gates Now

| Level | Gate | Status |
|-------|------|--------|
| **Local (pre-commit)** | gitleaks + yamllint | ✅ Blocks secrets AND bad style |
| **CI (GitHub Actions)** | yamllint (repo config) | ✅ Same rules as local |
| **CI** | kustomize build | ✅ K8s manifest validation |
| **CI** | kubeconform | ✅ K8s schema validation |

## Before/After

**Before:** Bad YAML style could be committed locally, only caught in CI
**After:** Bad YAML style blocked at commit time (`pre-commit run yamllint`)

## Testing

```bash
pre-commit run --all-files
# 🔐 Detect secrets........................................................Passed
# 🔀 Check merge conflicts.................................................Passed
# 🔑 Detect private keys...................................................Passed
# 📦 Check large files.....................................................Passed
# 📄 Check YAML syntax.....................................................Passed
# 📝 YAML style check......................................................Passed
```