### PR TITLE
fix(kyverno): bypass check-ingress-tls for HTTP redirect ingresses

### DIFF
--- a/apps/00-infra/kyverno/base/policies/check-ingress-tls.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-ingress-tls.yaml
@@ -9,6 +9,7 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Production applications must use HTTPS. This policy audits Ingress resources for TLS configuration.
+      HTTP-to-HTTPS redirect ingresses (entrypoint: web) are automatically bypassed.
 spec:
   validationFailureAction: Audit
   background: true
@@ -20,6 +21,12 @@ spec:
           - resources:
               kinds:
                 - Ingress
+      preconditions:
+        all:
+          # Skip HTTP redirect ingresses (they use 'web' entrypoint and redirect to HTTPS)
+          - key: "{{ request.object.metadata.annotations.['traefik.ingress.kubernetes.io/router.entrypoints'] || 'websecure' }}"
+            operator: NotEquals
+            value: "web"
       validate:
         message: "Ingress must have TLS configured for maturity Level 2 (Silver)."
         pattern:


### PR DESCRIPTION
## Summary
HTTP-to-HTTPS redirect ingresses use the `web` entrypoint and intentionally don't have TLS (they just redirect to HTTPS). This was causing false positives in maturity scoring.

## Fix
Add precondition to skip ingresses with `traefik.ingress.kubernetes.io/router.entrypoints: web` annotation.

## Impact
Unblocks Gold maturity for apps with HTTP redirect ingresses:
- homeassistant
- radarr  
- sonarr
- and others

## Testing
After merge and policy sync, maturity-controller will recalculate and promote eligible apps to Gold.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Ingress validation now automatically bypasses HTTP-to-HTTPS redirect configurations
  * Strengthened TLS enforcement for standard Ingress resources

* **Documentation**
  * Updated policy description to clarify automatic bypass behavior for redirect ingresses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->