### PR TITLE
fix(n8n): allow ingress from tools namespace

### DIFF
--- a/apps/60-services/n8n/base/networkpolicy.yaml
+++ b/apps/60-services/n8n/base/networkpolicy.yaml
@@ -19,6 +19,11 @@ spec:
       ports:
         - protocol: TCP
           port: 5678
+    # Allow ingress from tools (Changedetection)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: tools
   egress:
     # Allow all egress (Workflows need to call external APIs)
     - {}


### PR DESCRIPTION
Allow change-detection (tools namespace) to reach n8n webhooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network configuration to enable additional service connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->