### PR TITLE
fix(kyverno): handle null volumes in check-config-syncer-relevance policy

### DIFF
--- a/apps/00-infra/kyverno/base/policies/check-config-syncer-relevance.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-config-syncer-relevance.yaml
@@ -20,7 +20,7 @@ spec:
                 - Pod
       preconditions:
         all:
-          - key: "{{ request.object.spec.volumes[?contains(nfs.server, '192.168.111.69')] | length(@) }}"
+          - key: "{{ request.object.spec.volumes || `[]` | [?contains(nfs.server, '192.168.111.69')] | length(@) }}"
             operator: GreaterThan
             value: 0
       validate:


### PR DESCRIPTION
## Problem
Policy `check-config-syncer-relevance` causes JMESPath errors when deployments have no volumes, blocking maturity progression even though apps pass all actual requirements.

**Error:** `JMESPath query failed: Invalid type for: <nil>, expected: []jmespath.JpType{"array", "string"}`

**Affected apps (6 total):**
- cert-manager-webhook
- cert-manager-webhook-gandi
- cloudnative-pg
- infisical-operator  
- vpa-recommender
- vpa-updater

All have resources + probes, pass Bronze requirements, but stuck at `maturity: none`.

## Solution
Use JMESPath default value operator to handle null volumes:
- **Before:** `request.object.spec.volumes[?...]` → fails on null
- **After:** `request.object.spec.volumes || \`[]\` | [?...]` → returns empty array on null

## Expected Result
After policy sync + maturity controller run:
- 6 apps → Bronze or higher (based on their actual compliance)

## References
- Discovered during bronzification session
- Same root cause as traefik initial blocker (policy error vs real violation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy validation to safely handle configurations with missing or undefined volume definitions, preventing unexpected errors during validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->