### PR TITLE
fix(external-dns-unifi): increase webhook container memory limits

### DIFF
--- a/apps/40-network/external-dns-unifi/values/common.yaml
+++ b/apps/40-network/external-dns-unifi/values/common.yaml
@@ -39,10 +39,10 @@ sidecars:
     resources:
       requests:
         cpu: "10m"
-        memory: "32Mi"
+        memory: "64Mi"
       limits:
         cpu: "50m"
-        memory: "64Mi"
+        memory: "128Mi"
     livenessProbe:
       tcpSocket:
         port: webhook


### PR DESCRIPTION
Increase webhook container memory limits from 64Mi/32Mi to 128Mi/64Mi to prevent OOMKilled errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated memory resource allocation for the External DNS Unifi service to optimize performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->