### PR TITLE
fix(homeassistant): increase litestream memory (OOMKilled fix)

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: homeassistant
     vixens.io/sizing: B-large
-    vixens.io/sizing.litestream: V-small
+    vixens.io/sizing.litestream: B-small
     vixens.io/sizing.config-syncer: V-nano
     vixens.io/sizing.restore-config: B-nano
     vixens.io/sizing.restore-db: B-nano
@@ -27,7 +27,7 @@ spec:
       labels:
         app: homeassistant
         vixens.io/sizing: B-large
-        vixens.io/sizing.litestream: V-small
+        vixens.io/sizing.litestream: B-small
         vixens.io/sizing.config-syncer: V-nano
         vixens.io/sizing.restore-config: B-nano
         vixens.io/sizing.restore-db: B-nano


### PR DESCRIPTION
## Summary
Fixes Home Assistant litestream container crashing with OOMKilled (105 restarts in 17h)

## Problem
**Symptoms:**
- Pod: `homeassistant-584449bc98-5zzvn` - CrashLoopBackOff (2/3 containers ready)
- Litestream container: **90 restarts**, repeatedly OOMKilled
- Main homeassistant container: 0 restarts (healthy)
- Config-syncer container: 15 restarts (healthy)

**Root Cause:**
- Litestream memory limit: **128Mi** (V-small sizing)
- Home Assistant SQLite DB has grown significantly over time
- Litestream crashes during DB compaction/replication (~5 minutes after startup)
- Exit code 137 = Out Of Memory

**Evidence:**
```bash
$ kubectl -n homeassistant logs homeassistant-584449bc98-5zzvn -c litestream
time=2026-03-13T15:21:27 level=INFO msg="initialized db" path=/config/home-assistant_v2.db
time=2026-03-13T15:21:27 level=INFO msg="starting compaction monitor" level=2 interval=5m0s
[... then OOMKilled 5 minutes later]

$ kubectl -n homeassistant get pod homeassistant-584449bc98-5zzvn -o json | jq '.status.containerStatuses[] | select(.name == "litestream") | .lastState.terminated'
{
  "exitCode": 137,
  "reason": "OOMKilled",
  "finishedAt": "2026-03-13T15:26:06Z"
}
```

## Changes
**Increased litestream memory allocation:**
- Sizing label: `V-small` → `B-small`
- Memory: 64Mi/128Mi → ~256Mi/512Mi

## Impact
- ✅ Litestream will have sufficient memory for large SQLite operations
- ✅ Continuous backup to S3 will resume normally
- ✅ Home Assistant pod will stabilize (no more restarts)
- ✅ No impact on homeassistant container (already B-large)

## Validation
After merge:
1. ArgoCD will sync the change (~3min)
2. Deployment will rollout new pod
3. Verify litestream starts and stays running:
   ```bash
   kubectl -n homeassistant get pods -w
   kubectl -n homeassistant logs -f deployment/homeassistant -c litestream
   ```
4. Confirm 0 restarts after 1 hour

## Related
- Troubleshooting session: Home Assistant "clignotte" investigation
- Similar to incident 2026-03-09 (sizing race condition)