### PR TITLE
fix(argocd): disable openclaw app - needs investigation

### DIFF
--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -64,7 +64,8 @@ resources:
   - apps/hydrus-client.yaml
   - apps/music-assistant.yaml
   - apps/vaultwarden.yaml
-  - apps/openclaw.yaml
+  # DISABLED 2026-03-09: openclaw down - needs investigation (init containers or secrets issue)
+  # - apps/openclaw.yaml
   - apps/cloudnative-pg.yaml
   - apps/redis-shared.yaml
   - apps/postgresql-shared.yaml


### PR DESCRIPTION
Openclaw is down on the cluster. Disabling ArgoCD app until the issue is investigated.

Comment added explaining the disable reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Temporarily disabled a service in the production environment pending further investigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->