### PR TITLE
fix(derives): major policy refactors (M2, M4, M8, M13)

### DIFF
--- a/apps/00-infra/kyverno/base/policies/check-managed-by-label.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-managed-by-label.yaml
@@ -2,22 +2,20 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  labels:
-    argocd.argoproj.io/instance: kyverno
-  name: add-default-labels
+  name: check-managed-by-label
   annotations:
-    policies.kyverno.io/title: Add Default Labels
+    policies.kyverno.io/title: Check Managed-By Label
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: low
-    policies.kyverno.io/subject: Pod, Deployment, StatefulSet
+    policies.kyverno.io/subject: Deployment, StatefulSet, DaemonSet
     policies.kyverno.io/description: >-
-      Mutates resources to add default labels for consistency.
-      Adds 'managed-by: kyverno' label if not present.
+      Validates that resources have the app.kubernetes.io/managed-by label set.
+      This label indicates the tool managing the resource (e.g., kustomize, helm).
 spec:
   validationFailureAction: Audit
   background: true
   rules:
-    - name: add-managed-by-label
+    - name: validate-managed-by-label
       match:
         any:
           - resources:

--- a/apps/00-infra/kyverno/base/policies/mutate-app-name-label.yaml
+++ b/apps/00-infra/kyverno/base/policies/mutate-app-name-label.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: mutate-app-name-label
+  annotations:
+    policies.kyverno.io/title: Add app.kubernetes.io/name Label
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: low
+    policies.kyverno.io/subject: Deployment, StatefulSet, DaemonSet
+    policies.kyverno.io/description: >-
+      Mutates Deployments, StatefulSets, and DaemonSets to add the standard
+      app.kubernetes.io/name label derived from metadata.name if not already present.
+      This enables consistent kubectl filtering and ServiceMonitor selectors.
+spec:
+  schemaValidation: false
+  rules:
+    - name: add-app-name-to-deployment
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kyverno
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            labels:
+              +(app.kubernetes.io/name): "{{ request.object.metadata.name }}"
+          spec:
+            template:
+              metadata:
+                labels:
+                  +(app.kubernetes.io/name): "{{ request.object.metadata.name }}"
+    - name: add-app-name-to-statefulset
+      match:
+        any:
+          - resources:
+              kinds:
+                - StatefulSet
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kyverno
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            labels:
+              +(app.kubernetes.io/name): "{{ request.object.metadata.name }}"
+          spec:
+            template:
+              metadata:
+                labels:
+                  +(app.kubernetes.io/name): "{{ request.object.metadata.name }}"
+    - name: add-app-name-to-daemonset
+      match:
+        any:
+          - resources:
+              kinds:
+                - DaemonSet
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kyverno
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            labels:
+              +(app.kubernetes.io/name): "{{ request.object.metadata.name }}"
+          spec:
+            template:
+              metadata:
+                labels:
+                  +(app.kubernetes.io/name): "{{ request.object.metadata.name }}"

--- a/apps/00-infra/kyverno/base/policies/require-resource-limits.yaml
+++ b/apps/00-infra/kyverno/base/policies/require-resource-limits.yaml
@@ -2,22 +2,21 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  labels:
-    argocd.argoproj.io/instance: kyverno
-  name: require-resources
+  name: require-resource-limits
   annotations:
-    policies.kyverno.io/title: Require Resources
+    policies.kyverno.io/title: Require Resource Limits
     policies.kyverno.io/category: Maturity (Silver)
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      Resources requests and limits are required for all containers for maturity Level 2 (Silver).
-      This policy audits containers that do not have resource limits defined.
+      Resource limits (CPU and memory) are required for all containers for
+      maturity Level 2 (Silver). Limits prevent resource exhaustion and enable
+      proper QoS class assignment (Burstable or Guaranteed).
 spec:
   validationFailureAction: Audit
   background: true
   rules:
-    - name: validate-resources
+    - name: validate-resource-limits
       match:
         any:
           - resources:
