### PR TITLE
feat(openclaw): install gcloud CLI in install-tools init container

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -54,7 +54,7 @@ spec:
           args:
             - |
               set -e
-              TOOLS_VERSION="1"
+              TOOLS_VERSION="2"
               if [ -f /data/tools/.installed-version ] && [ "$(cat /data/tools/.installed-version)" = "$TOOLS_VERSION" ]; then
                 echo "Tools v$TOOLS_VERSION already present, skipping reinstall"
               else
@@ -89,6 +89,12 @@ spec:
                 tar -xzf /tmp/himalaya.tar.gz -C /data/tools/bin/ himalaya && chmod +x /data/tools/bin/himalaya && rm /tmp/himalaya.tar.gz
                 curl -sSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
                 python3 /tmp/get-pip.py --root=/data/tools --ignore-installed && rm /tmp/get-pip.py
+                # Install gcloud CLI (standalone archive → /data/tools/google-cloud-sdk/)
+                curl -sSL "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz" -o /tmp/gcloud.tar.gz
+                tar -xzf /tmp/gcloud.tar.gz -C /data/tools/ && rm /tmp/gcloud.tar.gz
+                ln -sf /data/tools/google-cloud-sdk/bin/gcloud /data/tools/bin/gcloud
+                ln -sf /data/tools/google-cloud-sdk/bin/gsutil /data/tools/bin/gsutil
+                ln -sf /data/tools/google-cloud-sdk/bin/bq /data/tools/bin/bq
                 echo "node ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/node
                 echo "$TOOLS_VERSION" > /data/tools/.installed-version
                 apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

- Bump `TOOLS_VERSION` from `1` to `2` to force reinstall on pods that already have tools cached
- Download Google Cloud CLI standalone archive (x86_64) into `/data/tools/google-cloud-sdk/`
- Symlink `gcloud`, `gsutil`, `bq` binaries into `/data/tools/bin/` (already in PATH for all containers sharing the data PVC)

## Why

OpenClaw agents need `gcloud` CLI available for GCP operations (GCS buckets, Vertex AI, etc.).
The install-tools init container is the canonical place for shared CLI tools on the data volume.

## Impact

- First deploy after merge: init container reinstalls ALL tools (TOOLS_VERSION bump) — expect ~5-10 min pod startup
- Subsequent deploys: init container skips (version cached)
- No changes to other containers, secrets, or configs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google Cloud CLI tools (gcloud, gsutil, bq) are now installed and available in the deployment environment.

* **Chores**
  * Updated tools version used during deployment initialization to the next release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->