### PR TITLE
docs(derive-c6): fix version divergences

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,10 +254,10 @@ mcp__playwright__browser_snapshot()
 - **Regeneration:** Copy from terravixens after `terraform apply` (see `.secrets/README.md`)
 
 **Core Stack:**
-- OS: Talos Linux v1.11.0 (immutable, API-driven)
+- OS: Talos Linux v1.12.4 (immutable, API-driven)
 - Kubernetes: v1.34.0
 - Infrastructure: Terraform + Talos provider
-- GitOps: ArgoCD v7.7.7 (App-of-Apps pattern)
+- GitOps: ArgoCD v3.3.3 (App-of-Apps pattern)
 - CNI: Cilium v1.18.3 (eBPF, kube-proxy replacement)
 - LoadBalancer: Cilium L2 Announcements + LB IPAM
 - Ingress: Traefik v3.x

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -543,10 +543,10 @@ cat docs/adr/008-trunk-based-gitops-workflow.md
 **Vixens** is a multi-cluster Kubernetes homelab infrastructure following GitOps best practices.
 
 **Core Stack:**
-- OS: Talos Linux v1.11.0 (immutable, API-driven)
+- OS: Talos Linux v1.12.4 (immutable, API-driven)
 - Kubernetes: v1.34.0
 - Infrastructure: Terraform + Talos provider
-- GitOps: ArgoCD v7.7.7 (App-of-Apps pattern)
+- GitOps: ArgoCD v3.3.3 (App-of-Apps pattern)
 - CNI: Cilium v1.18.3 (eBPF, kube-proxy replacement)
 - LoadBalancer: Cilium L2 Announcements + LB IPAM
 - Ingress: Traefik v3.x

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Kubernetes](https://img.shields.io/badge/Kubernetes-v1.34.0-blue.svg)](https://kubernetes.io/)
-[![Talos](https://img.shields.io/badge/Talos-v1.11.0-orange.svg)](https://www.talos.dev/)
-[![ArgoCD](https://img.shields.io/badge/ArgoCD-v7.7.7-green.svg)](https://argo-cd.readthedocs.io/)
+[![Talos](https://img.shields.io/badge/Talos-v1.12.4-orange.svg)](https://www.talos.dev/)
+[![ArgoCD](https://img.shields.io/badge/ArgoCD-v3.3.3-green.svg)](https://argo-cd.readthedocs.io/)
 
 ---
 
@@ -49,9 +49,9 @@ just resume
 
 | Component | Version | Purpose |
 |-----------|---------|---------|
-| **Talos Linux** | v1.11.0 | Immutable, API-driven OS |
+| **Talos Linux** | v1.12.4 | Immutable, API-driven OS |
 | **Kubernetes** | v1.34.0 | Container orchestration |
-| **ArgoCD** | v7.7.7 | GitOps continuous delivery |
+| **ArgoCD** | v3.3.3 | GitOps continuous delivery |
 | **Cilium** | v1.18.3 | CNI with eBPF (kube-proxy replacement) |
 | **Traefik** | v3.x | Ingress controller |
 | **Synology CSI** | Latest | Persistent storage (iSCSI) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ This document defines the architectural approach for standardizing the Vixens cl
     - **Network:** Cilium (CNI) + AdGuard Home (Internal DNS HA).
     - **Storage:** Synology CSI (iSCSI/NFS).
     - **Secrets:** Infisical Operator (Injector for storage & app secrets).
-    - **GitOps:** ArgoCD v7.x using a Trunk-based workflow (main branch).
+    - **GitOps:** ArgoCD v3.3.3 using a Trunk-based workflow (main branch).
 
 **Key Findings (2026-03-08):**
 - **Durability Gaps:** Many SQLite-based applications lack continuous replication → Blocage niveau Emerald (317 violations check-backup).

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -62,7 +62,7 @@ Le cluster Vixens nécessite une phase de consolidation après une période de c
 
 ### 4.3. Technical Constraints (Real-world Analysis)
 *   **Kubernetes Version :** v1.34.0
-*   **OS :** Talos Linux v1.12.2 (Kernel 6.18.5)
+*   **OS :** Talos Linux v1.12.4 (Kernel 6.18.5)
 *   **Nodes :** 3 Control-planes (phoebe, poison, powder), 2 Workers (peach, pearl)
 *   **IP Range :** 192.168.111.191 - 192.168.111.195
 *   **CNI :** Cilium


### PR DESCRIPTION
## Summary
Fixes derive C6 (vixens-f1w5): Documentation version divergences

## Changes
- **README.md**: Talos v1.11.0→v1.12.4, ArgoCD v7.7.7→v3.3.3
- **CLAUDE.md**: Talos v1.11.0→v1.12.4, ArgoCD v7.7.7→v3.3.3
- **GEMINI.md**: Talos v1.11.0→v1.12.4, ArgoCD v7.7.7→v3.3.3
- **docs/prd.md**: Talos v1.12.2→v1.12.4
- **docs/architecture.md**: ArgoCD v7.x→v3.3.3

All versions now match deployed cluster state.

## Validation
- Versions confirmed against cluster: `talosctl version`, `kubectl version`, `argocd version`
- Documentation consistency verified across all 5 files

## Related
- Task: vixens-f1w5
- Dérive: C6 (Critical - P1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated infrastructure version references: Talos Linux to v1.12.4 and ArgoCD to v3.3.3 across documentation
  * Added Infisical Operator reference to technical constraints documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->