### PR TITLE
fix(n8n): standardize manifests and remove manual waves

### DIFF
--- a/apps/60-services/n8n/base/pvc.yaml
+++ b/apps/60-services/n8n/base/pvc.yaml
@@ -4,7 +4,6 @@ kind: PersistentVolumeClaim
 metadata:
   name: n8n-config-pvc
   annotations:
-    argocd.argoproj.io/sync-wave: "10"
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
Aligning n8n with the rest of the cluster by removing resource-level sync-waves. Only the Application manifest will carry the wave.