### PR TITLE
fix(homeassistant): increase litestream memory limit to 2Gi (SB-medium)

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: homeassistant
     vixens.io/sizing: B-large
-    vixens.io/sizing.litestream: B-medium
+    vixens.io/sizing.litestream: SB-medium
     vixens.io/sizing.config-syncer: B-small
     vixens.io/sizing.restore-config: B-nano
     vixens.io/sizing.restore-db: B-nano
@@ -27,7 +27,7 @@ spec:
       labels:
         app: homeassistant
         vixens.io/sizing: B-large
-        vixens.io/sizing.litestream: B-medium
+        vixens.io/sizing.litestream: SB-medium
         vixens.io/sizing.config-syncer: B-small
         vixens.io/sizing.restore-config: B-nano
         vixens.io/sizing.restore-db: B-nano

--- a/apps/10-home/homeassistant/overlays/prod/resources-patch.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/resources-patch.yaml
@@ -11,5 +11,5 @@ spec:
       labels:
         vixens.io/sizing: B-xlarge
         vixens.io/sizing.homeassistant: B-xlarge
-        vixens.io/sizing.litestream: B-medium
+        vixens.io/sizing.litestream: SB-medium
         vixens.io/sizing.config-syncer: B-small


### PR DESCRIPTION
Upgrade litestream sidecar from B-medium (1Gi limit) to SB-medium (2Gi limit) to resolve OOMKilled crashes during database replication.