### PR TITLE
fix(homeassistant): exclude SQLite files from rclone sync

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -102,7 +102,7 @@ spec:
               export RCLONE_CONFIG_S3_ACCESS_KEY_ID=$LITESTREAM_ACCESS_KEY_ID
               export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=$LITESTREAM_SECRET_ACCESS_KEY
               export RCLONE_CONFIG_S3_ENDPOINT=$LITESTREAM_ENDPOINT
-              rclone copy s3:$LITESTREAM_BUCKET/config /config --transfers 4 --exclude "*.log" --exclude "tts/**" --exclude "backups/**" --exclude "tmp_backups/**" --exclude "lost+found/**" --exclude ".*-litestream" --exclude ".*-litestream/**" 2>/dev/null || true
+              rclone copy s3:$LITESTREAM_BUCKET/config /config --transfers 4 --exclude "*.log" --exclude "*.db" --exclude "*.db-*" --exclude "tts/**" --exclude "backups/**" --exclude "tmp_backups/**" --exclude "lost+found/**" --exclude ".*-litestream" --exclude ".*-litestream/**" 2>/dev/null || true
           envFrom:
             - secretRef:
                 name: homeassistant-secrets
@@ -243,7 +243,7 @@ spec:
               export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=$LITESTREAM_SECRET_ACCESS_KEY
               export RCLONE_CONFIG_S3_ENDPOINT=$LITESTREAM_ENDPOINT
               sync_s3() {
-                rclone sync /config s3:$LITESTREAM_BUCKET/config --exclude "*.log" --exclude "tts/**" --exclude "backups/**" --exclude "tmp_backups/**" --exclude "lost+found/**" --exclude ".*-litestream" --exclude ".*-litestream/**"
+                rclone sync /config s3:$LITESTREAM_BUCKET/config --exclude "*.log" --exclude "*.db" --exclude "*.db-*" --exclude "tts/**" --exclude "backups/**" --exclude "tmp_backups/**" --exclude "lost+found/**" --exclude ".*-litestream" --exclude ".*-litestream/**"
               }
               while true; do
                 sync_s3;


### PR DESCRIPTION
## Summary
- Exclude `*.db` and `*.db-*` files from rclone sync (both restore-config and config-syncer)
- Litestream already handles SQLite replication
- Fixes CrashLoopBackOff caused by rclone failing on active SQLite files

## Problem
config-syncer was trying to sync `home-assistant_v2.db*` files that are constantly being written by Home Assistant, causing:
```
ERROR: home-assistant_v2.db: Failed to copy: can't copy - source file is being updated
```

## Solution
Added exclusions to rclone commands:
- `--exclude "*.db"`
- `--exclude "*.db-*"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to exclude database files from backup and restore synchronization operations, improving system efficiency and reliability during maintenance procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->