### PR TITLE
fix(cert-manager+booklore): fix probe misconfigurations

### DIFF
--- a/apps/00-infra/kyverno/base/policies/mutate-cainjector-probes.yaml
+++ b/apps/00-infra/kyverno/base/policies/mutate-cainjector-probes.yaml
@@ -44,21 +44,19 @@ spec:
                 containers:
                   - name: "{{ element.name }}"
                     livenessProbe:
-                      exec:
-                        command:
-                          - sh
-                          - -c
-                          - pgrep -f cainjector || exit 1
+                      httpGet:
+                        path: /healthz
+                        port: 9402
+                        scheme: HTTP
                       initialDelaySeconds: 10
                       periodSeconds: 30
                       timeoutSeconds: 5
                       failureThreshold: 3
                     readinessProbe:
-                      exec:
-                        command:
-                          - sh
-                          - -c
-                          - pgrep -f cainjector || exit 1
+                      httpGet:
+                        path: /readyz
+                        port: 9402
+                        scheme: HTTP
                       initialDelaySeconds: 5
                       periodSeconds: 10
                       timeoutSeconds: 5

--- a/apps/20-media/booklore/base/deployment.yaml
+++ b/apps/20-media/booklore/base/deployment.yaml
@@ -149,7 +149,7 @@ spec:
             httpGet:
               path: /
               port: http
-            failureThreshold: 20
+            failureThreshold: 40
             periodSeconds: 10
             timeoutSeconds: 5
         - name: config-syncer


### PR DESCRIPTION
## Summary

### cert-manager-cainjector — distroless image breaks Kyverno-injected probe
- **Root cause**: \`mutate-cainjector-probes\` policy injects \`sh -c "pgrep -f cainjector"\` but cert-manager v1.14 uses a distroless image → no \`sh\` → probe always errors → cainjector never Ready → rolling update deadlock (new pod waits for Ready, old pod holds leader lease)
- **Fix**: Use \`httpGet /healthz\` + \`/readyz\` on port 9402 (cert-manager native health endpoints, available since v1.11)

### booklore — startup timeout on loaded nodes
- **Root cause**: Spring Boot takes ~194s to start, \`startupProbe.failureThreshold: 20\` × 10s = 200s budget → times out under load
- **Fix**: \`failureThreshold: 20 → 40\` (400s budget, 2× margin)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Upgraded health monitoring systems with more efficient detection methods to provide improved real-time service status visibility, faster problem identification, and enhanced response times to system issues.
  * Refined startup validation configuration to strengthen service initialization reliability, enhance recovery capabilities, and minimize potential disruptions during deployment and system maintenance operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->