### PR TITLE
ci(derive-c7): update kubeconform to K8s 1.34.0

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -214,7 +214,7 @@ jobs:
             fi
 
             # Valider avec kubeconform (sur le YAML buildé)
-            if ! kubeconform -ignore-missing-schemas -kubernetes-version 1.30.0 -strict -skip "$SKIP_KINDS" /tmp/built.yaml 2>&1; then
+            if ! kubeconform -ignore-missing-schemas -kubernetes-version 1.34.0 -strict -skip "$SKIP_KINDS" /tmp/built.yaml 2>&1; then
               echo "❌ KUBECONFORM FAILED: $overlay"
               return 1
             fi


### PR DESCRIPTION
## Summary
Fixes derive C7 (vixens-x98l): kubeconform validating against K8s 1.30.0 while cluster runs 1.34.0

## Changes
`.github/workflows/validate.yaml`:
- kubeconform `kubernetes-version`: 1.30.0 → 1.34.0

## Rationale
- Cluster runs K8s 1.34.0 (4 versions ahead of CI validation)
- APIs/CRDs introduced in K8s 1.31-1.34 were not being validated
- Risk: invalid manifests could pass CI silently (false negatives)

## Impact
- May reveal previously masked validation errors (expected behavior)
- Ensures CI validates against actual cluster K8s version
- Reduces risk of deploying incompatible manifests

## Validation
- Version matches cluster: `kubectl version --short` shows v1.34.0
- CI will run kubeconform with correct K8s schema version

## Related
- Task: vixens-x98l
- Dérive: C7 (Critical - P1)