### PR TITLE
fix(netvisor): bypass Kyverno securityContext mutation for privileged daemon

### DIFF
--- a/apps/40-network/netvisor/base/daemon-daemonset.yaml
+++ b/apps/40-network/netvisor/base/daemon-daemonset.yaml
@@ -14,6 +14,7 @@ spec:
       annotations:
         vixens.io/fast-start: "true"
         vixens.io/service-binding: "false"
+        vixens.io/explicitly-allow-root: "true"
       labels:
         app: netvisor-daemon
         vixens.io/sizing.daemon: G-nano


### PR DESCRIPTION
netvisor-daemon needs `privileged: true` (packet capture). Kyverno `mutate-security-context` injects `allowPrivilegeEscalation: false` which is invalid with privileged. Adds bypass annotation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes DaemonSet configuration with a new annotation for runtime permission management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->