### PR TITLE
feat(mealie): add probes to sidecars for Silver compliance

### DIFF
--- a/apps/10-home/mealie/base/deployment.yaml
+++ b/apps/10-home/mealie/base/deployment.yaml
@@ -168,6 +168,16 @@ spec:
             - name: mealie-litestream-config
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
+          livenessProbe:
+            tcpSocket:
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 10
           resources:
             requests:
               cpu: 25m
@@ -206,6 +216,22 @@ spec:
           envFrom:
             - secretRef:
                 name: mealie-secrets
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f rclone || exit 1
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f rclone || exit 1
+            initialDelaySeconds: 5
+            periodSeconds: 10
           volumeMounts:
             - name: data
               mountPath: /app/data


### PR DESCRIPTION
## Summary

Fix  policy failure by adding probes to sidecar containers.

## Changes

### litestream sidecar
- **livenessProbe**: tcpSocket on metrics port 9090  
- **readinessProbe**: tcpSocket on metrics port 9090

### config-syncer sidecar
- **livenessProbe**: exec probe checking rclone process
- **readinessProbe**: exec probe checking rclone process

## Impact

Completes Silver tier requirements for mealie (2/2 PRs for this app).

After this merge + deployment + maturity scan:
- **Expected:** mealie Bronze → Silver

## Validation

- ✅ yamllint passes
- ⏳ Will verify maturity label after deployment

## Campaign

Silverification - mealie complete (app 1/23)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced application deployment health monitoring to improve system reliability and uptime by adding automated health checks that detect and respond to service issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->