### PR TITLE
fix(resources): add explicit resources as fallback for sizing-v2 race condition

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -153,6 +153,13 @@ spec:
               readOnly: true
       containers:
         - name: homeassistant
+          resources:
+            requests:
+              cpu: 100m
+              memory: 1Gi
+            limits:
+              cpu: 1000m
+              memory: 2Gi
           image: ghcr.io/home-assistant/home-assistant:2026.3.2
           imagePullPolicy: Always
           ports:
@@ -189,6 +196,13 @@ spec:
             - name: config
               mountPath: /config
         - name: litestream
+          resources:
+            requests:
+              cpu: 50m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 2Gi
           image: litestream/litestream:0.5.9
           securityContext:
             runAsUser: 1000
@@ -228,6 +242,13 @@ spec:
             failureThreshold: 15
             periodSeconds: 10
         - name: config-syncer
+          resources:
+            requests:
+              cpu: 25m
+              memory: 256Mi
+            limits:
+              cpu: 250m
+              memory: 512Mi
           image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000

--- a/apps/10-home/mealie/base/deployment.yaml
+++ b/apps/10-home/mealie/base/deployment.yaml
@@ -92,6 +92,13 @@ spec:
       priorityClassName: vixens-low
       containers:
         - name: mealie
+          resources:
+            requests:
+              cpu: 50m
+              memory: 512Mi
+            limits:
+              cpu: 200m
+              memory: 2Gi
           image: ghcr.io/mealie-recipes/mealie:v3.12.0
           ports:
             - containerPort: 9000
@@ -126,6 +133,13 @@ spec:
             - name: data
               mountPath: /app/data
         - name: litestream
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: litestream/litestream:0.5.9
           securityContext:
             runAsUser: 1000
@@ -157,6 +171,13 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
         - name: config-syncer
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000

--- a/apps/20-media/amule/base/deployment.yaml
+++ b/apps/20-media/amule/base/deployment.yaml
@@ -33,6 +33,13 @@ spec:
       priorityClassName: vixens-low
       containers:
         - name: amule
+          resources:
+            requests:
+              cpu: 25m
+              memory: 256Mi
+            limits:
+              cpu: 100m
+              memory: 1Gi
           image: tchabaud/amule@sha256:66351396337f50b40613222c5c47adfbc8685eb631b38e73f217358f54182d64
           ports:
             - containerPort: 4711

--- a/apps/20-media/hydrus-client/base/deployment.yaml
+++ b/apps/20-media/hydrus-client/base/deployment.yaml
@@ -176,6 +176,13 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: hydrus-client
+          resources:
+            requests:
+              cpu: 100m
+              memory: 1Gi
+            limits:
+              cpu: 400m
+              memory: 4Gi
           image: ghcr.io/hydrusnetwork/hydrus:v663
           ports:
             - containerPort: 5800
@@ -204,6 +211,13 @@ spec:
             - name: client-files
               mountPath: /opt/hydrus/db/client_files
         - name: litestream
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: litestream/litestream:0.5.9
           securityContext:
             runAsUser: 1000

--- a/apps/20-media/jellyfin/base/deployment.yaml
+++ b/apps/20-media/jellyfin/base/deployment.yaml
@@ -30,6 +30,13 @@ spec:
           effect: NoSchedule
       containers:
         - name: jellyfin
+          resources:
+            requests:
+              cpu: 50m
+              memory: 512Mi
+            limits:
+              cpu: 200m
+              memory: 2Gi
           image: jellyfin/jellyfin:10.11.6
           ports:
             - containerPort: 8096

--- a/apps/20-media/jellyseerr/base/deployment.yaml
+++ b/apps/20-media/jellyseerr/base/deployment.yaml
@@ -29,6 +29,13 @@ spec:
       priorityClassName: vixens-medium
       containers:
         - name: jellyseerr
+          resources:
+            requests:
+              cpu: 50m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
           image: fallenbagel/jellyseerr:2.7
           ports:
             - containerPort: 5055

