### PR TITLE
fix(hydrus-client): move probes from init container to sidecar (K8s 1.30+ compliance)

### DIFF
--- a/apps/20-media/hydrus-client/base/deployment.yaml
+++ b/apps/20-media/hydrus-client/base/deployment.yaml
@@ -100,22 +100,6 @@ spec:
             - name: hydrus-client-litestream-config
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
-          livenessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - pgrep -f litestream || exit 1
-            initialDelaySeconds: 10
-            periodSeconds: 30
-          readinessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - pgrep -f litestream || exit 1
-            initialDelaySeconds: 5
-            periodSeconds: 10
         - name: restore-mappings
           image: litestream/litestream:0.5.9
           securityContext:
@@ -241,6 +225,24 @@ spec:
             - name: hydrus-client-litestream-config
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            failureThreshold: 15
+            periodSeconds: 10
       volumes:
         - name: config
           persistentVolumeClaim:


### PR DESCRIPTION
## Problem

PR #2034 added liveness/readiness probes to the `restore-db` **init container** in hydrus-client. This violates Kubernetes 1.30+ API rules:

```
spec.template.spec.initContainers[2].livenessProbe: Forbidden:
  may not be set for init containers without restartPolicy=Always
```

This blocked **all ArgoCD syncs** for hydrus-client and prevented the Silverification campaign completion.

## Root Cause

- **K8s 1.30+**: Init containers cannot have liveness/readiness probes unless they have `restartPolicy: Always` (sidecar pattern)
- **restore-db**: Regular init container (run-once) → probes forbidden
- **litestream**: Normal sidecar container → probes required for Silver tier

## Solution

- ❌ **Remove** probes from `restore-db` init container
- ✅ **Add** probes (liveness, readiness, startup) to `litestream` sidecar container

Probes use litestream's `/metrics` endpoint (port 9090) for health checks.

## Verification

```bash
# Dry-run validation
kubectl apply --dry-run=server -k apps/20-media/hydrus-client/overlays/dev

# After merge: sync and verify
kubectl -n media get pods -l app=hydrus-client -o yaml | grep -A 10 "livenessProbe:"
```

## Impact

- **Unblocks**: ArgoCD sync for hydrus-client
- **Enables**: Silver maturity tier verification
- **Restores**: Silverification campaign progress (11/12 apps blocked)

## Related

- Original PR: #2034
- Cluster recovery PR: #2046 (revert broken policy)
- Campaign: Silverification (Bronze → Silver)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded health monitoring for Hydrus client deployment. Transitioned from execution-based health checks to HTTP-based metrics probes. Now includes comprehensive liveness, readiness, and startup checks with customizable timing and failure thresholds for enhanced service availability detection and improved operational reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->