### PR TITLE
feat: migrate Jellyseerr→Seerr v3.1.0 + fix maturity-controller TTL (vixens-90u4, vixens-27f)

### DIFF
--- a/apps/00-infra/maturity-controller/base/cronjob.yaml
+++ b/apps/00-infra/maturity-controller/base/cronjob.yaml
@@ -7,8 +7,11 @@ metadata:
 spec:
   schedule: "*/15 * * * *"
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 3600
       template:
         spec:
           serviceAccountName: maturity-controller

--- a/apps/20-media/jellyseerr/base/deployment.yaml
+++ b/apps/20-media/jellyseerr/base/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             limits:
               cpu: 500m
               memory: 1Gi
-          image: fallenbagel/jellyseerr:2.7
+          image: ghcr.io/seerr-team/seerr:v3.1.0
           ports:
             - containerPort: 5055
               name: http


### PR DESCRIPTION
## Summary

### feat(90u4): Jellyseerr → Seerr v3.1.0
- `fallenbagel/jellyseerr:2.7` → `ghcr.io/seerr-team/seerr:v3.1.0`
- Jellyseerr/Overseerr merged into Seerr (Feb 2026) — development stopped on original fork
- **Drop-in replacement**: same port 5055, same PVC mount `/app/config`, same env vars
- Auto-migrates SQLite DB + config on first boot via built-in migration

### fix(27f): maturity-controller CronJob TTL
- `ttlSecondsAfterFinished: 3600` — auto-deletes jobs after 1h
- `successfulJobsHistoryLimit: 3` / `failedJobsHistoryLimit: 1`
- Other CronJobs are covered by Kyverno `add-ttl-jobs` policy; maturity-controller is in `kyverno` namespace which is excluded from the mutation

Also cleaned up stale old jobs (>7 days) manually: firefly-cron, descheduler, renovate, scan-vulnerability, maturity-controller.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Updates
* Upgraded jellyseerr application to version 3.1.0, bringing latest improvements to the media management system
* Optimized infrastructure job retention and cleanup settings for improved backend efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->