--- a/apps/20-media/lidarr/base/deployment.yaml
+++ b/apps/20-media/lidarr/base/deployment.yaml
@@ -90,6 +90,13 @@ spec:
               subPath: litestream.yml
       containers:
         - name: lidarr
+          resources:
+            requests:
+              cpu: 50m
+              memory: 512Mi
+            limits:
+              cpu: 200m
+              memory: 2Gi
           image: ghcr.io/hotio/lidarr:release
           ports:
             - containerPort: 8686 # Default Lidarr UI port
@@ -142,6 +149,13 @@ spec:
               mountPath: /music
               subPath: music
         - name: litestream
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: litestream/litestream:0.5.9
           securityContext:
             runAsUser: 1000
@@ -163,6 +177,13 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: config-syncer
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000

--- a/apps/20-media/music-assistant/base/deployment.yaml
+++ b/apps/20-media/music-assistant/base/deployment.yaml
@@ -32,6 +32,13 @@ spec:
       priorityClassName: vixens-medium
       containers:
         - name: music-assistant
+          resources:
+            requests:
+              cpu: 50m
+              memory: 512Mi
+            limits:
+              cpu: 200m
+              memory: 2Gi
           image: ghcr.io/music-assistant/server:2.8.0b9
           ports:
             - containerPort: 8095

--- a/apps/20-media/mylar/base/deployment.yaml
+++ b/apps/20-media/mylar/base/deployment.yaml
@@ -90,6 +90,13 @@ spec:
               subPath: litestream.yml
       containers:
         - name: mylar
+          resources:
+            requests:
+              cpu: 50m
+              memory: 512Mi
+            limits:
+              cpu: 200m
+              memory: 2Gi
           image: ghcr.io/linuxserver/mylar3:version-v0.8.1
           ports:
             - containerPort: 8090 # Default Mylar UI port
@@ -137,6 +144,13 @@ spec:
               mountPath: /comics
               subPath: Comics
         - name: litestream
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: litestream/litestream:0.5.9
           securityContext:
             runAsUser: 1000
@@ -158,6 +172,13 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: config-syncer
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000

--- a/apps/20-media/prowlarr/base/deployment.yaml
+++ b/apps/20-media/prowlarr/base/deployment.yaml
@@ -90,6 +90,13 @@ spec:
               subPath: litestream.yml
       containers:
         - name: prowlarr
+          resources:
+            requests:
+              cpu: 50m
+              memory: 512Mi
+            limits:
+              cpu: 200m
+              memory: 2Gi
           image: ghcr.io/hotio/prowlarr:release
           ports:
             - containerPort: 9696 # Default Prowlarr UI port
@@ -137,6 +144,13 @@ spec:
             - name: config
               mountPath: /config
         - name: litestream
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: litestream/litestream:0.5.9
           securityContext:
             runAsUser: 1000
@@ -158,6 +172,13 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: config-syncer
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000

--- a/apps/20-media/pyload/base/deployment.yaml
+++ b/apps/20-media/pyload/base/deployment.yaml
@@ -32,6 +32,13 @@ spec:
       priorityClassName: vixens-low
       containers:
         - name: pyload
+          resources:
+            requests:
+              cpu: 25m
+              memory: 256Mi
+            limits:
+              cpu: 100m
+              memory: 1Gi
           image: lscr.io/linuxserver/pyload-ng:0.5.0
           ports:
             - containerPort: 8000

--- a/apps/20-media/qbittorrent/base/deployment.yaml
+++ b/apps/20-media/qbittorrent/base/deployment.yaml
@@ -33,6 +33,13 @@ spec:
       priorityClassName: vixens-medium
       containers:
         - name: qbittorrent
+          resources:
+            requests:
+              cpu: 50m
+              memory: 512Mi
+            limits:
+              cpu: 200m
+              memory: 2Gi
           image: lscr.io/linuxserver/qbittorrent:5.1.4
           ports:
             - containerPort: 8080

