### PR TITLE
fix(n8n): reorder sync-waves

### DIFF
--- a/apps/60-services/n8n/base/pvc.yaml
+++ b/apps/60-services/n8n/base/pvc.yaml
@@ -4,7 +4,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: n8n-config-pvc
   annotations:
-    argocd.argoproj.io/sync-wave: "11"
+    argocd.argoproj.io/sync-wave: "10"
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
PVC must be wave 10 and App wave 11 to ensure proper creation order in ArgoCD.