### PR TITLE
fix(kyverno): remove element.name from validate.message (foreach scope)

### DIFF
--- a/apps/00-infra/kyverno/base/policies/check-explicit-resources.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-explicit-resources.yaml
@@ -34,10 +34,7 @@ spec:
                 - cert-manager
                 - infisical-operator-system
       validate:
-        message: >-
-          Container '{{ element.name }}' defines explicit resources.requests without
-          a vixens.io/sizing.{{ element.name }} label. Consider migrating to the
-          sizing label system (e.g. vixens.io/sizing.{{ element.name }}: B-small).
+        message: "Container defines explicit resources.requests without a vixens.io/sizing.<container> label. Consider migrating to the sizing label system."
         foreach:
           - list: "request.object.spec.containers"
             preconditions:

--- a/apps/00-infra/kyverno/base/policies/require-resource-limits.yaml
+++ b/apps/00-infra/kyverno/base/policies/require-resource-limits.yaml
@@ -36,10 +36,7 @@ spec:
                 - cert-manager
                 - infisical-operator-system
       validate:
-        message: >-
-          Container '{{ element.name }}' has no limits declaration.
-          Add a vixens.io/sizing.{{ element.name }} label (any mode injects limits)
-          or set explicit resources.limits. See sizing-v2-mutate policy.
+        message: "Container has no limits declaration. Add a vixens.io/sizing.<container> label or explicit resources.limits."
         foreach:
           - list: "request.object.spec.containers"
             preconditions:

--- a/apps/00-infra/kyverno/base/policies/require-resource-requests.yaml
+++ b/apps/00-infra/kyverno/base/policies/require-resource-requests.yaml
@@ -37,10 +37,7 @@ spec:
                 - cert-manager
                 - infisical-operator-system
       validate:
-        message: >-
-          Container '{{ element.name }}' has no sizing declaration.
-          Add a vixens.io/sizing.{{ element.name }} label (e.g. V-small, B-medium)
-          or set explicit resources.requests. See sizing-v2-mutate policy.
+        message: "Container has no sizing declaration. Add a vixens.io/sizing.<container> label or explicit resources.requests."
         foreach:
           - list: "request.object.spec.containers"
             preconditions:


### PR DESCRIPTION
## Fix

Kyverno webhook rejects policies where `element.*` variables appear outside a `foreach` block.

`validate.message` is evaluated at the rule level (outside foreach), causing:
```
admission webhook denied: variable 'element.name' present outside of foreach at path /validate/message
```

**Changed files:**
- `require-resource-requests.yaml`: generic message (logic unchanged)
- `require-resource-limits.yaml`: generic message (logic unchanged)
- `check-explicit-resources.yaml`: generic message (logic unchanged)

The foreach preconditions, deny conditions, and all validation logic are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined Kyverno policy validation messages across resource requirement policies. Updated messages now provide clearer, more concise guidance on implementing resource requests, limits, and sizing label configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->