### PR TITLE
fix(postgresql): provision n8n database

### DIFF
--- a/apps/04-databases/postgresql-shared/base/credentials/n8n-secret.yaml
+++ b/apps/04-databases/postgresql-shared/base/credentials/n8n-secret.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: n8n-db-credentials
+  namespace: databases
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
+  authentication:
+    universalAuth:
+      credentialsRef:
+        secretName: infisical-universal-auth
+        secretNamespace: argocd
+      secretsScope:
+        projectSlug: vixens
+        envSlug: prod
+        secretsPath: /apps/60-services/n8n
+  managedSecretReference:
+    secretName: n8n-db-credentials
+    creationPolicy: Owner
+    secretNamespace: databases

--- a/apps/04-databases/postgresql-shared/base/databases/n8n.yaml
+++ b/apps/04-databases/postgresql-shared/base/databases/n8n.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: n8n
+  namespace: databases
+spec:
+  cluster:
+    name: postgresql-shared
+  name: n8n
+  owner: n8n
+  ensure: present

--- a/apps/04-databases/postgresql-shared/base/kustomization.yaml
+++ b/apps/04-databases/postgresql-shared/base/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - credentials/netbird-postgresql-credentials.yaml
   - credentials/penpot-secret.yaml
   - credentials/vikunja-secret.yaml
+  - credentials/n8n-secret.yaml
   - databases/docspell.yaml
   - databases/scanopy.yaml
   - databases/linkwarden.yaml
@@ -27,3 +28,4 @@ resources:
   - databases/firefly-iii.yaml
   - databases/penpot.yaml
   - databases/vikunja.yaml
+  - databases/n8n.yaml


### PR DESCRIPTION
Added missing Infisical sync and database definition for n8n.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Provisioned database infrastructure for the n8n service, including credentials management and database resource configuration within the PostgreSQL cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->