### PR TITLE
fix(cert-manager): add app label to webhooks for policy compatibility

### DIFF
--- a/apps/00-infra/cert-manager-webhook-gandi/values/common.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/values/common.yaml
@@ -18,6 +18,7 @@ tolerations:
     effect: NoSchedule
 # Pod sizing labels
 podLabels:
+  app: webhook-gandi  # For legacy Kyverno policy compatibility
   vixens.io/sizing.cert-manager-webhook-gandi: G-nano
 # Try podAnnotations — chart may not support, but harmless if ignored
 # Actual annotation applied via kustomize overlay patch (cert-manager-webhook-gandi is a known case)

--- a/apps/00-infra/cert-manager/values/common.yaml
+++ b/apps/00-infra/cert-manager/values/common.yaml
@@ -56,6 +56,7 @@ webhook:
       operator: Exists
       effect: NoSchedule
   podLabels:
+    app: webhook  # For legacy Kyverno policy compatibility
     vixens.io/sizing.webhook: G-nano
   podAnnotations:
     vixens.io/fast-start: "true"


### PR DESCRIPTION
Adds legacy app label to cert-manager webhooks for Kyverno policy compatibility. Fixes Bronze maturity blocker (check-service-binding policy expects app label).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pod labeling in cert-manager webhook configurations to enhance system integration and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->