### PR TITLE
fix(n8n): use synelia-iscsi-delete for immediate binding

### DIFF
--- a/apps/60-services/n8n/base/pvc.yaml
+++ b/apps/60-services/n8n/base/pvc.yaml
@@ -4,10 +4,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: n8n-config-pvc
 spec:
-  volumeBindingMode: Immediate
   accessModes:
     - ReadWriteOnce
-  storageClassName: synelia-iscsi-retain
+  storageClassName: synelia-iscsi-delete
   resources:
     requests:
       storage: 5Gi


### PR DESCRIPTION
## Summary
- Use `synelia-iscsi-delete` storage class instead of `synelia-iscsi-retain`
- The Retain storage class has `WaitForFirstConsumer` binding mode which prevents PVC from binding without a Pod reference

## Testing
- Verified PVC binds immediately with Delete storage class

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated storage configuration to optimize resource management and cleanup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->