### PR TITLE
fix(goldilocks): add sizing labels via Helm additionalLabels

### DIFF
--- a/apps/02-monitoring/goldilocks/values/common.yaml
+++ b/apps/02-monitoring/goldilocks/values/common.yaml
@@ -18,6 +18,9 @@ controller:
     requests: {}  # Explicitly empty - Kyverno mutates via sizing labels
     limits: {}
   deployment:
+    additionalLabels:
+      vixens.io/sizing-v2: "true"
+      vixens.io/sizing.goldilocks: G-nano  # container name: goldilocks
     podAnnotations:
       vixens.io/fast-start: "true"
       vixens.io/nometrics: "true"  # goldilocks-controller has no Prometheus metrics port defined
@@ -46,6 +49,9 @@ dashboard:
     requests: {}  # Explicitly empty - Kyverno mutates via sizing labels
     limits: {}
   deployment:
+    additionalLabels:
+      vixens.io/sizing-v2: "true"
+      vixens.io/sizing.goldilocks: G-nano  # container name: goldilocks
     podAnnotations:
       vixens.io/fast-start: "true"
       vixens.io/nometrics: "true"  # goldilocks-dashboard is a web UI with no /metrics endpoint


### PR DESCRIPTION
## Summary

Fixes goldilocks Bronze tier issue using Helm chart's native `additionalLabels` support.

## Problem

Goldilocks remained Bronze tier despite multiple fix attempts:
1. **PR #2052**: Attempted `resources: {}` in Helm values → **FAILED** (Helm deep-merge kept chart defaults)
2. **PR #2055**: Attempted `resources: {requests: {}, limits: {}}` → **FAILED** (still deep-merged)
3. Kustomize patches attempted (similar to velero) → **FAILED** (ArgoCD multi-source limitation)

## Root Causes

### 1. Helm Deep-Merge Behavior
```yaml
# Chart defaults (fairwinds/goldilocks v10.2.0)
controller:
  resources:
    requests:
      cpu: 25m
      memory: 256Mi

# Our override (WRONG approach)
controller:
  resources: {}             # ❌ Doesn't override nested blocks
  # OR
  resources:
    requests: {}            # ❌ Still merges with chart defaults
    limits: {}
```

Result: Chart's `requests` block survives, creating anti-pattern (manual resources).

### 2. ArgoCD Multi-Source Limitation
Same architectural issue as velero (#2057):
- Goldilocks uses Helm-only deployment (empty Kustomize base)
- Kustomize patches don't apply to Helm-rendered resources
- Patches were silently ignored

## Solution: Use Helm Chart Native Support

The goldilocks Helm chart (v10.x) **natively supports** `additionalLabels`:
```yaml
# values/common.yaml
controller:
  deployment:
    additionalLabels:
      vixens.io/sizing-v2: "true"
      vixens.io/sizing.goldilocks: G-nano  # container name: goldilocks

dashboard:
  deployment:
    additionalLabels:
      vixens.io/sizing-v2: "true"
      vixens.io/sizing.goldilocks: G-nano  # container name: goldilocks
```

**Confirmed by librarian agent:** [fairwinds/charts master](https://github.com/FairwindsOps/charts/blob/master/stable/goldilocks/values.yaml)

### How It Works

The chart applies `additionalLabels` to **BOTH**:
1. Deployment metadata (`metadata.labels`)
2. Pod template labels (`spec.template.metadata.labels`) ✅ ← What Kyverno needs

Templates confirmed:
- [`templates/controller-deployment.yaml`](https://github.com/FairwindsOps/charts/blob/master/stable/goldilocks/templates/controller-deployment.yaml)
- [`templates/dashboard-deployment.yaml`](https://github.com/FairwindsOps/charts/blob/master/stable/goldilocks/templates/dashboard-deployment.yaml)

## Changes

### Added (values/common.yaml)
- `controller.deployment.additionalLabels.vixens.io/sizing-v2: "true"`
- `controller.deployment.additionalLabels.vixens.io/sizing.goldilocks: G-nano`
- `dashboard.deployment.additionalLabels.vixens.io/sizing-v2: "true"`
- `dashboard.deployment.additionalLabels.vixens.io/sizing.goldilocks: G-nano`

**Note**: Container name is `goldilocks` for both controller and dashboard deployments (verified via kubectl).

### No Files Removed
Unlike velero fix (#2057), goldilocks had no Kustomize patches to remove (those attempts were never merged).

## Expected Impact

After ArgoCD sync + maturity scan:
- goldilocks-controller: Bronze → **Silver** ✅
- goldilocks-dashboard: Bronze → **Silver** ✅

## Testing

- [ ] yamllint passed
- [ ] Kustomize build successful
- [ ] Helm values validation passed
- [ ] ArgoCD sync clean
- [ ] Pod labels verified: `kubectl get pods -n monitoring -l app.kubernetes.io/name=goldilocks -o json | jq '.items[].metadata.labels'`
- [ ] Maturity scan confirms Silver tier

## Lessons Learned

**Helm Deep-Merge Gotcha:**
- `resources: {}` does NOT override nested `requests/limits` blocks
- Helm merges values recursively, preserving chart defaults
- **Solution**: Don't fight Helm merge behavior — use chart native features

**Helm-Only App Pattern (velero + goldilocks):**
1. Check if chart supports native label/annotation injection
2. Use Helm values first (cleanest approach)
3. Kustomize patches only work with non-empty Kustomize bases
4. Post-rendering is complex fallback (not needed here)

## Related

Part of Silverification Campaign - targeting all Bronze apps → Silver minimum
Refs: 
- #2052 (first goldilocks attempt - Helm deep-merge issue discovered)
- #2055 (second attempt - still failed)
- #2057 (velero fix - same ArgoCD multi-source pattern)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment configurations with additional metadata labels for improved operational organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->