### PR TITLE
feat(changedetection): add probes to browserless sidecar for Silver

### DIFF
--- a/apps/70-tools/changedetection/base/deployment.yaml
+++ b/apps/70-tools/changedetection/base/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         vixens.io/fast-start: "true"
         vixens.io/no-long-connections: "true"
       labels:
+        kubectl.kubernetes.io/restartedAt: "2026-03-12T11:00:00Z"
         app: changedetection
         vixens.io/sizing.restore-config: B-nano
         vixens.io/sizing.changedetection: V-small
@@ -116,6 +117,16 @@ spec:
               value: "10"
             - name: CHROME_REFRESH_TIME
               value: "600000"
+          livenessProbe:
+            tcpSocket:
+              port: playwright
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: playwright
+            initialDelaySeconds: 5
+            periodSeconds: 10
         - name: config-syncer
           image: rclone/rclone:1.73
           command:


### PR DESCRIPTION
## Summary

Add probes to browserless sidecar for Silver tier compliance.

## Changes

- **browserless sidecar**: tcpSocket probes on port 3000 (playwright)
- **restartedAt annotation**: triggers rollout for verification

Resources already mutated by Kyverno sizing-v2 (no manual config needed).

## Impact

Bronze → Silver (changedetection 2/23 apps)

## Validation

- ✅ yamllint passes
- ⏳ Will verify maturity after deployment

## Campaign

Silverification - app 2/23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced service reliability with automatic pod restart tracking and improved health monitoring to enable faster failure detection and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->