### PR TITLE
fix(birdnet-go): correct data-syncer probe configuration to prevent restarts

### DIFF
--- a/apps/20-media/birdnet-go/base/deployment.yaml
+++ b/apps/20-media/birdnet-go/base/deployment.yaml
@@ -245,17 +245,22 @@ spec:
           readinessProbe:
             exec:
               command:
-                - pgrep
-                - rclone
+                - sh
+                - -c
+                - "pgrep -f 'sync_s3' || pgrep -f 'rclone sync'"
             initialDelaySeconds: 10
-            periodSeconds: 30
+            periodSeconds: 90  # Longer than sync cycle (sync 5s + sleep 60s)
+            timeoutSeconds: 5  # Industry standard for sidecars (promtail lesson)
+            failureThreshold: 3
           livenessProbe:
             exec:
               command:
-                - pgrep
-                - rclone
+                - sh
+                - -c
+                - "pgrep -f 'sync_s3' || pgrep -f 'rclone sync'"
             initialDelaySeconds: 30
-            periodSeconds: 60
+            periodSeconds: 90  # Longer than sync cycle (sync 5s + sleep 60s)
+            timeoutSeconds: 5  # Industry standard for sidecars (promtail lesson)
             failureThreshold: 3
       volumes:
         - name: config


### PR DESCRIPTION
## Issue

BirdNet-Go `data-syncer` container experiencing **269 restarts in 30h**.

### Root Cause

The data-syncer runs a sync loop:
```bash
while true; do
  rclone sync /data s3:... ;  # ~5 seconds
  sleep 60;                    # 60 seconds idle
done
```

Probes were checking `pgrep rclone`, which **fails during the sleep period** (rclone not running) → probe fails → container restarts.

---

## Resolution

### Changed Probe Command
```yaml
# OLD (fails during sleep)
command: ["pgrep", "rclone"]

# NEW (checks shell script process)
command: ["sh", "-c", "pgrep -f 'sync_s3' || pgrep -f 'rclone sync'"]
```

### Adjusted Timings

| Parameter | Old | New | Rationale |
|-----------|-----|-----|-----------|
| `periodSeconds` (readiness) | 30 | 90 | Longer than sync cycle (65s) |
| `periodSeconds` (liveness) | 60 | 90 | Longer than sync cycle (65s) |
| `timeoutSeconds` | 1 | 5 | Industry standard for sidecars (promtail lesson) |

---

## Standards Compliance

- ✅ **Silver tier**: `require-probes` policy (liveness + readiness)
- ✅ **Promtail lesson**: 5s timeout (not 1s - too strict for sidecars)
- ✅ **Probe logic**: Checks shell loop, not just rclone process
- ✅ **Cycle-aware**: `periodSeconds: 90` > sync cycle (65s)

---

## Validation

- ✅ yamllint: PASSED
- ✅ kustomize build: PASSED
- ✅ Pre-commit hooks: PASSED (secrets, YAML, merge conflicts)

---

## Expected Result

- data-syncer restart count stabilizes at **0**
- Probes pass during both sync and sleep phases
- Container remains healthy throughout 90s cycle

---

**Part of production cluster health monitoring - proactive fix for high restart count.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced health monitoring and failure detection for the data sync service to improve system reliability and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->