### PR TITLE
fix(frigate): update litestream config to use env vars for bucket/endpoint

### DIFF
--- a/apps/20-media/frigate/base/litestream-config.yaml
+++ b/apps/20-media/frigate/base/litestream-config.yaml
@@ -8,6 +8,6 @@ data:
     dbs:
       - path: /config/frigate.db
         replicas:
-          - url: s3://vixens-litestream/frigate/frigate.db
-            endpoint: http://192.168.111.69:9000
+          - url: s3://$LITESTREAM_BUCKET/frigate.db
+            endpoint: $LITESTREAM_ENDPOINT
     addr: ":9090"


### PR DESCRIPTION
## Summary
- Update frigate litestream config to use $LITESTREAM_BUCKET and $LITESTREAM_ENDPOINT env vars
- Previously hardcoded to `vixens-litestream` bucket (which doesn't exist) and `192.168.111.69:9000` endpoint

## Root Cause
The litestream configmap was hardcoded with incorrect bucket and endpoint values, causing litestream to fail with 403 Access Denied.

## Related
- Part of S3 credentials fix (PR #2084 fixed mylar/prowlarr, this fixes frigate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to use environment variables for database replication settings, replacing hardcoded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->