### PR TITLE
fix(n8n): use synelia-iscsi-retain like other apps

### DIFF
--- a/apps/60-services/n8n/base/pvc.yaml
+++ b/apps/60-services/n8n/base/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: synelia-iscsi-delete
+  storageClassName: synelia-iscsi-retain
   resources:
     requests:
       storage: 5Gi


### PR DESCRIPTION
Revert to synelia-iscsi-retain storage class (same as all other apps in the cluster)