### PR TITLE
fix(cert-manager): enable ServerSideApply for multi-source patches

### DIFF
--- a/argocd/overlays/prod/apps/cert-manager.yaml
+++ b/argocd/overlays/prod/apps/cert-manager.yaml
@@ -44,4 +44,5 @@ spec:
         factor: 2
         maxDuration: 3m
     syncOptions:
+      - ServerSideApply=true
       - CreateNamespace=true


### PR DESCRIPTION
## Problem
Kustomize patches in ArgoCD multi-source require ServerSideApply to apply correctly to Helm-generated resources.

Without ServerSideApply, the patches in apps/00-infra/cert-manager/patches/prod/ are ignored.

## Solution
Add ServerSideApply=true to syncOptions (following it-tools pattern).

## Expected Result
- readinessProbe applied to cert-manager controller
- liveness + readiness probes applied to cert-manager-cainjector
- New ReplicaSets created with probes

## References
- Continuation of PR #2020
- Bronzification Phase 2