### PR TITLE
fix(derive-c5): reclassify CVE policies as Orichalcum (L7)

### DIFF
--- a/apps/00-infra/kyverno/base/policies/check-trivy-cve.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-trivy-cve.yaml
@@ -5,11 +5,11 @@ metadata:
   name: check-trivy-cve
   annotations:
     policies.kyverno.io/title: Require No Critical CVEs
-    policies.kyverno.io/category: Maturity (Diamond)
+    policies.kyverno.io/category: Maturity (Orichalcum)
     policies.kyverno.io/severity: high
     policies.kyverno.io/description: >-
       VulnerabilityReports for pods must show zero CRITICAL CVEs without explicit acquittement
-      annotation for maturity Level 6 (Diamond).
+      annotation for maturity Level 7 (Orichalcum).
 spec:
   validationFailureAction: Audit
   background: true
@@ -26,7 +26,7 @@ spec:
               annotations:
                 vixens.io/cve-accepted: "true"
       validate:
-        message: "VulnerabilityReport must show zero CRITICAL CVEs for maturity Level 6 (Diamond)."
+        message: "VulnerabilityReport must show zero CRITICAL CVEs for maturity Level 7 (Orichalcum)."
         pattern:
           report:
             summary:

--- a/apps/00-infra/kyverno/base/policies/check-vulnerability-scan.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-vulnerability-scan.yaml
@@ -5,9 +5,9 @@ metadata:
   name: check-vulnerability-scan
   annotations:
     policies.kyverno.io/title: Verify Security Scan
-    policies.kyverno.io/category: Maturity (Diamond)
+    policies.kyverno.io/category: Maturity (Orichalcum)
     policies.kyverno.io/description: >-
-      Diamond tier requires a clean vulnerability report from Trivy (0 critical vulnerabilities).
+      Orichalcum tier requires a clean vulnerability report from Trivy (0 critical vulnerabilities).
 spec:
   validationFailureAction: Audit
   background: true
@@ -24,7 +24,7 @@ spec:
             urlPath: "/apis/aquasecurity.github.io/v1alpha1/namespaces/{{request.namespace}}/vulnerabilityreports"
             jmesPath: "items[?metadata.labels.\"trivy-operator.resource.name\" == '{{request.object.metadata.labels.app}}'].report.summary.criticalCount | [0]"
       validate:
-        message: "Diamond tier requires a clean security scan (0 critical vulnerabilities). Current count: {{vuln_count || 'No report found'}}."
+        message: "Orichalcum tier requires a clean security scan (0 critical vulnerabilities). Current count: {{vuln_count || 'No report found'}}."
         deny:
           conditions:
             all:

--- a/docs/adr/023-7-tier-goldification-system-v2.md
+++ b/docs/adr/023-7-tier-goldification-system-v2.md
@@ -38,7 +38,7 @@ ADR-022 définissait le système 7-tiers initial. Suite à une revue critique, p
 | `vixens.io/nossoneeded: "true"` | Authentik SSO (Diamond) | App sans authentification utilisateur |
 | `vixens.io/nohomepage: "true"` | Homepage widget (Diamond) | Non pertinent pour le dashboard |
 | `vixens.io/noingressneeded: "true"` | Ingress (Bronze) | App interne, non exposée |
-| `vixens.io/cve-accepted: "true"` | Trivy CVE critique (Diamond) | CVE accepté, risque documenté |
+| `vixens.io/cve-accepted: "true"` | Trivy CVE critique (Orichalcum) | CVE accepté, risque documenté |
 | `vixens.io/digest-pinned: "true"` | Image digest (Diamond) | Opt-in : active le check (Renovate gère tag+digest) |
 | `vixens.io/needs-autoscaling: "true"` | HPA/KEDA (Platinum) | Opt-in : active le check (charge variable identifiée) |
 


### PR DESCRIPTION
## Summary
- Reclassify CVE compliance policies from Diamond (L6) to Orichalcum (L7) per ADR-023

## Context
ADR-023 v2.1 specifies that "Zéro CVE HIGH/CRITICAL" is an **Orichalcum** (Level 7) requirement, not Diamond (Level 6).

Both CVE policies were incorrectly annotated as Diamond:
- `check-trivy-cve.yaml`
- `check-vulnerability-scan.yaml`

## Changes
1. **check-trivy-cve.yaml**: `Maturity (Diamond)` → `Maturity (Orichalcum)`
2. **check-vulnerability-scan.yaml**: `Maturity (Diamond)` → `Maturity (Orichalcum)`
3. **ADR-023**: Fixed bypass table row (CVE → Orichalcum)

## Related
- Closes dérive C5
- Beads task: vixens-pjxu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security policy maturity level classifications from Diamond to Orichalcum tier.
  * Updated corresponding policy descriptions and validation messages to reflect tier changes.
  * Aligned documentation with maturity level updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->