### PR TITLE
fix(birdnet): correct litestream.yml field order (addr before dbs)

### DIFF
--- a/apps/20-media/birdnet-go/base/deployment.yaml
+++ b/apps/20-media/birdnet-go/base/deployment.yaml
@@ -65,12 +65,12 @@ spec:
           args:
             - |
               cat > /litestream-config/litestream.yml <<EOF
+              addr: ":9090"
               dbs:
                 - path: /data/birdnet.db
                   replicas:
                     - url: s3://${LITESTREAM_BUCKET}/birdnet.db
                       endpoint: ${LITESTREAM_ENDPOINT}
-              addr: ":9090"
               EOF
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Context
After PR #1966, birdnet-go still crashes with \"bucket required for s3 replica\" error.

## Root Cause
The generated `litestream.yml` had incorrect field order:
- **Before:** `dbs` → `replicas` → `addr`
- **After:** `addr` → `dbs` → `replicas` ✅

Litestream expects `addr` at root level BEFORE `dbs` section.

## Changes
- Moved `addr: ":9090"` to the **first line** of generated YAML (before `dbs:`)

## Testing
```bash
yamllint -c yamllint-config.yml apps/20-media/birdnet-go/base/deployment.yaml  # ✅
kustomize build apps/20-media/birdnet-go/overlays/prod  # ✅
```

## Expected Outcome
Init container `litestream-restore` will successfully read S3 bucket from generated config and restore database.

## Related
- PR #1965 - Initial fix (added init container, fixed firefly/promtail)
- PR #1966 - Fixed volume mount reference
- This PR - Fixes YAML field order for litestream compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized deployment configuration settings to improve clarity and eliminate duplicate entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->