### PR TITLE
feat(media): add litestream probes for Silver maturity (batch 6 apps)

### DIFF
--- a/apps/20-media/lazylibrarian/base/deployment.yaml
+++ b/apps/20-media/lazylibrarian/base/deployment.yaml
@@ -101,6 +101,22 @@ spec:
             - name: lazylibrarian-litestream-config
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f litestream || exit 1
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f litestream || exit 1
+            initialDelaySeconds: 5
+            periodSeconds: 10
       priorityClassName: vixens-low
       containers:
         - name: lazylibrarian

--- a/apps/20-media/lidarr/base/deployment.yaml
+++ b/apps/20-media/lidarr/base/deployment.yaml
@@ -89,6 +89,22 @@ spec:
             - name: lidarr-litestream-config
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f litestream || exit 1
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f litestream || exit 1
+            initialDelaySeconds: 5
+            periodSeconds: 10
       containers:
         - name: lidarr
           image: ghcr.io/linuxserver/lidarr:version-3.1.0.4875

--- a/apps/20-media/mylar/base/deployment.yaml
+++ b/apps/20-media/mylar/base/deployment.yaml
@@ -89,6 +89,22 @@ spec:
             - name: mylar-litestream-config
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f litestream || exit 1
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f litestream || exit 1
+            initialDelaySeconds: 5
+            periodSeconds: 10
       containers:
         - name: mylar
           image: ghcr.io/linuxserver/mylar3:version-v0.8.1

--- a/apps/20-media/prowlarr/base/deployment.yaml
+++ b/apps/20-media/prowlarr/base/deployment.yaml
@@ -89,6 +89,22 @@ spec:
             - name: prowlarr-litestream-config
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f litestream || exit 1
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f litestream || exit 1
+            initialDelaySeconds: 5
+            periodSeconds: 10
       containers:
         - name: prowlarr
           image: ghcr.io/linuxserver/prowlarr:version-1.31.2.4975

--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -126,6 +126,22 @@ spec:
             - name: sabnzbd-litestream-config
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f litestream || exit 1
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f litestream || exit 1
+            initialDelaySeconds: 5
+            periodSeconds: 10
         - name: config-syncer
           image: rclone/rclone:1.73
           securityContext:

--- a/apps/20-media/whisparr/base/deployment.yaml
+++ b/apps/20-media/whisparr/base/deployment.yaml
@@ -142,6 +142,22 @@ spec:
             - name: whisparr-litestream-config
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f litestream || exit 1
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f litestream || exit 1
+            initialDelaySeconds: 5
+            periodSeconds: 10
         - name: config-syncer
           image: rclone/rclone:1.73
           securityContext:


### PR DESCRIPTION
## Summary

Add probes to litestream sidecar for 6 media apps in one batch.

## Apps Modified
1. sabnzbd
2. whisparr
3. prowlarr
4. lidarr
5. mylar
6. lazylibrarian

## Changes

All apps get same fix:
- **litestream sidecar**: exec probe checking litestream process (`pgrep -f litestream`)
- Resources already mutated by Kyverno sizing-v2 (no manual config)

## Impact

Bronze → Silver (apps 3-8/23)

## Validation

- ✅ yamllint passes (all 6 files)
- ⏳ Will verify maturity after deployment

## Campaign

Silverification - batch 6 apps with identical fix