### PR TITLE
fix(goldilocks): correct Helm resources override for Kyverno mutation

### DIFF
--- a/apps/02-monitoring/goldilocks/values/common.yaml
+++ b/apps/02-monitoring/goldilocks/values/common.yaml
@@ -14,7 +14,9 @@ controller:
       drop:
         - ALL
     readOnlyRootFilesystem: true
-  resources: {}  # No manual resources - Kyverno mutates via sizing labels
+  resources:
+    requests: {}  # Explicitly empty - Kyverno mutates via sizing labels
+    limits: {}
   deployment:
     podAnnotations:
       vixens.io/fast-start: "true"
@@ -40,7 +42,9 @@ dashboard:
       drop:
         - ALL
     readOnlyRootFilesystem: true
-  resources: {}  # No manual resources - Kyverno mutates via sizing labels
+  resources:
+    requests: {}  # Explicitly empty - Kyverno mutates via sizing labels
+    limits: {}
   deployment:
     podAnnotations:
       vixens.io/fast-start: "true"


### PR DESCRIPTION
## Problem

PR #2052 attempted to remove manual resources from goldilocks by setting `resources: {}` in Helm values, but the chart still rendered `cpu: 25m, memory: 256Mi`.

**Root cause:** Helm **deep-merges** values. Setting `resources: {}` doesn't fully override chart defaults because the chart's `requests.cpu` and `requests.memory` survive the merge.

## Analysis (Librarian Research)

**Goldilocks Helm Chart** (fairwinds/goldilocks v10.2.0):
- Templates use **unconditional** `toYaml .Values.controller.resources` ([controller L56](https://github.com/fairwindsops/charts/blob/d2225ed52c42730dfe0b5e457d3ae0dd07305ba6/stable/goldilocks/templates/controller-deployment.yaml#L56-L57))
- No `if` guard, no `resources.enabled` toggle
- Default values: `requests: {cpu: 25m, memory: 256Mi}`

**Helm Deep-Merge Behavior:**
```yaml
# Chart defaults
controller:
  resources:
    requests:
      cpu: 25m
      memory: 256Mi

# Our override (PR #2052)
controller:
  resources: {}

# Result after Helm merge (WRONG!)
controller:
  resources:
    requests:      # ← Chart's requests block SURVIVES!
      cpu: 25m
      memory: 256Mi
```

Helm doesn't replace the entire `resources` map — it merges nested keys. The chart's `requests` block isn't overridden.

## Solution

Explicitly set sub-keys to empty maps:

```yaml
controller:
  resources:
    requests: {}  # ← Explicitly empty
    limits: {}

dashboard:
  resources:
    requests: {}
    limits: {}
```

**Rendered output:**
```yaml
resources:
  requests: {}
  limits: {}
```

Kubernetes treats `requests: {}` as "no requests set" → Kyverno `sizing-v2-mutate` policy can inject resources cleanly via sizing labels.

## Changes

**File:** `apps/02-monitoring/goldilocks/values/common.yaml`

```diff
controller:
-  resources: {}  # No manual resources - Kyverno mutates via sizing labels
+  resources:
+    requests: {}  # Explicitly empty - Kyverno mutates via sizing labels
+    limits: {}

dashboard:
-  resources: {}
+  resources:
+    requests: {}
+    limits: {}
```

## Validation

```bash
# YAML syntax valid
yamllint -c yamllint-config.yml apps/02-monitoring/goldilocks/values/common.yaml

# Changes minimal (+6 lines, -2 lines)
git diff apps/02-monitoring/goldilocks/values/common.yaml
```

## Expected Results

After merge + ArgoCD sync + maturity scan:
- **goldilocks-controller:** Anti-pattern resolved → Bronze → Silver
- **goldilocks-dashboard:** Anti-pattern resolved → Bronze → Silver
- Maturity controller logs: ✅ No more "ANTI-PATTERN" warnings

## Testing Plan

1. Merge PR
2. Update prod-stable tag
3. Force ArgoCD sync: `kubectl -n argocd patch application goldilocks ...`
4. Wait for pods to restart
5. Verify no manual resources:
   ```bash
   kubectl -n monitoring get deployment goldilocks-controller -o json | jq '.spec.template.spec.containers[0].resources'
   # Expected: {}
   ```
6. Verify sizing labels present:
   ```bash
   kubectl -n monitoring get deployment goldilocks-controller -o json | jq '.spec.template.metadata.labels | with_entries(select(.key | startswith("vixens.io/sizing")))'
   # Expected: vixens.io/sizing.goldilocks-controller: G-nano
   ```
7. Wait 15 min for maturity scan
8. Verify tier upgrade:
   ```bash
   kubectl -n monitoring get deployments -l app.kubernetes.io/name=goldilocks -o json | jq -r '.items[] | "\(.metadata.name): \(.metadata.labels.\"vixens.io/maturity\")"'
   # Expected: goldilocks-controller: silver, goldilocks-dashboard: silver
   ```

## Related

- PR #2052 (initial attempt - incorrect `resources: {}` placement)
- Silverification Campaign (goldilocks anti-pattern fix)
- Librarian research session: bg_56bc8fa3 (Helm chart deep-merge analysis)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated monitoring configuration to use explicit resource request and limit structures, improving configuration clarity and consistency across controller and dashboard components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->