### PR TITLE
fix(birdnet): use generated-litestream-config in litestream container

### DIFF
--- a/apps/20-media/birdnet-go/base/deployment.yaml
+++ b/apps/20-media/birdnet-go/base/deployment.yaml
@@ -182,7 +182,7 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
-            - name: litestream-config
+            - name: generated-litestream-config
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
           resources:
@@ -270,9 +270,6 @@ spec:
           nfs:
             server: 192.168.111.69
             path: /volume3/Internal
-        - name: litestream-config
-          configMap:
-            name: birdnet-go-litestream-config
         - name: generated-litestream-config
           emptyDir: {}
       securityContext:


### PR DESCRIPTION
## Context
Post-PR #1965 merge, birdnet-go is still in CrashLoopBackOff because the litestream container (main, not init) was still using the old `litestream-config` ConfigMap instead of the dynamically generated `generated-litestream-config`.

## Root Cause
PR #1965 added init container to generate litestream config with env var interpolation, but forgot to update the **litestream container** (line 185) volume mount from `litestream-config` to `generated-litestream-config`.

## Changes
- Line 185: Changed `litestream-config` → `generated-litestream-config` in litestream container volumeMount
- Lines 273-275: Removed unused `litestream-config` ConfigMap volume definition

## Impact
- ✅ Init container `litestream-restore` will now read correct generated config
- ✅ Main container `litestream` will now read correct generated config
- ✅ Both containers use same generated file with interpolated `$LITESTREAM_BUCKET`

## Testing
```bash
yamllint -c yamllint-config.yml apps/20-media/birdnet-go/base/deployment.yaml  # ✅ Pass
kustomize build apps/20-media/birdnet-go/overlays/prod  # ✅ OK
```

## Related
- PR #1965 - Initial fix (added init container, fixed firefly/promtail)
- This PR completes the birdnet-go fix by ensuring ALL containers use generated config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored deployment configuration management to dynamically generate configurations at container startup, improving system reliability and reducing reliance on pre-configured resources. Configuration is now self-contained within the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->