### PR TITLE
fix(n8n): conform to Vixens sync-wave standards

### DIFF
--- a/apps/60-services/n8n/base/pvc.yaml
+++ b/apps/60-services/n8n/base/pvc.yaml
@@ -4,7 +4,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: n8n-config-pvc
   annotations:
-    argocd.argoproj.io/sync-wave: "11"
+    argocd.argoproj.io/sync-wave: "10"
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
Aligning PVC wave with the Deployment (wave 10) to fix ArgoCD deadlock without using health ignore hacks.