### PR TITLE
fix(kyverno): correct element path in check-infisical-secrets APICall

### DIFF
--- a/apps/00-infra/kyverno/base/policies/check-infisical-secrets.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-infisical-secrets.yaml
@@ -31,7 +31,7 @@ spec:
             context:
               - name: secret_data
                 apiCall:
-                  urlPath: "/api/v1/namespaces/{{request.namespace}}/secrets/{{element.name}}"
+                  urlPath: "/api/v1/namespaces/{{request.namespace}}/secrets/{{element.secretRef.name}}"
                   jmesPath: "metadata.annotations.\"infisical.com/managed\" || metadata.labels.\"app.kubernetes.io/managed-by\" == 'infisical-operator' || metadata.annotations.\"secrets.infisical.com/version\" || 'false'"
             deny:
               conditions:


### PR DESCRIPTION
## Summary

Fix APICall path in `check-infisical-secrets` policy following PR #2026.

## Problem

PR #2026 changed the foreach list to:
```yaml
list: "request.object.spec.containers[].envFrom[] || \`[]\` | [?secretRef]"
```

This returns objects like `{secretRef: {name: "..."}}`, not direct `{name: "..."}`.

But the APICall still used:
```yaml
urlPath: "/api/v1/namespaces/{{request.namespace}}/secrets/{{element.name}}"
```

Result: **"Unknown key 'name'" error**, blocking Silver maturity.

## Solution

Change APICall to use correct element structure:
```yaml
urlPath: "/api/v1/namespaces/{{request.namespace}}/secrets/{{element.secretRef.name}}"
```

## Impact

Unblocks Silver progression for apps using envFrom.secretRef (mealie, authentik, etc.)

## Validation

- ✅ yamllint passes
- ⏳ Will verify policy passes after Kyverno rescan