### PR TITLE
docs(derive-c10): fix prod cluster status

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ just resume
 | Environment | Nodes | VIP | Status |
 |-------------|-------|-----|--------|
 | **Dev** | daphne, diva, dulce (3 CP HA) | 192.168.111.160 | ✅ Active |
-| **Prod** | Physical nodes (3) | 192.168.111.200 | 📅 Phase 3 |📅 Phase 3 |
+| **Prod** | peach, pearl, phoebe, poison, powder (5 nodes) | 192.168.111.190 | ✅ Active |
 
 ### Repository Structure
 


### PR DESCRIPTION
## Summary
Fixes derive C10 (vixens-tft7): README.md prod cluster information incorrect

## Changes
README.md Multi-Cluster Setup table:
- **Nodes**: 'Physical nodes (3)' → 'peach, pearl, phoebe, poison, powder (5 nodes)'
- **VIP**: 192.168.111.200 → 192.168.111.190
- **Status**: '📅 Phase 3' → '✅ Active'

## Validation
- Verified via `kubectl get nodes`: 5 nodes (peach, pearl, phoebe, poison, powder)
- Verified VIP via kubeconfig: 192.168.111.190
- Verified versions: Talos v1.12.4, K8s v1.34.0
- Cluster active for 67 days (since ~03/04/2026)

## Related
- Task: vixens-tft7
- Dérive: C10 (Critical - P1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Multi-Cluster Setup documentation with production environment configuration changes, including node composition and network address adjustments.
  * Production environment status updated to Active operational state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->