### PR TITLE
fix(n8n): add N8N_URL and WEBHOOK_URL env vars

### DIFF
--- a/apps/60-services/n8n/base/deployment.yaml
+++ b/apps/60-services/n8n/base/deployment.yaml
@@ -44,6 +44,10 @@ spec:
           env:
             - name: N8N_PORT
               value: "5678"
+            - name: N8N_URL
+              value: "https://n8n.truxonline.com"
+            - name: WEBHOOK_URL
+              value: "https://n8n.truxonline.com"
             - name: DB_TYPE
               value: "postgresdb"
             - name: DB_POSTGRESDB_HOST


### PR DESCRIPTION
Set N8N_URL and WEBHOOK_URL so webhooks generate correct URLs pointing to n8n.truxonline.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated n8n deployment configuration to include service URL and webhook URL environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->