### PR TITLE
fix(homeassistant): apply litestream memory fix to prod overlay

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/resources-patch.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/resources-patch.yaml
@@ -11,5 +11,5 @@ spec:
       labels:
         vixens.io/sizing: B-xlarge
         vixens.io/sizing.homeassistant: B-xlarge
-        vixens.io/sizing.litestream: B-nano
+        vixens.io/sizing.litestream: B-small
         vixens.io/sizing.config-syncer: B-nano


### PR DESCRIPTION
## Summary
- Fix litestream OOMKilled in production by updating prod overlay sizing

## Context
PR #2073 updated the base deployment to `B-small` for litestream, but the **prod overlay** (`resources-patch.yaml`) was overriding it back to `B-nano`.

This resulted in the pod template still having 128Mi memory limit, causing litestream to crash with exit code 137 (OOMKilled) when handling large SQLite databases.

## Changes
- `apps/10-home/homeassistant/overlays/prod/resources-patch.yaml`: Changed `vixens.io/sizing.litestream` from `B-nano` to `B-small`

## Expected Result
- Litestream container gets ~256Mi/512Mi memory (B-small profile)
- No more OOMKilled restarts
- Home Assistant stops "flickering"