### PR TITLE
fix(kyverno): change require-probes category to Maturity (Silver)

### DIFF
--- a/apps/00-infra/kyverno/base/policies/require-probes.yaml
+++ b/apps/00-infra/kyverno/base/policies/require-probes.yaml
@@ -7,7 +7,7 @@ metadata:
   name: require-probes
   annotations:
     policies.kyverno.io/title: Require Probes
-    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/category: Maturity (Silver)
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-


### PR DESCRIPTION
## Summary

Fixes derive C9 - require-probes policy was categorized as 'Best Practices' instead of 'Maturity (Silver)', causing maturity-controller to ignore 128 probe violations.

## Changes

- Changed `policies.kyverno.io/category` from `Best Practices` to `Maturity (Silver)` in `require-probes.yaml`

## Impact

**Before:**
- 128 probe violations were **invisible** to maturity-controller
- Apps without probes could reach Silver/Gold tiers

**After:**
- maturity-controller will now **count** these violations
- ~20 apps may drop tier until probes are added
- Accurate Silver tier enforcement

## Testing

- [ ] ArgoCD sync completed
- [ ] Policy deployed with correct category
- [ ] maturity-controller sees violations in PolicyReports
- [ ] No new blocking issues

## Related

- Derive: vixens-wx0n (C9)
- Similar fix: PR #2044 (require-resources)

## Validation

```bash
# Verify deployed policy category
kubectl get clusterpolicy require-probes -o yaml | grep category

# Verify maturity-controller sees violations
kubectl get policyreport -A -o json | jq '.items[].results[] | select(.policy == "require-probes" and .category | contains("Silver"))'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated policy categorization metadata to improve organization and discoverability within the policy management system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->