### PR TITLE
URGENT: Revert broken sizing policy - restore cluster

### DIFF
--- a/apps/00-infra/kyverno/base/policies/require-resources.yaml
+++ b/apps/00-infra/kyverno/base/policies/require-resources.yaml
@@ -12,7 +12,7 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Resources requests and limits are required for all containers for maturity Level 2 (Silver).
-      Exception: Pods with vixens.io/sizing.* labels are exempt (resources mutated by Kyverno sizing-v2-mutate policy).
+      This policy audits containers that do not have resource limits defined.
 spec:
   validationFailureAction: Audit
   background: true
@@ -29,14 +29,6 @@ spec:
               namespaces:
                 - kube-system
                 - kyverno
-          # Exclude: Pods with vixens.io/sizing.* labels (Kyverno mutation)
-          - resources:
-              kinds:
-                - Pod
-              selector:
-                matchExpressions:
-                  - key: "vixens.io/sizing.*"
-                    operator: Exists
       validate:
         message: "CPU and memory resource requests and limits are required."
         pattern:


### PR DESCRIPTION
## 🚨 URGENT ROLLBACK NEEDED

PR #2045 **BROKE THE CLUSTER**:
- **43 apps went Bronze** (was 4 before)
- changedetection went **Orichalcum** (max tier) - clearly broken
- openclaw, penpot-* still Bronze

**Root Cause:**
```yaml
selector:
  matchExpressions:
    - key: "vixens.io/sizing.*"  # ← DOESN'T WORK IN KYVERNO
      operator: Exists
```

Kyverno doesn't support wildcard in `matchExpressions` keys.

## This PR

Reverts commit 96da8359 (PR #2045) to restore cluster to working state.

**Keeps:** Category change to "Maturity (Silver)" from #2044 ✅  
**Removes:** Broken sizing exception ❌

## Impact

After merge + sync:
- Cluster restored to pre-#2045 state
- ~60 Gold, ~20 Silver, ~15 Platinum, **4 Bronze** (normal)
- openclaw/changedetection/penpot still Bronze (known issue, needs different fix)

**MERGE ASAP TO RESTORE CLUSTER!**