--- a/apps/20-media/radarr/base/deployment.yaml
+++ b/apps/20-media/radarr/base/deployment.yaml
@@ -74,6 +74,13 @@ spec:
               mountPath: /config
       containers:
         - name: radarr
+          resources:
+            requests:
+              cpu: 50m
+              memory: 512Mi
+            limits:
+              cpu: 200m
+              memory: 2Gi
           image: ghcr.io/hotio/radarr:release
           ports:
             - containerPort: 7878 # Default Radarr UI port
@@ -126,6 +133,13 @@ spec:
               mountPath: /movies
               subPath: movies
         - name: litestream
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: litestream/litestream:0.5.9
           securityContext:
             runAsUser: 1000
@@ -165,6 +179,13 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: config-syncer
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000

--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -72,6 +72,13 @@ spec:
               mountPath: /config
       containers:
         - name: sabnzbd
+          resources:
+            requests:
+              cpu: 50m
+              memory: 512Mi
+            limits:
+              cpu: 200m
+              memory: 2Gi
           image: ghcr.io/linuxserver/sabnzbd:version-4.4.1
           ports:
             - containerPort: 8080 # Default Sabnzbd UI port
@@ -113,6 +120,13 @@ spec:
             - name: downloads
               mountPath: /downloads
         - name: litestream
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: litestream/litestream:0.5.9
           securityContext:
             runAsUser: 1000
@@ -143,6 +157,13 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
         - name: config-syncer
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000

--- a/apps/20-media/sonarr/base/deployment.yaml
+++ b/apps/20-media/sonarr/base/deployment.yaml
@@ -90,6 +90,13 @@ spec:
               subPath: litestream.yml
       containers:
         - name: sonarr
+          resources:
+            requests:
+              cpu: 50m
+              memory: 512Mi
+            limits:
+              cpu: 200m
+              memory: 2Gi
           image: ghcr.io/hotio/sonarr:release
           ports:
             - containerPort: 8989 # Default Sonarr UI port
@@ -142,6 +149,13 @@ spec:
               mountPath: /tv
               subPath: TV Show
         - name: litestream
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: litestream/litestream:0.5.9
           securityContext:
             runAsUser: 1000
@@ -173,6 +187,13 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: config-syncer
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000

--- a/apps/20-media/whisparr/base/deployment.yaml
+++ b/apps/20-media/whisparr/base/deployment.yaml
@@ -73,6 +73,13 @@ spec:
               mountPath: /config
       containers:
         - name: whisparr
+          resources:
+            requests:
+              cpu: 50m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
           image: ghcr.io/hotio/whisparr:nightly
           ports:
             - containerPort: 6969 # Default Whisparr UI port
@@ -124,6 +131,13 @@ spec:
               mountPath: /media
               subPath: xxx
         - name: litestream
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: litestream/litestream:0.5.9
           securityContext:
             runAsUser: 1000
@@ -154,6 +168,13 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
         - name: config-syncer
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000

--- a/apps/60-services/firefly-iii-importer/base/deployment.yaml
+++ b/apps/60-services/firefly-iii-importer/base/deployment.yaml
@@ -30,6 +30,13 @@ spec:
           effect: NoSchedule
       containers:
         - name: importer
+          resources:
+            requests:
+              cpu: 25m
+              memory: 256Mi
+            limits:
+              cpu: 100m
+              memory: 1Gi
           image: fireflyiii/data-importer:version-2.1.1
           ports:
             - containerPort: 8080

--- a/apps/60-services/gluetun/base/deployment.yaml
+++ b/apps/60-services/gluetun/base/deployment.yaml
@@ -29,6 +29,13 @@ spec:
       priorityClassName: vixens-medium
       containers:
         - name: gluetun
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 50m
+              memory: 128Mi
           image: ghcr.io/qdm12/gluetun:v3.41.1
           securityContext:
             capabilities:

