### PR TITLE
feat(openclaw): add requested packages for Vixens agents

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -54,7 +54,7 @@ spec:
           args:
             - |
               set -e
-              TOOLS_VERSION="3"
+              TOOLS_VERSION="4"
               if [ -f /data/tools/.installed-version ] && [ "$(cat /data/tools/.installed-version)" = "$TOOLS_VERSION" ]; then
                 echo "Tools v$TOOLS_VERSION already present, skipping reinstall"
               else
@@ -65,7 +65,7 @@ spec:
                 apt-get install -y --no-install-recommends \
                   jq rsync python3-pip tree nano htop git sudo nmap dnsutils \
                   netcat-traditional sqlite3 ffmpeg imagemagick curl wget \
-                  ca-certificates gnupg lsb-release build-essential unzip zip gzip
+                  ca-certificates gnupg lsb-release build-essential unzip zip gzip openssl nodejs npm
                 for bin in jq rsync tree nano htop git nmap netcat ffmpeg convert sqlite3; do
                   cp /usr/bin/$bin /data/tools/bin/ 2>/dev/null || true
                   ldd /usr/bin/$bin 2>/dev/null | grep "=>" | awk '{print $3}' | xargs -I {} cp {} /data/tools/lib/ 2>/dev/null || true
@@ -95,8 +95,15 @@ spec:
                 ln -sf /data/tools/google-cloud-sdk/bin/gcloud /data/tools/bin/gcloud
                 ln -sf /data/tools/google-cloud-sdk/bin/gsutil /data/tools/bin/gsutil
                 ln -sf /data/tools/google-cloud-sdk/bin/bq /data/tools/bin/bq
-                # Install Google Python libraries
-                pip3 install --root=/data/tools google-auth-oauthlib google-api-python-client
+                # Install Python libraries
+                pip3 install --root=/data/tools \
+                  google-api-python-client google-auth-oauthlib google-auth-httplib2 \
+                  requests urllib3 pandas beautifulsoup4 lxml PyMuPDF pynetbox surrealdb
+                # Install Node packages
+                npm install -g @sinclair/typebox tslib
+                mkdir -p /data/tools/node_modules
+                cp -r /usr/local/lib/node_modules/@sinclair /data/tools/node_modules/ 2>/dev/null || true
+                cp -r /usr/local/lib/node_modules/tslib /data/tools/node_modules/ 2>/dev/null || true
                 echo "node ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/node
                 echo "$TOOLS_VERSION" > /data/tools/.installed-version
                 apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
Install additional packages requested for Vixens agents in openclaw init container.

## Packages Added

### Python
- `google-api-python-client` (already present)
- `google-auth-oauthlib` (already present)
- `google-auth-httplib2` ✨
- `requests` ✨
- `urllib3` ✨
- `pandas` ✨ (Aurelia insiste)
- `beautifulsoup4` + `lxml` ✨ (scraping Leclerc/Lidl)
- `PyMuPDF` ✨ (tickets de caisse PDF)
- `pynetbox` ✨ (automatisation inventaire réseau)
- `surrealdb` ✨ (projet Hairem)

### Node
- `@sinclair/typebox` ✨
- `tslib` ✨

### System
- `openssl` ✨
- `nodejs` + `npm` ✨ (requis pour les packages Node)
- `jq` (already present)
- `curl` (already present)

## Technical
- Bumped `TOOLS_VERSION` from 3 → 4 to force reinstall on next pod restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Tools version from 3 to 4
  * Added system utilities and expanded package dependencies
  * Updated Python library dependencies
  * Added Node.js packages for improved ecosystem support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->