### PR TITLE
fix(mylar,prowlarr): fix escaped LITESTREAM_BUCKET env var in config-syncer

### DIFF
--- a/apps/20-media/mylar/base/deployment.yaml
+++ b/apps/20-media/mylar/base/deployment.yaml
@@ -190,7 +190,7 @@ spec:
               export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=$LITESTREAM_SECRET_ACCESS_KEY
               export RCLONE_CONFIG_S3_ENDPOINT=$LITESTREAM_ENDPOINT
               sync_s3() {
-                rclone sync /config s3:\$LITESTREAM_BUCKET/config --exclude "*.db*" --exclude "*.log" --exclude ".*-litestream" --exclude ".*-litestream/**"
+                rclone sync /config s3:$LITESTREAM_BUCKET/config --exclude "*.db*" --exclude "*.log" --exclude ".*-litestream" --exclude ".*-litestream/**"
               }
               while true; do
                 sync_s3;

--- a/apps/20-media/prowlarr/base/deployment.yaml
+++ b/apps/20-media/prowlarr/base/deployment.yaml
@@ -190,7 +190,7 @@ spec:
               export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=$LITESTREAM_SECRET_ACCESS_KEY
               export RCLONE_CONFIG_S3_ENDPOINT=$LITESTREAM_ENDPOINT
               sync_s3() {
-                rclone sync /config s3:\$LITESTREAM_BUCKET/config --exclude "*.db*" --exclude "*.log" --exclude ".*-litestream" --exclude ".*-litestream/**"
+                rclone sync /config s3:$LITESTREAM_BUCKET/config --exclude "*.db*" --exclude "*.log" --exclude ".*-litestream" --exclude ".*-litestream/**"
               }
               while true; do
                 sync_s3;


### PR DESCRIPTION
## Summary
- Fix escaped \$LITESTREAM_BUCKET in config-syncer container for mylar and prowlarr
- The escaped variable was preventing S3 sync from working (400 Bad Request)

## Root Cause
Line 193 in both deployments had `s3:\$LITESTREAM_BUCKET/config` instead of `s3:$LITESTREAM_BUCKET/config`

## Testing
- Other apps with correct syntax (radarr, sonarr, lidarr) now work after S3 credential fix
- After this PR merges, mylar and prowlarr will restart and sync correctly