### PR TITLE
fix(n8n): remove deprecated storage-class annotation

### DIFF
--- a/apps/60-services/n8n/base/pvc.yaml
+++ b/apps/60-services/n8n/base/pvc.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: n8n-config-pvc
-  annotations:
-    volume.beta.kubernetes.io/storage-class: synelia-iscsi-retain
 spec:
   volumeBindingMode: Immediate
   accessModes:


### PR DESCRIPTION
## Summary
- Remove deprecated `volume.beta.kubernetes.io/storage-class` annotation from PVC
- This annotation may override `volumeBindingMode: Immediate` in the spec

## Testing
- Verify PVC binds immediately instead of waiting for first consumer