### PR TITLE
feat(it-tools): add priorityClassName via strategic merge patch

### DIFF
--- a/apps/70-tools/it-tools/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/it-tools/overlays/prod/kustomization.yaml
@@ -25,3 +25,6 @@ patches:
     target:
       kind: Deployment
       name: it-tools
+
+patchesStrategicMerge:
+  - priority-class-patch.yaml

--- a/apps/70-tools/it-tools/overlays/prod/priority-class-patch.yaml
+++ b/apps/70-tools/it-tools/overlays/prod/priority-class-patch.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: it-tools
+spec:
+  template:
+    spec:
+      priorityClassName: vixens-low


### PR DESCRIPTION
## Summary
Helm chart `jeffresc/it-tools:0.1.4` doesn't support priorityClassName in values.yaml

## Solution
- Add `patchesStrategicMerge` to Kustomize overlay
- Patch Deployment spec with `priorityClassName: vixens-low`

## Bronze Violation Fixed
- `require-priority-class`: priorityClassName now set via Kustomize patch

## Validation
- ✅ yamllint passed
- ⏳ Waiting for ArgoCD to apply patch