### PR TITLE
feat(lazylibrarian): Bronze maturity - cleanup old ReplicaSet

### DIFF
--- a/apps/20-media/lazylibrarian/base/deployment.yaml
+++ b/apps/20-media/lazylibrarian/base/deployment.yaml
@@ -34,6 +34,7 @@ spec:
         prometheus.io/path: "/metrics"
         vixens.io/no-long-connections: "true"
         vixens.io/explicitly-allow-root: "true"
+        kubectl.kubernetes.io/restartedAt: "2026-03-11T21:00:00Z"
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
## Summary
Trigger rollout to cleanup old ReplicaSet with `:latest` image tag blocking Bronze maturity.

## Problem
- Current deployment has **correct** pinned image (`version-e7c7ce2d`)
- Old ReplicaSet `lazylibrarian-67b6f58d54` has `:latest` tag (not garbage collected)
- Maturity controller aggregates ALL ReplicaSets → blocked by old RS
- `revisionHistoryLimit: 3` but 4 RS exist (GC stuck)

## Solution
Add `kubectl.kubernetes.io/restartedAt` annotation to force new rollout:
- Creates new ReplicaSet
- Triggers garbage collection of old RS
- Clears Bronze violation (`check-image-tag`)

## Validation
- ✅ yamllint passed
- ✅ kustomize build (dev + prod) OK
- ✅ Pre-commit hooks passed

## Expected Result
After ArgoCD sync + maturity controller (15 min):
```
vixens.io/maturity: bronze
vixens.io/maturity-missing: silver
```

## Testing
```bash
# After merge + sync
kubectl get deployment -n media lazylibrarian -o jsonpath='{.metadata.labels.vixens\.io/maturity}'
kubectl get replicasets -n media -l app=lazylibrarian  # Should have ≤3 RS
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment configuration to ensure consistent pod restart behavior during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->