### PR TITLE
fix(openclaw): curl flag typo - use -sLo instead of -sOs for rclone download

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -117,7 +117,7 @@ spec:
               chmod +x /data/tools/bin/kubectl
 
               # rclone - download directly to shared volume
-              curl -sOs /tmp/rclone.zip https://downloads.rclone.org/rclone-current-linux-amd64.zip
+              curl -sLo /tmp/rclone.zip https://downloads.rclone.org/rclone-current-linux-amd64.zip
               unzip -j /tmp/rclone.zip rclone -d /data/tools/bin/
               chmod +x /data/tools/bin/rclone
               rm -f /tmp/rclone.zip


### PR DESCRIPTION
## Summary

The `install-tools` init container was failing because rclone wasn't being downloaded correctly.

**Bug**: `curl -sOs /tmp/rclone.zip` doesn't write to the file - `-Os` means "silent + write to remote filename" but there's no filename from the URL path.

**Fix**: Changed to `curl -sLo /tmp/rclone.zip` which correctly writes to the specified output file.

## Evidence

```
unzip:  cannot find or open /tmp/rclone.zip, /tmp/rclone.zip.zip or /tmp/rclone.zip.ZIP.
chmod: cannot access '/data/tools/bin/rclone': No such file or directory
```

## Testing

Will be verified when ArgoCD syncs and the pod restarts.