### PR TITLE
fix(openclaw): add set -e to init container install scripts

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -52,6 +52,7 @@ spec:
             - -c
           args:
             - |
+              set -e
               TOOLS_VERSION="1"
               if [ -f /data/tools/.installed-version ] && [ "$(cat /data/tools/.installed-version)" = "$TOOLS_VERSION" ]; then
                 echo "Tools v$TOOLS_VERSION already present, skipping reinstall"
@@ -198,6 +199,7 @@ spec:
             - -c
           args:
             - |
+              set -e
               PLUGIN_VERSION="2026.1.22"
               if [ -f /data/node_modules/.gemini-plugin-version ] && \
                  [ "$(cat /data/node_modules/.gemini-plugin-version)" = "$PLUGIN_VERSION" ] && \


### PR DESCRIPTION
## Problem

Without \`set -e\`, a failed download (GitHub rate limit, network timeout, CDN issue) in \`install-tools\` or \`install-gemini\` would silently continue and still write the version file at the end of the block.

**Result:** next restart hits the skip condition → tools considered installed → missing tools permanently (until someone manually increments \`TOOLS_VERSION\` / \`PLUGIN_VERSION\`).

**Example failure path in \`install-tools\`:**
\`\`\`sh
curl -sLo /data/tools/bin/talosctl "https://github.com/..."  # network timeout
chmod +x /data/tools/bin/talosctl                              # succeeds on empty file
# ... rest of script continues ...
echo "1" > /data/tools/.installed-version                      # written!
# → next restart: "Tools v1 already present, skipping reinstall"
# → talosctl is missing forever
\`\`\`

## Fix

Add \`set -e\` at the top of both args scripts (before the version check).

- Commands in \`if\` conditions are exempt from \`set -e\` by POSIX → version check unaffected
- \`chown ... || true\` at the end is exempt → always runs safely
- Any failed \`curl\`, \`npm install\`, \`tar\`, etc. → container exits non-zero → Kubernetes restarts it → clean retry

## Validation

- ✅ \`yamllint\` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment initialization error handling to immediately stop on failures during setup, ensuring cleaner failure states and more reliable deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->