### PR TITLE
fix(openclaw): set SB-xlarge sizing for main container (OOM fix)

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         vixens.io/sizing.restore-config: B-nano
         vixens.io/sizing.setup-config: G-nano
         vixens.io/sizing.install-gemini: B-medium
+        vixens.io/sizing.openclaw: SB-xlarge
         vixens.io/backup-profile: "relaxed"
       annotations:
         vixens.io/fast-start: "true"


### PR DESCRIPTION
## Problem

OpenClaw main container had no `vixens.io/sizing.*` label, so Kyverno's unlabeled sidecar defaults gave it only **128Mi request / 512Mi limit**.

During cold start, jiti TypeScript compilation (triggered by new `@google/gemini-cli` install) pushes RSS to ~350MB+ before port 18789 opens. The OOM killer terminates the container (exit code 137) before the startup probe can succeed → crash loop.

## Evidence

```
Last State: Terminated
  Reason: Error
  Exit Code: 137     ← OOM kill
  Started: Wed, 11 Mar 2026 10:41:33 +0100
  Finished: Wed, 11 Mar 2026 10:49:29 +0100   ← killed after ~8min (jiti peak)
```

VPA recommendation already knew:
- `target: 1.7Gi` 
- `lowerBound: 763Mi`

But VPA couldn't override the 512Mi limit because it needs stable history, and the pod kept OOMing before accumulating it.

## Fix

Add `vixens.io/sizing.openclaw: SB-xlarge` label:
- **Request:** 2Gi (matches VPA target)
- **Limit:** 8Gi (room for jiti cold-start burst)
- **CPU:** 200m req / 2000m lim (burstable for compilation)

VPA will tune down after the first successful startup builds history.

## Impact

- OpenClaw can complete cold startup without OOM
- Lisa and other Discord agents come back online
- VPA takes over long-term right-sizing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration with infrastructure metadata label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->