### PR TITLE
fix(homeassistant): configure litestream retention to prevent WAL accumulation + OOM

### DIFF
--- a/apps/10-home/homeassistant/base/litestream-config.yaml
+++ b/apps/10-home/homeassistant/base/litestream-config.yaml
@@ -10,4 +10,7 @@ data:
         replicas:
           - url: s3://$LITESTREAM_BUCKET/home-assistant_v2.db
             endpoint: $LITESTREAM_ENDPOINT
+            retention: 24h
+            retention-check-interval: 1h
+            snapshot-interval: 6h
     addr: ":9090"


### PR DESCRIPTION
## Summary

- Add `retention: 24h` + `retention-check-interval: 1h` + `snapshot-interval: 6h` to litestream config

## Root Cause

Missing `snapshot-interval` → litestream never took a snapshot → WAL segments kept indefinitely:
- 24,543 files / **134 GiB** accumulated in 4 days
- VPA correctly measured litestream needing **2.5 GB RAM** for compaction
- OOM killed at 2 GB cgroup limit → iSCSI errors → PVC remounted `emergency_ro` → HA down

## Fix

1. **MinIO purged** (exec into config-syncer): `rclone delete s3://vixens-prod-homeassistant/home-assistant_v2.db/`
2. **Config updated**: `snapshot-interval: 6h` enables WAL pruning after 24h retention

## At Steady State

~4 snapshots/day (~200 MB each) + 24h WAL = **~2-3 GB total** in MinIO vs 134 GiB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database replication configuration with new retention and snapshot settings for enhanced data persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->