### PR TITLE
fix(openclaw,sonarr): complete sizing coverage and add required labels

### DIFF
--- a/apps/20-media/sonarr/base/deployment.yaml
+++ b/apps/20-media/sonarr/base/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: sonarr
   labels:
     app: sonarr
+    app.kubernetes.io/managed-by: kustomize
     vixens.io/sizing-v2: "true"
     vixens.io/vpa-mode: Auto
 spec:

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -26,6 +26,7 @@ spec:
         vixens.io/sizing.setup-config: G-nano
         vixens.io/sizing.install-gemini: B-medium
         vixens.io/sizing.openclaw: SB-xlarge
+        vixens.io/sizing.data-syncer: V-nano
         vixens.io/backup-profile: "relaxed"
       annotations:
         vixens.io/fast-start: "true"


### PR DESCRIPTION
## Summary

Quick wins for remaining Bronze apps - completing missing sizing labels and required metadata.

## Changes

### openclaw
- ✅ **Added** `vixens.io/sizing.data-syncer: V-nano` label
- **Issue:** data-syncer sidecar was missing sizing label (partial coverage)
- **Expected:** Bronze → Silver (all 6 containers now have sizing labels)

### sonarr
- ✅ **Added** `app.kubernetes.io/managed-by: kustomize` label
- **Issue:** Missing required Bronze-tier label
- **Expected:** None → Silver+ (passes Bronze validation)

## Validation

```bash
# YAML validation passed
yamllint -c yamllint-config.yml apps/**/*.yaml

# Both deployments verified
```

## Expected Results

After automatic maturity scan (runs every 15 min):
- **openclaw:** sizing validation PASS (all containers covered) → Silver
- **sonarr:** Bronze label validation PASS → Silver+

## Testing Plan

1. Merge PR
2. Update prod-stable tag
3. Wait 15 minutes for automatic maturity scan
4. Verify tier changes:
   ```bash
   kubectl get deployments -A -o json | jq -r '.items[] | select(.metadata.name | test("openclaw|sonarr")) | "\(.metadata.namespace)/\(.metadata.name): \(.metadata.labels."vixens.io/maturity")"'
   ```

## Related

Part of Silverification Campaign - 2/9 remaining Bronze apps addressed.

Next: goldilocks anti-pattern migration, infrastructure apps analysis.