### PR TITLE
fix(it-tools): use JSON patch instead of strategic merge

### DIFF
--- a/apps/70-tools/it-tools/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/it-tools/overlays/prod/kustomization.yaml
@@ -25,6 +25,10 @@ patches:
     target:
       kind: Deployment
       name: it-tools
-
-patchesStrategicMerge:
-  - priority-class-patch.yaml
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/priorityClassName
+        value: vixens-low
+    target:
+      kind: Deployment
+      name: it-tools

--- a/apps/70-tools/it-tools/overlays/prod/priority-class-patch.yaml
+++ b/apps/70-tools/it-tools/overlays/prod/priority-class-patch.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: it-tools
-spec:
-  template:
-    spec:
-      priorityClassName: vixens-low


### PR DESCRIPTION
## Problem
PR #2011 used `patchesStrategicMerge` which fails in ArgoCD multi-source apps:
```
Error: no matches for Id Deployment.v1.apps/it-tools.[noNs]; failed to find unique target for patch
```

## Solution
- Use JSON patch (same approach as existing annotations patches)
- JSON patches work correctly with multi-source apps
- Remove `priority-class-patch.yaml` file

## Validation
- ✅ yamllint passed
- ✅ JSON patch syntax matches working annotation patches