### PR TITLE
fix(velero): complete Silver maturity - add startup probes

### DIFF
--- a/apps/00-infra/velero/overlays/prod/deployment-patches.yaml
+++ b/apps/00-infra/velero/overlays/prod/deployment-patches.yaml
@@ -20,4 +20,11 @@ spec:
       containers:
         - name: velero
           # Resources will be mutated by Kyverno based on vixens.io/sizing.velero label
+          startupProbe:
+            httpGet:
+              path: /metrics
+              port: 8085
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            failureThreshold: 30  # 5 min max startup time
           resources: {}

--- a/apps/00-infra/velero/overlays/prod/node-agent-probes.yaml
+++ b/apps/00-infra/velero/overlays/prod/node-agent-probes.yaml
@@ -21,3 +21,10 @@ spec:
               port: 8085
             initialDelaySeconds: 10
             periodSeconds: 30
+          startupProbe:
+            httpGet:
+              path: /metrics
+              port: 8085
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            failureThreshold: 30  # 5 min max startup time


### PR DESCRIPTION
## Summary

Complete velero silverification by adding missing startup probes (the gap from PR #2043).

## Problem

PR #2043 claimed to complete silverification but velero remained **Gold** tier, not Silver.

**Root cause:** Missing startup probes (Silver requirement from ADR-023 v2).

## Changes

### 1. Main Deployment (deployment-patches.yaml)
✅ Added `startupProbe` to velero container:
```yaml
startupProbe:
  httpGet:
    path: /metrics
    port: 8085
  initialDelaySeconds: 0
  periodSeconds: 10
  failureThreshold: 30  # 5 min max startup time
```

### 2. Node Agent DaemonSet (node-agent-probes.yaml)
✅ Added `startupProbe` to node-agent container (same pattern)

## Silver Tier Requirements (ADR-023 v2)

| Requirement | Before | After |
|-------------|--------|-------|
| CPU/Memory limits | ✅ (via sizing labels) | ✅ |
| Readiness probe | ✅ | ✅ |
| Liveness probe | ✅ | ✅ |
| **Startup probe** | ❌ **MISSING** | ✅ **ADDED** |
| TLS/HTTPS | ✅ (N/A backend) | ✅ |
| Secrets via Infisical | ✅ | ✅ |

## Validation

```bash
# YAML validation passed
yamllint -c yamllint-config.yml apps/00-infra/velero/**/*.yaml

# Startup probes present in patches
grep -A 6 'startupProbe:' apps/00-infra/velero/overlays/prod/*.yaml
```

## Expected Results

After merge + ArgoCD sync + maturity scan (15 min):
- **velero main Deployment:** Gold → Silver ✅
- **velero node-agent DaemonSet:** Gold → Silver ✅
- Maturity controller logs: startup probe validation PASS

## Current Status

**Before this PR:**
- Velero: Gold tier (startup probe missing)
- Campaign: 11/12 apps ≥ Silver (velero incomplete)

**After this PR:**
- Velero: Silver tier (all requirements satisfied)
- Campaign: **12/12 apps ≥ Silver** ✅ (100% complete)

## Testing Plan

1. Merge PR
2. Update prod-stable tag
3. Wait for ArgoCD sync (~2 min)
4. Verify startup probes applied:
   ```bash
   kubectl -n velero get deployment velero -o json | jq '.spec.template.spec.containers[0].startupProbe'
   kubectl -n velero get daemonset node-agent -o json | jq '.spec.template.spec.containers[0].startupProbe'
   ```
5. Wait 15 min for maturity scan
6. Check tier:
   ```bash
   kubectl -n velero get deployment velero -o json | jq -r '.metadata.labels."vixens.io/maturity"'
   ```

## Related

- PR #2043 (incomplete silverification - claimed Silver but was Gold)
- Silverification Campaign (now truly 12/12 complete)
- ADR-023 v2 (7-Tier Maturity System)