### PR TITLE
fix(openclaw): quote rclone exclude patterns to prevent shell glob expansion

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -433,18 +433,33 @@ spec:
               echo "DEBUG: RCLONE_BUCKET=$RCLONE_BUCKET"
 
               # Rclone reads RCLONE_CONFIG_S3_* env vars automatically from envFrom secretRef
-              EXCLUDES="--exclude lost+found/** --exclude node_modules/** --exclude tools/** --exclude gemini-cli/** --exclude browser/** --exclude canvas/** --exclude extensions/** --exclude .openclaw/** --exclude media/** --exclude netbox-mcp-server/**"
+              # NOTE: excludes must be single-quoted directly in the command - never via a variable.
+              # The rclone image uses WORKDIR /data, so unquoted globs (tools/**) expand to
+              # real files and break the rclone arg parser.
+              do_rclone_sync() {
+                rclone sync /data "s3:${RCLONE_BUCKET}" \
+                  --exclude 'lost+found/**' \
+                  --exclude 'node_modules/**' \
+                  --exclude 'tools/**' \
+                  --exclude 'gemini-cli/**' \
+                  --exclude 'browser/**' \
+                  --exclude 'canvas/**' \
+                  --exclude 'extensions/**' \
+                  --exclude '.openclaw/**' \
+                  --exclude 'media/**' \
+                  --exclude 'netbox-mcp-server/**'
+              }
 
               # Handle pending backup lock from external tool
               if [ -f /data/backup.lock ]; then
                 echo "backup.lock found - performing immediate backup before sync loop"
-                rclone sync /data s3:$RCLONE_BUCKET $EXCLUDES || echo "Backup failed"
+                do_rclone_sync || echo "Backup failed"
                 rm -f /data/backup.lock
                 echo "Backup complete, lock removed"
               fi
 
               sync_s3() {
-                rclone sync /data s3:$RCLONE_BUCKET $EXCLUDES || echo "Sync failed"
+                do_rclone_sync || echo "Sync failed"
               }
               while true; do
                 sync_s3;


### PR DESCRIPTION
## Root Cause

The rclone Docker image sets \`WORKDIR /data\`. The data-syncer script stored exclude
patterns in a shell variable:
\`\`\`sh
EXCLUDES="--exclude tools/** --exclude .openclaw/** ..."
rclone sync /data s3:$BUCKET $EXCLUDES  # BUG: unquoted glob expansion
\`\`\`

When \`\$EXCLUDES\` is unquoted, the shell glob-expands patterns like \`tools/**\` into
actual files (\`tools/lib\`, \`tools/usr\`...) because CWD is \`/data\`. The \`--exclude\`
flags get separated from their patterns → rclone receives 18 positional args → crash.

## Fix

Use a function with single-quoted patterns directly in the rclone command:
\`\`\`sh
do_rclone_sync() {
  rclone sync /data "s3:${RCLONE_BUCKET}" \
    --exclude 'lost+found/**' \
    --exclude 'tools/**' \
    ...
}
\`\`\`

Single quotes prevent shell glob expansion entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved data synchronization and backup reliability by enhancing consistency in S3 bucket synchronization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->