### PR TITLE
feat(openclaw): install google-auth-oauthlib and google-api-python-client

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -54,7 +54,7 @@ spec:
           args:
             - |
               set -e
-              TOOLS_VERSION="2"
+              TOOLS_VERSION="3"
               if [ -f /data/tools/.installed-version ] && [ "$(cat /data/tools/.installed-version)" = "$TOOLS_VERSION" ]; then
                 echo "Tools v$TOOLS_VERSION already present, skipping reinstall"
               else
@@ -95,6 +95,8 @@ spec:
                 ln -sf /data/tools/google-cloud-sdk/bin/gcloud /data/tools/bin/gcloud
                 ln -sf /data/tools/google-cloud-sdk/bin/gsutil /data/tools/bin/gsutil
                 ln -sf /data/tools/google-cloud-sdk/bin/bq /data/tools/bin/bq
+                # Install Google Python libraries
+                pip3 install --root=/data/tools google-auth-oauthlib google-api-python-client
                 echo "node ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/node
                 echo "$TOOLS_VERSION" > /data/tools/.installed-version
                 apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

- Bump \`TOOLS_VERSION\` from \`2\` to \`3\` to force reinstall
- Install Google Python libraries via \`pip3 install --root=/data/tools\`:
  - **google-auth-oauthlib** — OAuth2 flow support for Google APIs
  - **google-api-python-client** — Discovery-based Google API client
- Packages land in \`/data/tools/usr/local/lib/python*/dist-packages\` (covered by \`PYTHONPATH\`)

## Note

Pod currently initializing with v2 (gcloud). This PR bumps to v3 → next pod startup will reinstall everything including these Python libs.