### PR TITLE
fix(prod): jellyseerr fsGroupChangePolicy + nocodb startup probe

### DIFF
--- a/apps/20-media/jellyseerr/base/deployment.yaml
+++ b/apps/20-media/jellyseerr/base/deployment.yaml
@@ -77,4 +77,4 @@ spec:
             claimName: jellyseerr-config-pvc
       securityContext:
         fsGroup: 1000
-        fsGroupChangePolicy: OnRootMismatch
+        fsGroupChangePolicy: Always

--- a/apps/70-tools/nocodb/base/deployment.yaml
+++ b/apps/70-tools/nocodb/base/deployment.yaml
@@ -90,7 +90,7 @@ spec:
             httpGet:
               path: /api/v1/health
               port: http
-            failureThreshold: 15
+            failureThreshold: 30
             periodSeconds: 10
             timeoutSeconds: 5
       volumes:


### PR DESCRIPTION
## Summary
- **jellyseerr**: `fsGroupChangePolicy: OnRootMismatch → Always` — force rechown of PVC after Seerr image migration (EACCES on /app/config/logs/)
- **nocodb**: startup `failureThreshold: 15 → 30` (300s window) — 0.301.4 startup is slower than probe allows

Both apps currently in CrashLoopBackOff in prod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Jellyseerr deployment security configuration
  * Enhanced NocoDB startup resilience by adjusting health check parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->