### PR TITLE
feat(media): migrate arr apps from LinuxServer to Hotio images

### DIFF
--- a/apps/20-media/lidarr/base/deployment.yaml
+++ b/apps/20-media/lidarr/base/deployment.yaml
@@ -90,7 +90,7 @@ spec:
               subPath: litestream.yml
       containers:
         - name: lidarr
-          image: ghcr.io/linuxserver/lidarr:version-3.1.0.4875
+          image: ghcr.io/hotio/lidarr:release
           ports:
             - containerPort: 8686 # Default Lidarr UI port
               name: http

--- a/apps/20-media/prowlarr/base/deployment.yaml
+++ b/apps/20-media/prowlarr/base/deployment.yaml
@@ -90,7 +90,7 @@ spec:
               subPath: litestream.yml
       containers:
         - name: prowlarr
-          image: ghcr.io/linuxserver/prowlarr:version-1.31.2.4975
+          image: ghcr.io/hotio/prowlarr:release
           ports:
             - containerPort: 9696 # Default Prowlarr UI port
               name: http

--- a/apps/20-media/radarr/base/deployment.yaml
+++ b/apps/20-media/radarr/base/deployment.yaml
@@ -74,7 +74,7 @@ spec:
               mountPath: /config
       containers:
         - name: radarr
-          image: ghcr.io/linuxserver/radarr:version-6.0.4.10291
+          image: ghcr.io/hotio/radarr:release
           ports:
             - containerPort: 7878 # Default Radarr UI port
               name: http

--- a/apps/20-media/sonarr/base/deployment.yaml
+++ b/apps/20-media/sonarr/base/deployment.yaml
@@ -90,7 +90,7 @@ spec:
               subPath: litestream.yml
       containers:
         - name: sonarr
-          image: ghcr.io/linuxserver/sonarr:version-4.0.16.2944
+          image: ghcr.io/hotio/sonarr:release
           ports:
             - containerPort: 8989 # Default Sonarr UI port
               name: http


### PR DESCRIPTION
## Summary

Migrate 4 media apps from deprecated LinuxServer.io images to Hotio images.

## Changes

| App | From | To |
|-----|------|----|
| radarr | `ghcr.io/linuxserver/radarr:version-6.0.4.10291` | `ghcr.io/hotio/radarr:release` |
| prowlarr | `ghcr.io/linuxserver/prowlarr:version-1.31.2.4975` | `ghcr.io/hotio/prowlarr:release` |
| sonarr | `ghcr.io/linuxserver/sonarr:version-4.0.16.2944` | `ghcr.io/hotio/sonarr:release` |
| lidarr | `ghcr.io/linuxserver/lidarr:version-3.1.0.4875` | `ghcr.io/hotio/lidarr:release` |

## Why Hotio?

- LinuxServer.io is deprecating these images
- Hotio has better user/group handling (PUID/PGID compatible)
- Smaller image sizes
- Active maintenance

## Compatibility

- PUID/PGID env vars: ✅ Compatible (Hotio uses same vars)
- Volume paths (`/config`, `/downloads`, `/movies`, `/tv`, `/music`): ✅ Unchanged
- Database configs (Litestream, InfisicalSecrets): ✅ Unchanged
- Ports: ✅ Unchanged (7878, 9696, 8989, 8686)

## Validation

- ✅ `just lint` passes
- ✅ `kustomize build` passes for all 4 apps (prod overlay)
- ✅ All resource kinds preserved (Deployment, Service, Ingress, PVC, etc.)

## Tasks

Closes: vixens-wj03 (radarr), vixens-pgwx (prowlarr), vixens-plra (sonarr+lidarr)