### PR TITLE
fix(kyverno): handle null envFrom in check-infisical-secrets policy

### DIFF
--- a/apps/00-infra/kyverno/base/policies/check-infisical-secrets.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-infisical-secrets.yaml
@@ -21,13 +21,13 @@ spec:
                 - Pod
       preconditions:
         any:
-          - key: "{{ request.object.spec.containers[].envFrom[].secretRef.name || '[]' | length(@) }}"
+          - key: "{{ request.object.spec.containers[].envFrom[] || `[]` | [?secretRef] | length(@) }}"
             operator: GreaterThan
             value: 0
       validate:
         message: "Secrets should be managed via Infisical for maturity Level 2 (Silver). Ensure InfisicalSecret is used."
         foreach:
-          - list: "request.object.spec.containers[].envFrom[].secretRef"
+          - list: "request.object.spec.containers[].envFrom[] || `[]` | [?secretRef]"
             context:
               - name: secret_data
                 apiCall:


### PR DESCRIPTION
## Summary

Fix JMESPath evaluation errors in `check-infisical-secrets` policy when containers don't have `envFrom` field.

## Problem

12 Bronze apps blocked by policy ERROR on Pods/ReplicaSets:
- Policy fails when `envFrom[]` is null/absent
- JMESPath projection `containers[].envFrom[].secretRef` returns empty set (not null)
- `length(@)` on empty set causes evaluation ERROR
- Blocks maturity progression even for apps without secret references

## Solution

Same pattern as PR #2023 (`check-config-syncer-relevance`):
- Use `|| \`[]\`` to handle null/absent arrays
- Filter with `[?secretRef]` to only check entries with secretRef

**Before:**
```yaml
key: "{{ request.object.spec.containers[].envFrom[].secretRef.name || '[]' | length(@) }}"
list: "request.object.spec.containers[].envFrom[].secretRef"
```

**After:**
```yaml
key: "{{ request.object.spec.containers[].envFrom[] || \`[]\` | [?secretRef] | length(@) }}"
list: "request.object.spec.containers[].envFrom[] || \`[]\` | [?secretRef]"
```

## Impact

**Unblocks 12 apps for Silver progression:**
- authentik-server, authentik-worker
- homeassistant
- mealie
- booklore-mariadb
- frigate, radarr, sabnzbd, whisparr
- grafana
- changedetection
- penpot-backend, penpot-exporter
- velero

## Testing

- ✅ yamllint passes
- ⏳ Will verify maturity controller rescan after merge

## Related

- PR #2023 - Same JMESPath null handling pattern
- Silverification campaign (0/14 apps Bronze → Silver)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved secret validation logic to enhance reliability of infrastructure security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->