### PR TITLE
fix(cluster): additional fixes for unifi-webhook and lazylibrarian

### DIFF
--- a/apps/20-media/lazylibrarian/base/deployment.yaml
+++ b/apps/20-media/lazylibrarian/base/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         app: lazylibrarian
-        vixens.io/sizing.lazylibrarian: V-small
+        vixens.io/sizing.lazylibrarian: SB-small
         vixens.io/sizing.litestream: V-nano
         vixens.io/sizing.config-syncer: V-nano
         vixens.io/sizing.fix-permissions: G-nano

--- a/apps/40-network/external-dns-unifi/values/common.yaml
+++ b/apps/40-network/external-dns-unifi/values/common.yaml
@@ -66,5 +66,6 @@ policy: sync
 sources:
   - ingress
 podLabels:
+  vixens.io/sizing-v2: "true"
   vixens.io/sizing.external-dns: G-nano
   vixens.io/sizing.unifi-webhook: SB-micro


### PR DESCRIPTION
Added missing sizing-v2 label to unifi-webhook and switched lazylibrarian to SB-small.