### PR TITLE
fix(openclaw): fix KeyError in fix-config init container when skills key absent

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -254,7 +254,7 @@ spec:
             - |
               echo "Checking for invalid config keys..."
               if [ -f /data/openclaw.json ]; then
-                python3 -c "import json; p='/data/openclaw.json'; d=json.load(open(p)); s=d.get('skills',{}); l=s.get('load',{}) if isinstance(s,dict) else {}; l.pop('paths',None); (s.pop('load') if isinstance(s,dict) and not l else None); (d.pop('skills') if isinstance(s,dict) and not s else None); json.dump(d, open(p,'w')); print('Config fixed')" && echo 'Done'
+                python3 -c "import json; p='/data/openclaw.json'; d=json.load(open(p)); s=d.get('skills',{}); l=s.get('load',{}) if isinstance(s,dict) else {}; l.pop('paths',None); (s.pop('load',None) if isinstance(s,dict) and not l else None); (d.pop('skills',None) if isinstance(s,dict) and not s else None); json.dump(d, open(p,'w')); print('Config fixed')" && echo 'Done'
               else
                 echo "No config file to fix"
               fi


### PR DESCRIPTION
## Summary

- Fix `KeyError: 'load'` crash in `fix-config` init container
- Introduced in #1986: `s.pop('load')` and `d.pop('skills')` without default raise `KeyError` when the key doesn't exist
- Configs that have no `skills` section (e.g. after recovery cleanup) would crash the init container → OpenClaw stuck in `Init:CrashLoopBackOff`

## Fix

Replace `s.pop('load')` → `s.pop('load', None)` and `d.pop('skills')` → `d.pop('skills', None)`.

Two chars. The `.pop(key, None)` form silently returns `None` instead of raising `KeyError` when the key is absent.