### PR TITLE
fix(n8n): break ArgoCD PVC deadlock

### DIFF
--- a/apps/60-services/n8n/base/pvc.yaml
+++ b/apps/60-services/n8n/base/pvc.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: n8n-config-pvc
+  annotations:
+    argocd.argoproj.io/health-options: ignore
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
Added health-options: ignore to PVC to allow ArgoCD to proceed with deployment creation while the volume is waiting for the first consumer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration settings to adjust health monitoring behavior for persistent storage in the deployment system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->