### PR TITLE
fix(openclaw): allow ingress from n8n for webhook triggers

### DIFF
--- a/apps/60-services/openclaw/base/networkpolicy.yaml
+++ b/apps/60-services/openclaw/base/networkpolicy.yaml
@@ -24,6 +24,11 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: tools
+    # Allow ingress from n8n (webhook triggers)
+    - from:
+        - podSelector:
+            matchLabels:
+              app: n8n
   egress:
     # Allow all egress (homelab: DNS, inter-app, external APIs)
     - {}


### PR DESCRIPTION
Allow n8n (services namespace) to trigger openclaw webhooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated network policy to allow ingress traffic from n8n alongside existing trusted sources, enabling n8n services to communicate with the cluster without changing egress rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->