### PR TITLE
fix(homeassistant): increase memory for litestream and config-syncer

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     app: homeassistant
     vixens.io/sizing: B-large
-    vixens.io/sizing.litestream: B-small
-    vixens.io/sizing.config-syncer: V-nano
+    vixens.io/sizing.litestream: B-medium
+    vixens.io/sizing.config-syncer: B-small
     vixens.io/sizing.restore-config: B-nano
     vixens.io/sizing.restore-db: B-nano
     vixens.io/backup-profile: "standard"
@@ -27,8 +27,8 @@ spec:
       labels:
         app: homeassistant
         vixens.io/sizing: B-large
-        vixens.io/sizing.litestream: B-small
-        vixens.io/sizing.config-syncer: V-nano
+        vixens.io/sizing.litestream: B-medium
+        vixens.io/sizing.config-syncer: B-small
         vixens.io/sizing.restore-config: B-nano
         vixens.io/sizing.restore-db: B-nano
         vixens.io/backup-profile: "standard"
@@ -260,7 +260,7 @@ spec:
               command:
                 - sh
                 - -c
-                - pgrep -f rclone || exit 1
+                - pgrep -f "sh -c" || exit 1
             initialDelaySeconds: 10
             periodSeconds: 30
           readinessProbe:
@@ -268,7 +268,7 @@ spec:
               command:
                 - sh
                 - -c
-                - pgrep -f rclone || exit 1
+                - pgrep -f "sh -c" || exit 1
             initialDelaySeconds: 5
             periodSeconds: 10
           startupProbe:
@@ -276,7 +276,7 @@ spec:
               command:
                 - sh
                 - -c
-                - pgrep -f rclone || exit 1
+                - pgrep -f "sh -c" || exit 1
             failureThreshold: 15
             periodSeconds: 10
       volumes:

--- a/apps/10-home/homeassistant/overlays/prod/resources-patch.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/resources-patch.yaml
@@ -11,5 +11,5 @@ spec:
       labels:
         vixens.io/sizing: B-xlarge
         vixens.io/sizing.homeassistant: B-xlarge
-        vixens.io/sizing.litestream: B-small
-        vixens.io/sizing.config-syncer: B-nano
+        vixens.io/sizing.litestream: B-medium
+        vixens.io/sizing.config-syncer: B-small


### PR DESCRIPTION
## Summary
- litestream: B-small (512Mi) -> B-medium (1Gi) to fix OOMKilled
- config-syncer: V-nano (128Mi) -> B-small (512Mi) to fix OOMKilled  
- config-syncer: fix probes to check 'sh -c' instead of 'rclone' (rclone process only runs 5s out of 65s cycle)

## Root cause
- litestream: OOMKilled (exit code 137) - 512Mi insufficient
- config-syncer: OOMKilled + probe failures - 128Mi insufficient + probe checks for intermittent process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resource sizing allocations for deployed services to optimize performance and resource utilization.
  * Modified health check mechanisms to improve service availability monitoring and ensure better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->