### PR TITLE
fix(goldilocks): migrate manual resources to sizing labels (anti-pattern fix)

### DIFF
--- a/apps/02-monitoring/goldilocks/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/goldilocks/overlays/prod/kustomization.yaml
@@ -7,6 +7,54 @@ components:
 
 patches:
   - path: patch-infisical-env.yaml
+  # Goldilocks Controller - Add sizing labels to deployment metadata
+  - patch: |-
+      - op: add
+        path: /metadata/labels/vixens.io~1sizing-v2
+        value: "true"
+    target:
+      kind: Deployment
+      name: goldilocks-controller
+  # Goldilocks Controller - Add sizing label to pod template
+  - patch: |-
+      - op: add
+        path: /spec/template/metadata/labels/vixens.io~1sizing.goldilocks-controller
+        value: G-nano
+    target:
+      kind: Deployment
+      name: goldilocks-controller
+  # Goldilocks Controller - Remove manual resources (anti-pattern fix)
+  - patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value: {}
+    target:
+      kind: Deployment
+      name: goldilocks-controller
+  # Goldilocks Dashboard - Add sizing labels to deployment metadata
+  - patch: |-
+      - op: add
+        path: /metadata/labels/vixens.io~1sizing-v2
+        value: "true"
+    target:
+      kind: Deployment
+      name: goldilocks-dashboard
+  # Goldilocks Dashboard - Add sizing label to pod template
+  - patch: |-
+      - op: add
+        path: /spec/template/metadata/labels/vixens.io~1sizing.goldilocks-dashboard
+        value: V-small
+    target:
+      kind: Deployment
+      name: goldilocks-dashboard
+  # Goldilocks Dashboard - Remove manual resources (anti-pattern fix)
+  - patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value: {}
+    target:
+      kind: Deployment
+      name: goldilocks-dashboard
   - patch: |-
       - op: add
         path: /spec/template/metadata/labels/environment

--- a/apps/02-monitoring/goldilocks/values/common.yaml
+++ b/apps/02-monitoring/goldilocks/values/common.yaml
@@ -14,8 +14,7 @@ controller:
       drop:
         - ALL
     readOnlyRootFilesystem: true
-  podLabels:
-    vixens.io/sizing.goldilocks-controller: G-nano
+  resources: {}  # No manual resources - Kyverno mutates via sizing labels
   deployment:
     podAnnotations:
       vixens.io/fast-start: "true"
@@ -41,8 +40,7 @@ dashboard:
       drop:
         - ALL
     readOnlyRootFilesystem: true
-  podLabels:
-    vixens.io/sizing.goldilocks-dashboard: V-small
+  resources: {}  # No manual resources - Kyverno mutates via sizing labels
   deployment:
     podAnnotations:
       vixens.io/fast-start: "true"


### PR DESCRIPTION
## Summary

Fix goldilocks anti-pattern (manual resources instead of Kyverno mutation via sizing labels).

## Problem

Maturity controller flagged goldilocks-controller and goldilocks-dashboard with **ANTI-PATTERN** warnings:
- Manual resources present: `cpu: 25m, memory: 256Mi` (from Helm chart defaults)
- Sizing labels NOT on pod template (Helm `podLabels` field doesn't propagate correctly)
- Kyverno mutation not triggered → manual resources not replaced

## Solution

### 1. Helm Values Changes (common.yaml)
- ❌ Removed `podLabels` (ineffective - Helm doesn't propagate to `spec.template.metadata.labels`)
- ✅ Added `resources: {}` to override Helm chart default resources

### 2. Kustomize Patches (overlays/prod/kustomization.yaml)
- ✅ Add `vixens.io/sizing-v2: "true"` to Deployment metadata
- ✅ Add sizing labels to pod template:
  - controller: `vixens.io/sizing.goldilocks-controller: G-nano`
  - dashboard: `vixens.io/sizing.goldilocks-dashboard: V-small`
- ✅ Replace container resources with `{}` (defense-in-depth)

## Technical Details

**Multi-Source ArgoCD Application:**
- Source 1: Helm chart (fairwinds/goldilocks)  
- Source 2: Helm values (Git)
- Source 3: Kustomize overlays (Git)

ArgoCD renders Helm → renders Kustomize → merges → applies. 
JSON patches in Source 3 CAN patch Helm-rendered resources from Source 1.

**JSON Patch Format:**
Using RFC 6902 format with `~1` escape for `/` in label keys:
```yaml
- op: add
  path: /metadata/labels/vixens.io~1sizing-v2
  value: "true"
```

## Validation

```bash
# YAML validation passed
yamllint -c yamllint-config.yml apps/02-monitoring/goldilocks/**/*.yaml

# Multi-source ArgoCD app structure preserved
```

## Expected Results

After ArgoCD sync + maturity scan (every 15 min):
- **goldilocks-controller:** Anti-pattern resolved, Bronze → Silver+
- **goldilocks-dashboard:** Anti-pattern resolved, Bronze → Silver+
- Maturity controller logs: ✅ sizing validation PASS

## Testing Plan

1. Merge PR
2. Update prod-stable tag
3. Wait for ArgoCD sync (~2 min)
4. Verify pods have sizing labels:
   ```bash
   kubectl get pods -n monitoring -l app.kubernetes.io/name=goldilocks -o json | jq '.items[] | {name: .metadata.name, labels: .metadata.labels | with_entries(select(.key | startswith("vixens.io/sizing")))}'
   ```
5. Verify no manual resources:
   ```bash
   kubectl get deployments -n monitoring goldilocks-controller goldilocks-dashboard -o json | jq '.items[] | {name: .metadata.name, resources: .spec.template.spec.containers[].resources}'
   ```
6. Wait 15 min for maturity scan
7. Check tier upgrade:
   ```bash
   kubectl get deployments -n monitoring -l app.kubernetes.io/name=goldilocks -o json | jq -r '.items[] | "\(.metadata.name): \(.metadata.labels.\"vixens.io/maturity\")"'
   ```

## Related

Part of Silverification Campaign - anti-pattern migration phase.

Remaining Bronze apps after this fix: 5 (all infrastructure)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Goldilocks controller and dashboard deployments with new sizing labels for enhanced resource optimization
  * Migrated from manual container resource specifications to automated resource sizing configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->