### PR TITLE
fix(booklore): fix kustomize build and set sizing

### DIFF
--- a/apps/20-media/booklore/overlays/prod/kustomization.yaml
+++ b/apps/20-media/booklore/overlays/prod/kustomization.yaml
@@ -16,5 +16,4 @@ patches:
       - op: replace
         path: /spec/authentication/universalAuth/secretsScope/envSlug
         value: prod
-  - path: mariadb-resources-patch.yaml
-  - path: resources-patch.yaml
+


### PR DESCRIPTION
Removed empty patches causing build error and set sizing to SB-medium to fix scheduling.