### PR TITLE
feat(lidarr): Bronze maturity - cleanup old ReplicaSet

### DIFF
--- a/apps/20-media/lidarr/base/deployment.yaml
+++ b/apps/20-media/lidarr/base/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/path: "/metrics"
         vixens.io/no-long-connections: "true"
+        kubectl.kubernetes.io/restartedAt: "2026-03-11T21:20:00Z"
     spec:
       priorityClassName: vixens-medium
       tolerations:


### PR DESCRIPTION
Trigger rollout to cleanup old ReplicaSet with `:latest` image tag blocking Bronze maturity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration with internal operational metadata.

---

**Note:** This release contains only internal infrastructure updates with no visible changes to end-user functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->