--- a/apps/60-services/n8n/base/deployment.yaml
+++ b/apps/60-services/n8n/base/deployment.yaml
@@ -32,6 +32,13 @@ spec:
           effect: NoSchedule
       containers:
         - name: n8n
+          resources:
+            requests:
+              cpu: 50m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
           image: docker.n8n.io/n8nio/n8n:latest
           securityContext:
             allowPrivilegeEscalation: false

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -257,6 +257,13 @@ spec:
               chown -R 1000:1000 /data/node_modules /data/gemini-cli 2>/dev/null || true
       containers:
         - name: openclaw
+          resources:
+            requests:
+              cpu: 200m
+              memory: 2Gi
+            limits:
+              cpu: 2000m
+              memory: 8Gi
           image: ghcr.io/openclaw/openclaw:2026.3.12
           imagePullPolicy: Always
           command:
@@ -327,6 +334,13 @@ spec:
             - name: data
               mountPath: /data
         - name: data-syncer
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000

--- a/apps/60-services/vaultwarden/base/deployment.yaml
+++ b/apps/60-services/vaultwarden/base/deployment.yaml
@@ -69,6 +69,13 @@ spec:
               mountPath: /data
       containers:
         - name: vaultwarden
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: vaultwarden/server:1.35.4
           ports:
             - containerPort: 80
@@ -107,6 +114,13 @@ spec:
             - name: data
               mountPath: /data
         - name: litestream
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: litestream/litestream:0.5.9
           securityContext:
             runAsUser: 1000
@@ -138,6 +152,13 @@ spec:
               mountPath: /etc/litestream.yml
               subPath: litestream.yml
         - name: config-syncer
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000

--- a/apps/70-tools/changedetection/base/deployment.yaml
+++ b/apps/70-tools/changedetection/base/deployment.yaml
@@ -58,6 +58,13 @@ spec:
       priorityClassName: vixens-low
       containers:
         - name: changedetection
+          resources:
+            requests:
+              cpu: 25m
+              memory: 256Mi
+            limits:
+              cpu: 100m
+              memory: 1Gi
           image: ghcr.io/dgtlmoon/changedetection.io:0.54.5
           ports:
             - containerPort: 5000
@@ -94,6 +101,13 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
         - name: browserless
+          resources:
+            requests:
+              cpu: 50m
+              memory: 512Mi
+            limits:
+              cpu: 200m
+              memory: 2Gi
           image: browserless/chrome:1.61.1-puppeteer-16.2.0
           ports:
             - containerPort: 3000
@@ -126,6 +140,13 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
         - name: config-syncer
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: rclone/rclone:1.73
           command:
             - sh

--- a/apps/70-tools/headlamp/base/deployment.yaml
+++ b/apps/70-tools/headlamp/base/deployment.yaml
@@ -27,6 +27,13 @@ spec:
       priorityClassName: vixens-medium
       containers:
         - name: headlamp
+          resources:
+            requests:
+              cpu: 25m
+              memory: 256Mi
+            limits:
+              cpu: 100m
+              memory: 1Gi
           image: ghcr.io/headlamp-k8s/headlamp:v0.40.1
           imagePullPolicy: IfNotPresent
           ports:

--- a/apps/70-tools/homepage/base/deployment.yaml
+++ b/apps/70-tools/homepage/base/deployment.yaml
@@ -53,6 +53,13 @@ spec:
       priorityClassName: vixens-low
       containers:
         - name: homepage
+          resources:
+            requests:
+              cpu: 25m
+              memory: 256Mi
+            limits:
+              cpu: 100m
+              memory: 1Gi
           image: ghcr.io/gethomepage/homepage:v1.11
           imagePullPolicy: IfNotPresent
           ports:

