### PR TITLE
fix(external-dns): bind webhook to 0.0.0.0

### DIFF
--- a/apps/40-network/external-dns-unifi/values/common.yaml
+++ b/apps/40-network/external-dns-unifi/values/common.yaml
@@ -13,6 +13,7 @@ extraArgs:
 sidecars:
   - name: unifi-webhook
     image: ghcr.io/kashalls/external-dns-unifi-webhook:v0.8.2
+    args: ["--host", "0.0.0.0"]
     ports:
       - containerPort: 8888
         name: webhook


### PR DESCRIPTION
Bind unifi-webhook to 0.0.0.0 so K8s liveness probes can reach it via pod IP.