### PR TITLE
feat(firefly-iii-importer): add startup probe for Silver maturity

### DIFF
--- a/apps/60-services/firefly-iii-importer/base/deployment.yaml
+++ b/apps/60-services/firefly-iii-importer/base/deployment.yaml
@@ -69,3 +69,9 @@ spec:
               port: http
             initialDelaySeconds: 10
             periodSeconds: 5
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 15
+            periodSeconds: 10


### PR DESCRIPTION
## Summary

Upgrade firefly-iii-importer from Bronze → Silver maturity tier.

## Changes

**Importer container:**
- ✅ Add `startupProbe` (httpGet /)

## Silver Requirements

- ✅ Resources limits (mutated by Kyverno sizing-v2)
- ✅ Readiness probe (already present)
- ✅ Liveness probe (already present)
- ✅ Startup probe (added)
- ✅ Secrets via Infisical (InfisicalSecret)
- ✅ Fast-start annotation present

## Notes

Deployment already has:
- `vixens.io/fast-start: "true"` annotation
- Kyverno sizing label (`vixens.io/sizing.importer: V-small`)

Part of Silverification campaign (15/23 apps completed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced service startup reliability through improved health check configuration for the importer container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->