--- a/apps/70-tools/linkwarden/base/deployment.yaml
+++ b/apps/70-tools/linkwarden/base/deployment.yaml
@@ -29,6 +29,13 @@ spec:
       priorityClassName: vixens-low
       containers:
         - name: linkwarden
+          resources:
+            requests:
+              cpu: 50m
+              memory: 512Mi
+            limits:
+              cpu: 200m
+              memory: 2Gi
           image: ghcr.io/linkwarden/linkwarden:v2.13.5
           imagePullPolicy: IfNotPresent
           ports:

--- a/apps/70-tools/netbox/base/deployment.yaml
+++ b/apps/70-tools/netbox/base/deployment.yaml
@@ -29,6 +29,13 @@ spec:
       priorityClassName: vixens-medium
       containers:
         - name: netbox
+          resources:
+            requests:
+              cpu: 50m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
           image: netboxcommunity/netbox:v4.5.4 # Pinned image version
           ports:
             - name: http

--- a/apps/70-tools/nocodb/base/deployment.yaml
+++ b/apps/70-tools/nocodb/base/deployment.yaml
@@ -31,6 +31,13 @@ spec:
           effect: NoSchedule
       containers:
         - name: nocodb
+          resources:
+            requests:
+              cpu: 25m
+              memory: 256Mi
+            limits:
+              cpu: 100m
+              memory: 1Gi
           image: nocodb/nocodb:0.301.3
           imagePullPolicy: IfNotPresent
           ports:

--- a/apps/99-test/whoami/base/deployment.yaml
+++ b/apps/99-test/whoami/base/deployment.yaml
@@ -29,6 +29,13 @@ spec:
           effect: NoSchedule
       containers:
         - name: whoami
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: traefik/whoami:v1.11.0
           ports:
             - name: http

--- a/apps/template-app/base/deployment.yaml
+++ b/apps/template-app/base/deployment.yaml
@@ -88,6 +88,13 @@ spec:
               subPath: litestream.yml
       containers:
         - name: template-app
+          resources:
+            requests:
+              cpu: 50m
+              memory: 512Mi
+            limits:
+              cpu: 200m
+              memory: 2Gi
           image: nginx:stable-alpine # Placeholder
           ports:
             - containerPort: 80
@@ -105,6 +112,13 @@ spec:
               mountPath: /config
         # 3. Optionnel: Sidecar Litestream
         - name: litestream
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: litestream/litestream:0.5.9
           securityContext:
             runAsUser: 1000
@@ -127,6 +141,13 @@ spec:
               subPath: litestream.yml
         # 4. Optionnel: Sidecar Config-Syncer
         - name: config-syncer
+          resources:
+            requests:
+              cpu: 5m
+              memory: 64Mi
+            limits:
+              cpu: 20m
+              memory: 256Mi
           image: rclone/rclone:1.73
           securityContext:
             runAsUser: 1000


### PR DESCRIPTION
## Summary

- Adds hardcoded `resources:` blocks to 29 deployment files that had `vixens.io/sizing.*` labels but no explicit resources
- Implements defense-in-depth: apps now have fallback resources even if Kyverno sizing-v2-mutate policy is not ready during bootstrap
- All resource values match the sizing-v2-mutate Kyverno policy exactly (same requests/limits per tier)

## Background

Incident 2026-03-09: Pods created before Kyverno is ready get default 128Mi with no CPU limit. The sizing labels alone are insufficient during cluster bootstrap or Kyverno restarts.

## Changes

- **29 deployment files** updated across: 10-home, 20-media, 60-services, 70-tools, 99-test, template-app
- Init containers with restore/fix patterns are intentionally skipped (short-lived, not critical)
- Main containers and sidecars (litestream, config-syncer, data-syncer) all get explicit resources

## Validation

- ✅ yamllint passes for all 29 files
- ✅ kustomize build passes for all apps (prod overlays)
- ✅ just lint passes

Closes: vixens-a42q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added resource constraints (CPU and memory requests and limits) across multiple application deployments for enhanced cluster stability and resource allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->