### PR TITLE
fix(sabnzbd,whisparr): recursive litestream exclusions + fix probes

### DIFF
--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -37,6 +37,12 @@ spec:
           operator: Exists
           effect: NoSchedule
       initContainers:
+        - name: fix-permissions
+          image: busybox:1.37.0
+          command: ["sh", "-c", "chown -R 1000:1000 /config && find /config -type d -name '*-litestream' -exec rm -rf {} + 2>/dev/null || true"]
+          volumeMounts:
+            - name: config
+              mountPath: /config
         - name: restore-config
           image: rclone/rclone:1.73
           securityContext:
@@ -54,11 +60,11 @@ spec:
               export RCLONE_CONFIG_S3_ENDPOINT=$LITESTREAM_ENDPOINT
               rclone copy s3:$LITESTREAM_BUCKET/config /config \
                 --transfers 4 \
-                --exclude "*.db*" \
-                --exclude "*.log" \
-                --exclude ".*-litestream" \
-                --exclude ".*-litestream/**" \
-                || true
+              --exclude "*.db*" \
+              --exclude "*.log" \
+              --exclude "**/*-litestream" \
+              --exclude "**/*-litestream/**" \
+              || true
           envFrom:
             - secretRef:
                 name: sabnzbd-secrets
@@ -126,19 +132,15 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
           livenessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - pgrep -f litestream || exit 1
+            httpGet:
+              path: /metrics
+              port: 9090
             initialDelaySeconds: 10
-            periodSeconds: 30
+            periodSeconds: 20
           readinessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - pgrep -f litestream || exit 1
+            httpGet:
+              path: /metrics
+              port: 9090
             initialDelaySeconds: 5
             periodSeconds: 10
         - name: config-syncer
@@ -158,10 +160,10 @@ spec:
               export RCLONE_CONFIG_S3_ENDPOINT=$LITESTREAM_ENDPOINT
               sync_s3() {
                 rclone sync /config s3:$LITESTREAM_BUCKET/config \
-                  --exclude "*.db*" \
-                  --exclude "*.log" \
-                  --exclude ".*-litestream" \
-                  --exclude ".*-litestream/**";
+                --exclude "*.db*" \
+                --exclude "*.log" \
+                --exclude "**/*-litestream" \
+                --exclude "**/*-litestream/**";
               }
               while true; do
                 sync_s3;

--- a/apps/20-media/whisparr/base/deployment.yaml
+++ b/apps/20-media/whisparr/base/deployment.yaml
@@ -40,7 +40,7 @@ spec:
       initContainers:
         - name: fix-permissions
           image: busybox:1.37.0
-          command: ["sh", "-c", "chown -R 1000:1000 /config && rm -rf /config/*.db-litestream /config/.*-litestream"]
+          command: ["sh", "-c", "chown -R 1000:1000 /config && find /config -type d -name '*-litestream' -exec rm -rf {} + 2>/dev/null || true"]
           volumeMounts:
             - name: config
               mountPath: /config
@@ -61,11 +61,11 @@ spec:
               export RCLONE_CONFIG_S3_ENDPOINT=$LITESTREAM_ENDPOINT
               rclone copy s3:$LITESTREAM_BUCKET/config /config \
                 --transfers 4 \
-                --exclude "*.db*" \
-                --exclude "*.log" \
-                --exclude ".*-litestream" \
-                --exclude ".*-litestream/**" \
-                || true
+              --exclude "*.db*" \
+              --exclude "*.log" \
+              --exclude "**/*-litestream" \
+              --exclude "**/*-litestream/**" \
+              || true
           envFrom:
             - secretRef:
                 name: whisparr-secrets
@@ -143,19 +143,15 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
           livenessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - pgrep -f litestream || exit 1
+            httpGet:
+              path: /metrics
+              port: 9090
             initialDelaySeconds: 10
-            periodSeconds: 30
+            periodSeconds: 20
           readinessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - pgrep -f litestream || exit 1
+            httpGet:
+              path: /metrics
+              port: 9090
             initialDelaySeconds: 5
             periodSeconds: 10
         - name: config-syncer
@@ -175,10 +171,10 @@ spec:
               export RCLONE_CONFIG_S3_ENDPOINT=$LITESTREAM_ENDPOINT
               sync_s3() {
                 rclone sync /config s3:$LITESTREAM_BUCKET/config \
-                  --exclude "*.db*" \
-                  --exclude "*.log" \
-                  --exclude ".*-litestream" \
-                  --exclude ".*-litestream/**";
+                --exclude "*.db*" \
+                --exclude "*.log" \
+                --exclude "**/*-litestream" \
+                --exclude "**/*-litestream/**";
               }
               while true; do
                 sync_s3;


### PR DESCRIPTION
## Summary
- Change rclone exclusions from `.*-litestream` to `**/*-litestream` for recursive matching
- Fix litestream probes from `pgrep` (not in image) to `httpGet /metrics:9090`
- Add fix-permissions init container to sabnzbd with recursive cleanup
- Update whisparr fix-permissions to use recursive `find`

## Root Cause
Two issues causing litestream CrashLoopBackOff:

1. **sabnzbd**: DB at `/config/admin/history1.db` - litestream metadata in subdirectory not excluded by `--exclude ".*-litestream"` pattern (doesn't match subdirs)
2. **Both apps**: Liveness probe using `pgrep -f litestream` fails because `pgrep` doesn't exist in litestream image

## Fixes Applied
- Recursive exclusion: `**/*-litestream` matches any depth
- HTTP probe on litestream metrics endpoint (port 9090)
- Recursive cleanup via `find -name '*-litestream' -exec rm -rf {} +`

Closes vixens-3o0e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved service health monitoring with HTTP-based metrics checks replacing process-based detection
  * Enhanced configuration directory permission handling and initialization
  * Updated file exclusion patterns in data synchronization for improved consistency and reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->