### PR TITLE
fix(openclaw): increase startupProbe failureThreshold 30 → 90 (900s)

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -286,7 +286,7 @@ spec:
           startupProbe:
             tcpSocket:
               port: 18789
-            failureThreshold: 30
+            failureThreshold: 90
             periodSeconds: 10
           volumeMounts:
             - name: data


### PR DESCRIPTION
## Problem

OpenClaw loads 31 agents and connects all their platforms (Discord, Telegram, GitHub, Gemini) at startup. This consistently takes 6-10 minutes.

The previous `failureThreshold: 30` with `periodSeconds: 10` only allowed **300s (5 min)** — the pod was crash-looping every 5 minutes, killing Lisa and all other agents before they could come online.

## Observed behavior

- Container started → claw-hass extension failure (harmless) → worker actively loading at 9.6% CPU → killed at exactly 300s
- Repeated on every restart (2+ restarts observed before this fix)

## Fix

`failureThreshold: 90` → **900s (15 min)** startup window. More than enough for all 31 agents to connect.

## Why this was always broken

The old pod (`openclaw-699676bfdb-vdxvf`) ran for days with 0 restarts — it just happened to start once and was never restarted. Our init container merge (PR #1988) triggered a rollout, exposing that the startup probe was too strict for this app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted container startup probe configuration to enhance service initialization resilience and allow extended startup sequencing time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->