### PR TITLE
fix(mealie): revert manual resources + add sidecar probes (Kyverno flow)

### DIFF
--- a/apps/10-home/mealie/base/deployment.yaml
+++ b/apps/10-home/mealie/base/deployment.yaml
@@ -33,6 +33,7 @@ spec:
         prometheus.io/path: "/metrics"
         vixens.io/no-long-connections: "true"
         vixens.io/explicitly-allow-root: "true"
+        kubectl.kubernetes.io/restartedAt: "2026-03-12T10:40:00Z"
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane
@@ -147,6 +148,16 @@ spec:
             - name: mealie-litestream-config
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
+          livenessProbe:
+            tcpSocket:
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 10
         - name: config-syncer
           image: rclone/rclone:1.73
           securityContext:
@@ -178,6 +189,22 @@ spec:
           envFrom:
             - secretRef:
                 name: mealie-secrets
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f rclone || exit 1
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f rclone || exit 1
+            initialDelaySeconds: 5
+            periodSeconds: 10
           volumeMounts:
             - name: data
               mountPath: /app/data


### PR DESCRIPTION
## Summary

Fix incorrect approach from PRs #2028 and #2029 which added manual resource limits, bypassing Kyverno mutation.

## Problem

Resources should be mutated by `sizing-v2-mutate` ClusterPolicy at Pod admission time, NOT configured manually in Deployment.

## Solution

### Reverts
- Revert PR #2028 (manual resource limits)
- Revert PR #2029 (probes + manual resources)

### Adds (Correctly)
- **litestream sidecar probes**: tcpSocket on port 9090
- **config-syncer sidecar probes**: exec checking rclone process
- **restartedAt annotation**: triggers rollout for Kyverno mutation

### Flow
1. Deployment has `vixens.io/sizing.*` labels
2. Rollout creates new Pods
3. Kyverno `sizing-v2-mutate` policy mutates resources at admission
4. Pods get correct resources automatically

## Impact

Bronze → Silver (mealie 1/23 apps, proper Kyverno flow)

## Validation

- ✅ yamllint passes
- ⏳ Will verify resources mutated + maturity label after deployment