### PR TITLE
fix(kyverno): change require-resources policy category to Maturity (Silver)

### DIFF
--- a/apps/00-infra/kyverno/base/policies/require-resources.yaml
+++ b/apps/00-infra/kyverno/base/policies/require-resources.yaml
@@ -7,7 +7,7 @@ metadata:
   name: require-resources
   annotations:
     policies.kyverno.io/title: Require Resources
-    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/category: Maturity (Silver)
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-


### PR DESCRIPTION
## Problem

The `require-resources` Kyverno policy was categorized as **Best Practices** instead of **Maturity (Silver)**.

This caused apps using Kyverno sizing mutation (`vixens.io/sizing.*` labels) to remain at Bronze tier even though:
- ✅ They have sizing labels configured
- ✅ Kyverno successfully mutates Pod resources at admission
- ✅ Pods run with correct resource limits

**Root cause:** The maturity controller only counts policy failures with category = `Maturity (...)`.

## Solution

Change policy annotation:
```yaml
- policies.kyverno.io/category: Best Practices
+ policies.kyverno.io/category: Maturity (Silver)
```

## Impact

**Unblocks 4 apps stuck at Bronze:**
- `services/openclaw`
- `tools/changedetection`
- `tools/penpot-backend`
- `tools/penpot-exporter`

All 4 apps have:
- ✅ Sizing labels (`vixens.io/sizing.*`) configured
- ✅ Pods with resources (Kyverno-mutated)
- ✅ No other Silver policy violations

**After this fix + ArgoCD sync + maturity scan → all 4 reach Silver (or higher).**

## Validation

After merge:
1. ArgoCD syncs updated policy
2. Kyverno regenerates PolicyReports with new category
3. Maturity controller scan recognizes sizing labels as valid
4. Apps transition Bronze → Silver+

**Result: 100% of cluster apps at Silver or higher.** 🎯

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kyverno policy metadata to reflect current maturity level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->