### PR TITLE
fix(argocd): correct dex-server sizing label to use container name

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/argocd/overlays/prod/kustomization.yaml
@@ -210,7 +210,7 @@ patches:
       name: argocd-dex-server
   - patch: |-
       - op: add
-        path: /spec/template/metadata/labels/vixens.io~1sizing.argocd-dex-server
+        path: /spec/template/metadata/labels/vixens.io~1sizing.dex
         value: G-nano
     target:
       kind: Deployment


### PR DESCRIPTION
## Summary

Fixes argocd-dex-server Bronze tier issue discovered during silverification campaign.

## Problem

The sizing label was using the deployment name (argocd-dex-server) instead of the container name (dex). The maturity controller's `validate_sizing_coverage()` function checks for `vixens.io/sizing.<container-name>`, not deployment name.

## Root Cause

PR #2054 added sizing labels using deployment names for all ArgoCD components. This worked for applicationset-controller and notifications-controller because their container names match their deployment names, but failed for dex-server:
- Container name: `dex`
- Deployment name: `argocd-dex-server`
- Label used (wrong): `vixens.io/sizing.argocd-dex-server`
- Label needed (correct): `vixens.io/sizing.dex`

## Changes

- Changed label from `vixens.io/sizing.argocd-dex-server` → `vixens.io/sizing.dex`

## Expected Impact

- argocd-dex-server: Bronze → Silver (after ArgoCD sync + maturity scan)

## Testing

- [ ] yamllint passed
- [ ] Kustomize build successful
- [ ] ArgoCD sync clean
- [ ] Maturity scan confirms Silver tier

## Related

Part of Silverification Campaign (targeting all Bronze apps → Silver minimum)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal infrastructure configuration labels for improved system organization and management consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->