### PR TITLE
feat(mealie): add resource limits for Silver maturity

### DIFF
--- a/apps/10-home/mealie/base/deployment.yaml
+++ b/apps/10-home/mealie/base/deployment.yaml
@@ -69,6 +69,13 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /app/data
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 50m
+              memory: 64Mi
         - name: restore-db
           image: litestream/litestream:0.5.9
           securityContext:
@@ -90,6 +97,13 @@ spec:
             - name: mealie-litestream-config
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 50m
+              memory: 64Mi
       priorityClassName: vixens-low
       containers:
         - name: mealie
@@ -126,6 +140,13 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /app/data
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
         - name: litestream
           image: litestream/litestream:0.5.9
           securityContext:
@@ -147,6 +168,13 @@ spec:
             - name: mealie-litestream-config
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 25m
+              memory: 32Mi
         - name: config-syncer
           image: rclone/rclone:1.73
           securityContext:
@@ -181,6 +209,13 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /app/data
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 25m
+              memory: 32Mi
       volumes:
         - name: data
           persistentVolumeClaim:


### PR DESCRIPTION
## Summary

Add `resources.limits` to mealie deployment for Silver tier compliance.

## Changes

All containers now have resource limits matching requests (QoS Guaranteed):
- **mealie** (main): 500m CPU / 512Mi RAM (V-medium)
- **litestream** (sidecar): 25m CPU / 32Mi RAM (V-nano)
- **config-syncer** (sidecar): 25m CPU / 32Mi RAM (V-nano)
- **restore-config** (init): 50m CPU / 64Mi RAM (B-nano)
- **restore-db** (init): 50m CPU / 64Mi RAM (B-nano)

## Impact

**Bronze → Silver progression** (1/23 apps)

## Validation

- ✅ yamllint passes
- ⏳ Will verify maturity label after deployment

## Campaign

Silverification sequential campaign - app 1/23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added resource requests and limits to deployment containers to improve resource management and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->