### PR TITLE
fix(openclaw): replace alpine+jq with python in fix-config init container

### DIFF
--- a/.opencode/napkin.md
+++ b/.opencode/napkin.md
@@ -203,6 +203,48 @@ diff /tmp/before.txt /tmp/after.txt
 
 **REFERENCE:** AGENTS.md Step 3b - Mandatory kustomize kinds diff check.
 
+### OpenClaw PVC Recovery Pattern
+
+**PATTERN:** When openclaw.json is lost/corrupted, old Released PVs on Synology NAS contain the backup.
+
+**PROCEDURE:**
+```bash
+# 1. Find Released PVs
+kubectl get pv | grep Released | grep openclaw
+
+# 2. Remove claimRef to make Available
+kubectl patch pv <pv-name> --type json -p '[{"op":"remove","path":"/spec/claimRef"}]'
+
+# 3. Create recovery PVC (must include volumeName + securityContext uid=1000)
+# 4. Create recovery pod (uid=1000, labels: vixens.io/sizing: recovery)
+# 5. kubectl exec and read /data/openclaw.json
+# 6. IMPORTANT: Remove skills.load.paths if present (old key, causes crash)
+# 7. Scale down openclaw, disable ArgoCD auto-sync, copy fixed config, re-enable
+# 8. Cleanup: delete recovery pod, pvc
+```
+
+**KEY LESSON:** openclaw.json may have `skills.load.paths` from old versions. Remove before restoring.
+Do instead: `python3 -c "import json,sys; d=json.load(sys.stdin); d.get('skills',{}).pop('load',None); print(json.dumps(d))" < original.json > fixed.json`
+
+**REFERENCE:** 2026-03-11 recovery from pvc-7c8f2a5a (Feb 15 backup) - recovered 31 agents incl. Lisa/Meli/Aurelia
+
+### ArgoCD Auto-Sync Temporary Disable (Emergency Only)
+
+**WHEN:** Need to make manual changes without ArgoCD selfHeal reverting (e.g., config recovery).
+
+```bash
+# Disable auto-sync
+kubectl patch application <app> -n argocd --type merge -p '{"spec":{"syncPolicy":{"automated":null}}}'
+
+# ... do manual work ...
+
+# Re-enable (MANDATORY - never leave disabled)
+kubectl patch application <app> -n argocd --type merge -p '{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
+```
+
+Do instead: ALWAYS re-enable auto-sync immediately after emergency work.
+**REFERENCE:** 2026-03-11 - Used to copy fixed openclaw.json without ArgoCD self-healing back
+
 ---
 
 ## 🚫 Anti-Patterns (Priority 6)

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -243,7 +243,7 @@ spec:
         # Fix invalid config keys that may have been self-injected
         # NOTE: Using alpine+jq because ghcr.io/jqlang/jq image has no shell
         - name: fix-config
-          image: alpine:3.23
+          image: python:3.12-alpine
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -252,17 +252,9 @@ spec:
             - -c
           args:
             - |
-              apk add --no-cache jq
               echo "Checking for invalid config keys..."
               if [ -f /data/openclaw.json ]; then
-                # Remove known invalid keys that openclaw may have auto-added
-                jq 'del(.skills.load.paths) | del(.skills.load) | if .skills == {} then del(.skills) else . end' /data/openclaw.json > /tmp/openclaw.json.tmp
-                if [ -s /tmp/openclaw.json.tmp ]; then
-                  mv /tmp/openclaw.json.tmp /data/openclaw.json
-                  echo "Config cleaned successfully"
-                else
-                  echo "WARNING: jq output empty, keeping original"
-                fi
+                python3 -c "import json; p='/data/openclaw.json'; d=json.load(open(p)); s=d.get('skills',{}); l=s.get('load',{}) if isinstance(s,dict) else {}; l.pop('paths',None); (s.pop('load') if isinstance(s,dict) and not l else None); (d.pop('skills') if isinstance(s,dict) and not s else None); json.dump(d, open(p,'w')); print('Config fixed')" && echo 'Done'
               else
                 echo "No config file to fix"
               fi


### PR DESCRIPTION
## Summary

- Replace `alpine:3.23` + `apk add jq` with `python:3.12-alpine` in the `fix-config` init container
- `apk add jq` was failing silently when init containers have no network access, leaving `skills.load.paths` invalid key uncleaned → openclaw crash on restart
- Python is available in the alpine Python image without needing any install step

## Root Cause

The `fix-config` init container tried to `apk add --no-cache jq` but this fails when Alpine can't reach package repos from within the cluster. The script then tried to run `jq` → not found → output empty → `WARNING: jq output empty, keeping original` → bad key survived → openclaw crashed.

## Fix

Use `python3 -c "..."` inline one-liner to perform the same JSON key removal. Python 3.12 is bundled in the `python:3.12-alpine` image, no network installation needed.

## Testing

- Napkin updated with PVC recovery patterns for future reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added recovery guides for OpenClaw PVC restoration and an emergency-only ArgoCD auto-sync disable/reenable workflow; includes step-by-step procedures, remediation tips, and a note on reverting changes. (Guides were added in two places.)

* **Refactor**
  * Updated configuration-processing step to use a Python-based JSON cleanup for safer removal of obsolete fields and more reliable config restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->