### PR TITLE
fix(openclaw): migrate legacy .openclaw/workspace to active workspace on startup

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -115,6 +115,26 @@ spec:
               rclone lsd s3:$RCLONE_BUCKET || echo "Rclone list failed"
               rclone copy s3:$RCLONE_BUCKET/.openclaw /data/.openclaw --transfers 4 --exclude "lost+found/**" 2>/dev/null || true
               rclone copy s3:$RCLONE_BUCKET/extensions /data/extensions --transfers 4 --exclude "lost+found/**" 2>/dev/null || true
+              # Step 1b: Migrate workspace from .openclaw/workspace/ to workspace/ if needed
+              # (openclaw changed workspace path between versions; legacy data lives in .openclaw/workspace/)
+              LEGACY_WS=/data/.openclaw/workspace
+              ACTIVE_WS=/data/workspace
+              if [ -d "$LEGACY_WS" ] && [ -f "$LEGACY_WS/MEMORY.md" ]; then
+                # Check if active workspace is still a blank template (IDENTITY.md has no name)
+                if ! grep -q '^- \*\*Name:\*\* ' "$ACTIVE_WS/IDENTITY.md" 2>/dev/null; then
+                  echo "Migrating workspace from $LEGACY_WS to $ACTIVE_WS..."
+                  cp -rn "$LEGACY_WS/." "$ACTIVE_WS/" 2>/dev/null || true
+                  # Force-overwrite key identity files
+                  for f in IDENTITY.md USER.md SOUL.md AGENTS.md MEMORY.md; do
+                    [ -f "$LEGACY_WS/$f" ] && cp -f "$LEGACY_WS/$f" "$ACTIVE_WS/$f" && echo "  migrated $f"
+                  done
+                  # Remove BOOTSTRAP.md if identity is now populated
+                  grep -q '^- \*\*Name:\*\* ' "$ACTIVE_WS/IDENTITY.md" 2>/dev/null && rm -f "$ACTIVE_WS/BOOTSTRAP.md" && echo "  removed BOOTSTRAP.md"
+                  echo "Workspace migration complete"
+                else
+                  echo "Active workspace already populated, skipping migration"
+                fi
+              fi
               # Step 2: Restore openclaw.json (was restore-config)
               if [ -f /data/backup.lock ]; then
                 echo "backup.lock found - preserving local config changes"


### PR DESCRIPTION
## Problème

OpenClaw a changé de structure de workspace entre versions. L'ancienne version stockait le workspace de Lisa dans \`/data/.openclaw/workspace/\` (sauvegardé/restauré via le restore-config init container). La version actuelle utilise \`/data/workspace/\`.

Au redémarrage, le workspace actif \`/data/workspace/\` était vide (templates par défaut), alors que la vraie mémoire de Lisa (IDENTITY.md, MEMORY.md, USER.md, SOUL.md remplis depuis février 2026) se trouvait dans \`/data/.openclaw/workspace/\`.

## Fix

Ajout d'une étape de migration dans le restore-config init container :
- Vérifie si le workspace actif contient encore le template vide (pas de nom dans IDENTITY.md)
- Si oui, et si le legacy workspace contient un MEMORY.md → migration automatique
- Force-overwrite des fichiers identité clés (IDENTITY.md, USER.md, SOUL.md, AGENTS.md, MEMORY.md)
- Supprime BOOTSTRAP.md si l'identité est maintenant définie
- Idempotent : skip si le workspace actif est déjà rempli

## Impact

Lisa retrouve sa mémoire et son identité après chaque redémarrage de pod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated workspace migration that safely transfers legacy data while preserving existing configurations during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->