### PR TITLE
feat(external-dns): Bronze maturity (probes + resources)

### DIFF
--- a/apps/40-network/external-dns-gandi/values/prod.yaml
+++ b/apps/40-network/external-dns-gandi/values/prod.yaml
@@ -21,9 +21,9 @@ tolerations:
     operator: Exists
     effect: NoSchedule
 livenessProbe:
-  enabled: false
+  enabled: true
 readinessProbe:
-  enabled: false
+  enabled: true
 # Ownership
 txtOwnerId: prod-gandi-public
 # Scope
@@ -46,3 +46,10 @@ commonAnnotations:  # Deployment metadata annotations (Gold maturity: sync-wave 
   goldilocks.fairwinds.com/enabled: "true"
   vpa.kubernetes.io/updateMode: "Off"
 revisionHistoryLimit: 3
+resources:
+  requests:
+    cpu: "10m"
+    memory: "64Mi"
+  limits:
+    cpu: "50m"
+    memory: "128Mi"

--- a/apps/40-network/external-dns-unifi/values/common.yaml
+++ b/apps/40-network/external-dns-unifi/values/common.yaml
@@ -36,14 +36,21 @@ sidecars:
         value: debug
       - name: UNIFI_SKIP_TLS_VERIFY
         value: "true"
+    resources:
+      requests:
+        cpu: "10m"
+        memory: "32Mi"
+      limits:
+        cpu: "50m"
+        memory: "64Mi"
 tolerations:
   - key: node-role.kubernetes.io/control-plane
     operator: Exists
     effect: NoSchedule
 livenessProbe:
-  enabled: false
+  enabled: true
 readinessProbe:
-  enabled: false
+  enabled: true
 # Scope
 policy: sync
 sources:


### PR DESCRIPTION
## Summary
Bronze maturity fixes for external-dns-gandi and external-dns-unifi

## Changes
**gandi:**
- Enable liveness/readiness probes (were disabled)
- Add resources (10m/64Mi → 50m/128Mi)

**unifi:**
- Enable liveness/readiness probes (were disabled in common.yaml)
- Add resources to unifi-webhook sidecar (10m/32Mi → 50m/64Mi)

## Bronze Violations Fixed
- `require-probes`: Probes now enabled
- `require-resources`: Resources defined for all containers

## Validation
- ✅ yamllint passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled health checks for external DNS services to improve reliability and availability
  * Configured resource allocation limits for DNS services to optimize performance and prevent resource contention

<!-- end of auto-generated comment: release notes by coderabbit.ai -->