### PR TITLE
feat(radarr): add startup probe to litestream + all probes to config-syncer

### DIFF
--- a/apps/20-media/radarr/base/deployment.yaml
+++ b/apps/20-media/radarr/base/deployment.yaml
@@ -152,6 +152,12 @@ spec:
               port: metrics
             initialDelaySeconds: 5
             periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            failureThreshold: 15
+            periodSeconds: 10
           envFrom:
             - secretRef:
                 name: radarr-secrets
@@ -196,6 +202,30 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /config
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f rclone || exit 1
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f rclone || exit 1
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          startupProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f rclone || exit 1
+            failureThreshold: 15
+            periodSeconds: 10
       volumes:
         - name: config
           persistentVolumeClaim:


### PR DESCRIPTION
## Summary

Upgrade radarr from Bronze → Silver maturity tier.

## Changes

**Litestream sidecar:**
- ✅ Add `startupProbe` (httpGet /metrics)

**Config-syncer sidecar:**
- ✅ Add `livenessProbe` (pgrep rclone)
- ✅ Add `readinessProbe` (pgrep rclone)
- ✅ Add `startupProbe` (pgrep rclone)

## Silver Requirements

- ✅ Resources limits (mutated by Kyverno sizing-v2)
- ✅ Readiness probes (all containers)
- ✅ Startup probes (all containers)
- ✅ Secrets via Infisical (InfisicalSecret)

## Validation

```bash
yamllint -c yamllint-config.yml apps/20-media/radarr/base/deployment.yaml
kustomize build apps/20-media/radarr/overlays/dev
```

Part of Silverification campaign (12/23 apps completed)