### PR TITLE
fix(external-dns): add missing RBAC for EndpointSlices

### DIFF
--- a/apps/40-network/external-dns-unifi/base/kustomization.yaml
+++ b/apps/40-network/external-dns-unifi/base/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - infisical-secret.yaml
+  - rbac-fix.yaml

--- a/apps/40-network/external-dns-unifi/base/rbac-fix.yaml
+++ b/apps/40-network/external-dns-unifi/base/rbac-fix.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns-unifi-endpointslices-fix
+rules:
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-unifi-endpointslices-fix-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns-unifi-endpointslices-fix
+subjects:
+  - kind: ServiceAccount
+    name: external-dns-unifi
+    namespace: networking


### PR DESCRIPTION
Adding a separate ClusterRole to fix forbidden endpointslices error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added missing RBAC permissions to enable the external-DNS service proper access to Kubernetes networking resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->