### PR TITLE
fix(synology-csi): upgrade node plugin to v1.2.1 (edge) in dev - evaluation

### DIFF
--- a/apps/01-storage/synology-csi/overlays/dev/kustomization.yaml
+++ b/apps/01-storage/synology-csi/overlays/dev/kustomization.yaml
@@ -2,23 +2,47 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:
-- includeTemplates: true
-  pairs:
-    cache-bust: '2'
-    vixens.lab/environment: dev
+  - includeTemplates: true
+    pairs:
+      cache-bust: '2'
+      vixens.lab/environment: dev
 namespace: synology-csi
-patches:
-- patch: "- op: replace\n  path: /parameters/igroup\n  value: \"vixens-dev-iscsi-group\"\
-    \n- op: add\n  path: /parameters/targetIps\n  value: \"192.168.111.70,192.168.111.71\""
-  target:
-    kind: StorageClass
-    name: synelia-iscsi-retain
-- patch: "- op: add\n  path: /parameters/igroup\n  value: \"vixens-dev-iscsi-group\"\
-    \n- op: add\n  path: /parameters/targetIps\n  value: \"192.168.111.70,192.168.111.71\""
-  target:
-    kind: StorageClass
-    name: synelia-iscsi-delete
-resources:
-- ../../base
 components:
-- ../../../../_shared/components/dev-hibernate
+  - ../../../../_shared/components/dev-hibernate
+patches:
+  - patch: |-
+      - op: replace
+        path: /parameters/igroup
+        value: "vixens-dev-iscsi-group"
+      - op: add
+        path: /parameters/targetIps
+        value: "192.168.111.70,192.168.111.71"
+    target:
+      kind: StorageClass
+      name: synelia-iscsi-retain
+  - patch: |-
+      - op: add
+        path: /parameters/igroup
+        value: "vixens-dev-iscsi-group"
+      - op: add
+        path: /parameters/targetIps
+        value: "192.168.111.70,192.168.111.71"
+    target:
+      kind: StorageClass
+      name: synelia-iscsi-delete
+  - patch: |-
+      apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: synology-csi-node
+      spec:
+        template:
+          spec:
+            containers:
+              - name: synology-csi-plugin
+                image: ghcr.io/zebernst/synology-csi:edge
+    target:
+      kind: DaemonSet
+      name: synology-csi-node
+resources:
+  - ../../base


### PR DESCRIPTION
## Summary

- **vixens-47cr**: Evaluate Synology CSI v1.2.1 in dev cluster before promoting to prod

## What changed

| Component | Before | After | Scope |
|-----------|--------|-------|-------|
| node (DaemonSet) | \`v1.2.0\` | \`edge\` (=v1.2.1) | **dev only** |
| controller (StatefulSet) | \`edge\` | \`edge\` | unchanged |
| prod (node) | \`v1.2.0\` | \`v1.2.0\` | **untouched** |

Also: migrates synology-csi dev overlay to use \`dev-hibernate\` component (cleanup).

## Why v1.2.1

26 commits since v1.2.0, key fixes:
- **fix #29**: Allow enabling space reclamation and FUA/Sync Cache SCSI commands for LUNs (critical iSCSI I/O fix)
- Add pod-security labels to namespace
- Note: v1.2.1 is on main branch (not yet formally tagged) — \`edge\` = commit \`6547268b\`

## Evaluation plan

- [ ] Dev cluster runs v1.2.1 for **1 week**
- [ ] Monitor: PVC mount failures, iSCSI disconnections, I/O errors
- [ ] If stable → PR to pin base images to v1.2.1 (promote to prod)
- [ ] If unstable → revert this PR

## Validation
- ✅ kustomize build dev: node on \`edge\`, controller on \`edge\`, StatefulSet \`replicas: 0\`
- ✅ kustomize build prod: node on \`v1.2.0\` (unchanged)
- ✅ yamllint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Introduced a shared development hibernation component to optimize resource usage by disabling replicas for workloads in development environments.
  * Standardized and improved configuration patch format for clearer, multi-operation edits in storage service configurations.
  * Updated storage node component configuration for better deployment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->