### PR TITLE
feat(booklore-mariadb): add startup probe + db-backup probes

### DIFF
--- a/apps/20-media/booklore/base/mariadb-deployment.yaml
+++ b/apps/20-media/booklore/base/mariadb-deployment.yaml
@@ -74,6 +74,11 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3
+          startupProbe:
+            exec:
+              command: ["mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+            failureThreshold: 15
+            periodSeconds: 10
         - name: db-backup
           image: alpine:3.23
           command:
@@ -109,6 +114,30 @@ spec:
           envFrom:
             - secretRef:
                 name: booklore-secrets
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f mariadb-dump || exit 1
+            initialDelaySeconds: 30
+            periodSeconds: 60
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f mariadb-dump || exit 1
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          startupProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f mariadb-dump || exit 1
+            failureThreshold: 15
+            periodSeconds: 10
       volumes:
         - name: config
           persistentVolumeClaim:


### PR DESCRIPTION
## Summary

Upgrade booklore-mariadb from Bronze → Silver maturity tier.

## Changes

**MariaDB container:**
- ✅ Add `startupProbe` (mysqladmin ping)

**DB-backup sidecar:**
- ✅ Add `livenessProbe` (pgrep mariadb-dump)
- ✅ Add `readinessProbe` (pgrep mariadb-dump)
- ✅ Add `startupProbe` (pgrep mariadb-dump)

## Silver Requirements

- ✅ Resources limits (mutated by Kyverno sizing-v2)
- ✅ Readiness probes (all containers)
- ✅ Startup probes (all containers)
- ✅ Secrets via Infisical (InfisicalSecret)
- ✅ Fast-start annotation present

## Notes

Deployment already has:
- `vixens.io/fast-start: "true"` annotation
- Kyverno sizing labels (`vixens.io/sizing.mariadb: V-small`, `vixens.io/sizing.db-backup: V-nano`)

Part of Silverification campaign (14/23 apps completed)