### PR TITLE
fix(external-dns-unifi): add probes to unifi-webhook sidecar

### DIFF
--- a/apps/40-network/external-dns-unifi/values/common.yaml
+++ b/apps/40-network/external-dns-unifi/values/common.yaml
@@ -43,6 +43,16 @@ sidecars:
       limits:
         cpu: "50m"
         memory: "64Mi"
+    livenessProbe:
+      tcpSocket:
+        port: webhook
+      initialDelaySeconds: 10
+      periodSeconds: 10
+    readinessProbe:
+      tcpSocket:
+        port: webhook
+      initialDelaySeconds: 5
+      periodSeconds: 10
 tolerations:
   - key: node-role.kubernetes.io/control-plane
     operator: Exists


### PR DESCRIPTION
## Problem
PR #2013 added probes to main container but missed the unifi-webhook sidecar

## Fix
- Add TCP liveness/readiness probes to sidecar
- Probes check port 8888 (webhook port)

## Bronze Violation Fixed
- `require-probes`: All containers now have probes