### PR TITLE
fix(argocd): remove duplicated docspell resource

### DIFF
--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -69,7 +69,6 @@ resources:
   - apps/cloudnative-pg.yaml
   - apps/redis-shared.yaml
   - apps/postgresql-shared.yaml
-  - apps/docspell.yaml
   - apps/changedetection.yaml
   - apps/adguard-home.yaml
   - apps/netbird.yaml


### PR DESCRIPTION
Fixes build failure on main introduced by previous merge.