### PR TITLE
docs(napkin): create agent memory with critical security rules

### DIFF
--- a/.opencode/napkin.md
+++ b/.opencode/napkin.md
@@ -1,0 +1,116 @@
+# Napkin - Agent Memory & Rules
+
+**Continuously curated runbook for AI agents working on Vixens.**
+
+Last updated: 2026-03-11
+
+---
+
+## 🔴 CRITICAL - Security Rules (Priority 1)
+
+### NEVER Write Credentials Anywhere
+
+**RULE:** Credentials MUST NEVER appear in:
+- ❌ Beads task descriptions
+- ❌ Git commit messages
+- ❌ PR descriptions or comments
+- ❌ Code comments
+- ❌ Documentation files
+- ❌ Log messages or debug output
+
+**WHERE credentials belong:**
+- ✅ Infisical vault (production secrets)
+- ✅ Kubernetes Secrets (managed by InfisicalSecret)
+- ✅ MinIO admin CLI (ephemeral, for rotation only)
+- ✅ `.secrets/` directory (gitignored, local only)
+
+**WHEN rotating credentials:**
+- ✅ "Rotated MinIO credentials for adguard-home"
+- ❌ "New key: ABC123XYZ / secret456..."
+
+**INCIDENT REFERENCE:** 2026-03-10 - Leaked credentials in PRs #1975-1977 via Beads task descriptions. Credentials rotated, PRs closed, `.beads/issues.jsonl` gitignored. **Root cause: Agent wrote credentials in task descriptions.**
+
+---
+
+## 📋 Workflow Standards (Priority 2)
+
+### Probe Timeout Standards
+
+**RULE:** Probe timeouts must match workload type:
+- APIs (low-latency): 1-2s
+- **DaemonSets/sidecars: 5s** (industry standard)
+- Batch jobs: 10s+
+
+**RATIONALE:** DaemonSets run on control-plane nodes under load. 1s timeout too strict → false failures → restarts.
+
+**EXAMPLES:**
+- ✅ Promtail: 5s timeout (PR #1980)
+- ✅ BirdNet data-syncer: 5s timeout (PR #1981)
+
+### Probe Logic for Periodic Containers
+
+**RULE:** For containers with `while true; do work; sleep N; done` pattern:
+- ❌ Check work process (`pgrep rclone`) - fails during sleep
+- ✅ Check shell script process (`pgrep -f 'script_name'`)
+- ✅ Set `periodSeconds` > work cycle duration
+
+**EXAMPLE:** BirdNet data-syncer (PR #1981)
+- Cycle: rclone sync (5s) + sleep 60s = 65s
+- Probe: `pgrep -f 'sync_s3'` with `periodSeconds: 90`
+
+---
+
+## 🎯 Resource Sizing (Priority 3)
+
+### CronJob Resource Limits
+
+**RULE:** CronJobs need generous limits (VPA doesn't apply):
+- Set explicit `requests` (normal operation)
+- Set high `limits` (burst protection)
+- Cost of OOM > cost of over-provisioning
+
+**EXAMPLE:** Renovate (PR #1980)
+- Request: 512Mi (normal)
+- Limit: 2Gi (burst during large dependency scans)
+
+---
+
+## 📝 Documentation Requirements (Priority 4)
+
+### Mandatory Updates
+
+**RULE:** After EVERY deployment, update:
+1. `docs/applications/<category>/<app>.md` - Deployment table + Known Issues
+2. `docs/STATUS.md` - Application status + restart counts
+
+**NO EXCEPTIONS.** Documentation is code.
+
+---
+
+## 🔧 Known Patterns (Priority 5)
+
+### DNS Dependency Cycles
+
+**PATTERN:** Service provides DNS but needs DNS to bootstrap (e.g., AdGuard Home).
+
+**SOLUTION:**
+- Use IP addresses instead of DNS names in init containers
+- Example: `LITESTREAM_ENDPOINT=http://192.168.111.69:9000` (not DNS)
+
+**REFERENCE:** AdGuard Home (2026-03-10) - Litestream needed MinIO via DNS, but AdGuard provides cluster DNS.
+
+---
+
+## 🚫 Anti-Patterns (Priority 6)
+
+### Things to NEVER Do
+
+1. **Suppress type errors:** No `as any`, `@ts-ignore`, `@ts-expect-error`
+2. **Commit without request:** Never `git commit` unless explicitly asked
+3. **Shotgun debugging:** Random changes hoping something works
+4. **Delete failing tests:** Fix the code, not the test
+5. **Skip validation:** Always run linters/tests before marking complete
+
+---
+
+**This napkin is continuously curated. Remove outdated items, keep only recurring high-value guidance.**


### PR DESCRIPTION
## Purpose

Create persistent memory (napkin) for AI agents across sessions to prevent recurring mistakes.

## Critical Rule Added

**NEVER write credentials in:**
- Task descriptions (Beads)
- Git commits or PR descriptions
- Code comments or documentation
- Log messages

**Credentials belong ONLY in:**
- Infisical vault
- Kubernetes Secrets (via InfisicalSecret)
- MinIO CLI (ephemeral rotation only)

## Incident Reference

**2026-03-10:** Leaked credentials in PRs #1975-1977 because agent wrote actual MinIO credentials in Beads task descriptions.

**Resolution:**
- Credentials rotated
- PRs closed
- `.beads/issues.jsonl` gitignored
- **This napkin created to prevent recurrence**

## Additional Rules Documented

- Probe timeout standards (5s for DaemonSets/sidecars)
- Probe logic for periodic containers
- CronJob resource limits
- Documentation requirements
- DNS dependency cycle patterns
- Anti-patterns (type suppression, shotgun debugging)

## How This Works

1. Napkin is read by agents at session start (via `napkin` skill)
2. Rules are continuously curated (outdated items removed)
3. High-priority patterns stay at top
4. Serves as **persistent memory** between sessions

---

**This napkin ensures the same security mistakes don't happen again.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added operational guidance documentation covering security practices, workflow standards, resource management, and known patterns for development teams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->