@@ -30,14 +29,11 @@ spec:
                 - kube-system
                 - kyverno
       validate:
-        message: "CPU and memory resource requests and limits are required."
+        message: "CPU and memory resource limits are required for maturity Level 2 (Silver)."
         pattern:
           spec:
             containers:
               - resources:
-                  requests:
-                    memory: "?*"
-                    cpu: "?*"
                   limits:
                     memory: "?*"
                     cpu: "?*"

--- a/apps/00-infra/kyverno/base/policies/require-resource-requests.yaml
+++ b/apps/00-infra/kyverno/base/policies/require-resource-requests.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-resource-requests
+  annotations:
+    policies.kyverno.io/title: Require Resource Requests
+    policies.kyverno.io/category: Maturity (Bronze)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Resource requests (CPU and memory) are required for all containers for
+      maturity Level 1 (Bronze). Requests enable the scheduler to make informed
+      placement decisions and are the minimum resource allocation requirement.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: validate-resource-requests
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kyverno
+      validate:
+        message: "CPU and memory resource requests are required for maturity Level 1 (Bronze)."
+        pattern:
+          spec:
+            containers:
+              - resources:
+                  requests:
+                    memory: "?*"
+                    cpu: "?*"

--- a/apps/_shared/components/base/kustomization.yaml
+++ b/apps/_shared/components/base/kustomization.yaml
@@ -2,9 +2,22 @@
 #
 # Kustomize Component: Base Requirements
 #
-# Minimal requirements for ALL applications:
-# - revisionHistoryLimit: 3
-# - SecurityContext hardened (pod level)
+# Minimal requirements for ALL applications (Bronze through Orichalcum).
+#
+# DEFENSE-IN-DEPTH: This component intentionally applies Diamond-level
+# security context (runAsNonRoot, seccompProfile: RuntimeDefault) to ALL
+# apps regardless of their target maturity tier. This is a security baseline,
+# not a tier requirement - all workloads should run with least privilege.
+#
+# Actual maturity tier is determined by Kyverno PolicyReports, not by which
+# components an app uses. Bronze apps using 'base' don't become Diamond;
+# they simply inherit good security defaults.
+#
+# Includes:
+#   - revisionHistoryLimit: 3 (prevent unbounded ReplicaSet growth)
+#   - runAsNonRoot: true (never run as root)
+#   - runAsUser/fsGroup: 1000 (predictable non-root UID)
+#   - seccompProfile: RuntimeDefault (container syscall filtering)
 #
 # Usage:
 #   components:


### PR DESCRIPTION
## Summary
Major policy refactoring batch addressing 4 dérives from ADR-023 v2.1 compliance audit.

### Changes

#### M2: Split require-resources into Bronze/Silver policies
- **require-resource-requests.yaml** (Bronze - L1) - validates CPU/memory requests
- **require-resource-limits.yaml** (Silver - L2) - validates CPU/memory limits
- Delete merged `require-resources.yaml` that conflated both tiers

#### M4: Document defense-in-depth in base component
- Added comprehensive documentation explaining why base includes Diamond-level security
- Security baseline != maturity tier (all apps should run securely regardless of tier)

#### M8: Add mutate-app-name-label policy
- Auto-inject `app.kubernetes.io/name` from `metadata.name` on Deployments, StatefulSets, DaemonSets
- Enables consistent kubectl filtering and ServiceMonitor selectors
- Fixes 30+ apps missing this standard label

#### M13: Rename add-default-labels → check-managed-by-label
- Policy validates presence, doesn't mutate (was misnamed)
- Name now accurately reflects behavior

### Dérives Resolved
- `vixens-k4f5` - M2: require-resources merges Bronze+Silver
- `vixens-k34v` - M4: base component applies Diamond to Bronze apps
- `vixens-7hxi` - M8: app.kubernetes.io/name absent on 30+ apps
- `vixens-n4ni` - M13: add-default-labels validate disguised as mutate

### Remaining
- `vixens-im52` - M9: 5 apps with explicit resources (deferred - requires individual app analysis)