### PR TITLE
fix(cert-manager): add --healthz-addr to cainjector to enable httpGet probes

### DIFF
--- a/apps/00-infra/cert-manager/values/common.yaml
+++ b/apps/00-infra/cert-manager/values/common.yaml
@@ -78,6 +78,10 @@ cainjector:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists
       effect: NoSchedule
+  extraArgs:
+    # Enable healthz HTTP server so Kyverno-injected httpGet probes work.
+    # cert-manager-cainjector uses a distroless image (no sh/pgrep available).
+    - --healthz-addr=:9402
   podLabels:
     vixens.io/sizing.cainjector: G-nano
   podAnnotations:

--- a/apps/00-infra/kyverno/base/policies/mutate-cainjector-probes.yaml
+++ b/apps/00-infra/kyverno/base/policies/mutate-cainjector-probes.yaml
@@ -44,21 +44,19 @@ spec:
                 containers:
                   - name: "{{ element.name }}"
                     livenessProbe:
-                      exec:
-                        command:
-                          - sh
-                          - -c
-                          - pgrep -f cainjector || exit 1
+                      httpGet:
+                        path: /healthz
+                        port: 9402
+                        scheme: HTTP
                       initialDelaySeconds: 10
                       periodSeconds: 30
                       timeoutSeconds: 5
                       failureThreshold: 3
                     readinessProbe:
-                      exec:
-                        command:
-                          - sh
-                          - -c
-                          - pgrep -f cainjector || exit 1
+                      httpGet:
+                        path: /readyz
+                        port: 9402
+                        scheme: HTTP
                       initialDelaySeconds: 5
                       periodSeconds: 10
                       timeoutSeconds: 5

--- a/apps/20-media/booklore/base/deployment.yaml
+++ b/apps/20-media/booklore/base/deployment.yaml
@@ -149,7 +149,7 @@ spec:
             httpGet:
               path: /
               port: http
-            failureThreshold: 20
+            failureThreshold: 40
             periodSeconds: 10
             timeoutSeconds: 5
         - name: config-syncer


### PR DESCRIPTION
cainjector v1.14.4 uses distroless image — no health HTTP server by default. Adding `--healthz-addr=:9402` enables the /healthz and /readyz endpoints that the Kyverno `mutate-cainjector-probes` policy injects via httpGet probe (fixed in PR #2156).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed health monitoring for cert-manager cainjector component to support minimal container images lacking shell utilities
  * Updated container health checks from process-based detection to HTTP-based probes for improved reliability and distroless image compatibility
  * Increased startup probe failure threshold to provide greater tolerance during application initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->