### PR TITLE
fix(traefik): trigger rollout for app label update

### DIFF
--- a/apps/00-infra/traefik/values/prod.yaml
+++ b/apps/00-infra/traefik/values/prod.yaml
@@ -32,6 +32,8 @@ deployment:
   podLabels:
     app: traefik  # For legacy Kyverno policy compatibility
     app.kubernetes.io/name: traefik
+  podAnnotations:
+    kubectl.kubernetes.io/restartedAt: "2026-03-12T04:35:00Z"
 # Ensure traefik pods spread across nodes
 topologySpreadConstraints:
   - maxSkew: 1


### PR DESCRIPTION
## Summary
Triggers deployment rollout to ensure new pods get the `app: traefik` label added in PR #2017.

## Problem
PR #2017 added `app: traefik` to podLabels, but existing pods haven't rolled out yet (ReplicaSet is 4 days old). Label changes alone don't trigger rollouts.

## Solution
Add `kubectl.kubernetes.io/restartedAt` annotation to force rollout, ensuring new pods get the label for Bronze policy compliance.

## Changes
- `apps/00-infra/traefik/values/prod.yaml`: Add restartedAt annotation

## Expected Result
- New ReplicaSet created with pods having `app: traefik` label
- Bronze policy errors resolved
- Traefik → Gold/Platinum maturity

## References
- Follows bronzification pattern (restartedAt annotation)
- Continuation of PR #2017