### PR TITLE
fix(grafana): G-medium→B-large to prevent OOM on Loki query spikes

### DIFF
--- a/apps/02-monitoring/grafana/base/values.yaml
+++ b/apps/02-monitoring/grafana/base/values.yaml
@@ -126,5 +126,5 @@ labels:
 
 # Pod sizing labels
 podLabels:
-  vixens.io/sizing.grafana: G-medium
+  vixens.io/sizing.grafana: B-large
   vixens.io/sizing.grafana-sc-dashboard: G-small


### PR DESCRIPTION
Grafana OOMKilled every ~38min (exit 137, 69 restarts). Guaranteed G-medium (512Mi req=lim) too tight for dashboard spikes. B-large = 1Gi req / 2Gi lim burstable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Grafana pod sizing to a larger allocation (label changed to B-large) to increase resource capacity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->