### PR TITLE
docs(derive-c8): remove non-existent 'just work' references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ yamllint --version
 just resume
 
 # 2. Work on task (full orchestration)
-just work <task_id>
+# See WORKFLOW.md for task workflow (bd update, work, bd close)
 
 # 3. Validate YAML before push
 just lint
@@ -290,7 +290,7 @@ Compare kinds before/after. A missing `kind` means a resource was silently dropp
 # Manual equivalent of "just resume"
 bd list --status in_progress --assignee coding-agent
 
-# Manual equivalent of "just work"
+# Manual workflow (see WORKFLOW.md for details)
 bd update <task_id> --status in_progress
 # ... do the work ...
 yamllint -c yamllint-config.yml apps/**/*.yaml
@@ -409,7 +409,7 @@ cd vixens
 bd list --status open --label documentation
 
 # Work on it
-just work <task_id>
+# Follow WORKFLOW.md for task execution
 
 # Follow the workflow
 # Update docs
@@ -423,7 +423,7 @@ just work <task_id>
 bd list --status open --label feat
 
 # Apply full workflow
-just work <task_id>
+# Follow WORKFLOW.md for task execution
 
 # Don't forget documentation updates!
 ```


### PR DESCRIPTION
## Summary
Fixes derive C8 (vixens-jh6o): AGENTS.md references non-existent 'just work' target

## Changes
Replace 4 occurrences of `just work <task_id>` with proper WORKFLOW.md references:
- Line 90: "See WORKFLOW.md for task workflow"
- Line 293: "Manual workflow (see WORKFLOW.md for details)"
- Line 412: "Follow WORKFLOW.md for task execution"
- Line 426: "Follow WORKFLOW.md for task execution"

## Rationale
- The `just work` target doesn't exist in justfile
- WORKFLOW.md documents the actual workflow using bd commands
- Prevents confusion for users/agents following AGENTS.md guide

## Validation
- ✅ Verified: No `just work` target in justfile
- ✅ All 4 references replaced
- ✅ WORKFLOW.md remains the authoritative workflow source

## Related
- Task: vixens-jh6o
- Dérive: C8 (Critical - P1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent documentation to guide users to the workflow documentation for proper command usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->