### PR TITLE
fix(openclaw): add DISCORD_TOKEN env var from secret

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -396,6 +396,11 @@ spec:
                 secretKeyRef:
                   name: openclaw-secrets
                   key: OPENCLAW_GATEWAY_TOKEN
+            - name: DISCORD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw-secrets
+                  key: OPENCLAW_DISCORD_TOKEN
           livenessProbe:
             tcpSocket:
               port: 18789


### PR DESCRIPTION
## Summary

Openclaw was crashing because it expected `DISCORD_TOKEN` environment variable but it wasn't being injected.

**Error:**
```
Gateway failed to start: Error: Startup failed: required secrets are unavailable. 
SecretRefResolutionError: Environment variable "DISCORD_TOKEN" is missing or empty.
```

**Fix:** Add `DISCORD_TOKEN` env var sourced from `openclaw-secrets.OPENCLAW_DISCORD_TOKEN`.

## Testing

Will be verified when ArgoCD syncs and pod restarts.