### PR TITLE
refactor(kustomize): move shared components from overlays to app base/ (7kh4 Part B)

### DIFF
--- a/apps/00-infra/argocd/base/kustomization.yaml
+++ b/apps/00-infra/argocd/base/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - argocd-crds.yaml
   - argocd-install.yaml
   - servicemonitor.yaml
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/00-infra/argocd/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/argocd/overlays/dev/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - ingress.yaml
 
 components:
-  - ../../../../_shared/components/revision-history-limit
 
 patches:
   - path: patches/repo-server-resources.yaml

--- a/apps/00-infra/argocd/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/argocd/overlays/prod/kustomization.yaml
@@ -254,4 +254,3 @@ patches:
     target:
       kind: StatefulSet
 components:
-  - ../../../../_shared/components/revision-history-limit

--- a/apps/00-infra/cilium-lb/base/kustomization.yaml
+++ b/apps/00-infra/cilium-lb/base/kustomization.yaml
@@ -10,3 +10,5 @@ commonLabels:
 resources:
   - ippool.yaml
   - l2policy.yaml
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/00-infra/cilium-lb/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/cilium-lb/overlays/dev/kustomization.yaml
@@ -2,7 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/revision-history-limit
 kind: Kustomization
 resources:
 - ippool.yaml

--- a/apps/00-infra/cilium-lb/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/kustomization.yaml
@@ -6,6 +6,5 @@ resources:
   - l2policy.yaml
 
 components:
-  - ../../../../_shared/components/revision-history-limit
 
 patches:

--- a/apps/00-infra/reloader/base/kustomization.yaml
+++ b/apps/00-infra/reloader/base/kustomization.yaml
@@ -27,3 +27,5 @@ patches:
               vixens.io/backup-profile: "relaxed"
           spec:
             priorityClassName: vixens-high
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/00-infra/reloader/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/reloader/overlays/dev/kustomization.yaml
@@ -2,7 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/revision-history-limit
 kind: Kustomization
 resources:
 - ../../base

--- a/apps/00-infra/reloader/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/reloader/overlays/prod/kustomization.yaml
@@ -7,6 +7,5 @@ resources:
 components:
   - ../../../../_shared/components/sync-wave/wave-3
   - ../../../../_shared/components/goldilocks/enabled
-  - ../../../../_shared/components/revision-history-limit
 
 patches:

--- a/apps/00-infra/traefik-dashboard/base/kustomization.yaml
+++ b/apps/00-infra/traefik-dashboard/base/kustomization.yaml
@@ -4,3 +4,5 @@ kind: Kustomization
 resources:
   - middleware.yaml
   - service.yaml
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/00-infra/traefik-dashboard/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/traefik-dashboard/overlays/dev/kustomization.yaml
@@ -2,7 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/revision-history-limit
 kind: Kustomization
 resources:
 - ../../base

--- a/apps/00-infra/traefik-dashboard/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/traefik-dashboard/overlays/prod/kustomization.yaml
@@ -7,6 +7,5 @@ resources:
   - ingressroute.yaml
 
 components:
-  - ../../../../_shared/components/revision-history-limit
 
 patches:

--- a/apps/00-infra/vpa/base/kustomization.yaml
+++ b/apps/00-infra/vpa/base/kustomization.yaml
@@ -46,3 +46,5 @@ patches:
     target:
       kind: Deployment
       name: vpa-vertical-pod-autoscaler-updater
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/00-infra/vpa/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/vpa/overlays/dev/kustomization.yaml
@@ -2,7 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/revision-history-limit
 kind: Kustomization
 patches:
 - path: resources-patch.yaml

--- a/apps/00-infra/vpa/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/vpa/overlays/prod/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
 components:
   - ../../../../_shared/components/sync-wave/wave-4
   - ../../../../_shared/components/goldilocks/enabled
-  - ../../../../_shared/components/revision-history-limit
 
 patches:
   - path: resources-patch.yaml

--- a/apps/01-storage/nfs-storage/base/kustomization.yaml
+++ b/apps/01-storage/nfs-storage/base/kustomization.yaml
@@ -10,3 +10,5 @@ commonLabels:
 
 resources:
   - namespace.yaml
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/01-storage/nfs-storage/overlays/dev/kustomization.yaml
+++ b/apps/01-storage/nfs-storage/overlays/dev/kustomization.yaml
@@ -2,7 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/revision-history-limit
 kind: Kustomization
 namespace: nfs-storage
 resources:

--- a/apps/01-storage/nfs-storage/overlays/prod/kustomization.yaml
+++ b/apps/01-storage/nfs-storage/overlays/prod/kustomization.yaml
@@ -6,6 +6,5 @@ resources:
   - ../../base
 
 components:
-  - ../../../../_shared/components/revision-history-limit
 
 patches:

--- a/apps/03-security/trivy/base/kustomization.yaml
+++ b/apps/03-security/trivy/base/kustomization.yaml
@@ -20,3 +20,5 @@ patches:
     target:
       kind: Deployment
       name: trivy-trivy-operator
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/03-security/trivy/overlays/dev/kustomization.yaml
+++ b/apps/03-security/trivy/overlays/dev/kustomization.yaml
@@ -2,7 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/revision-history-limit
 kind: Kustomization
 patches:
 - path: resources-patch.yaml

--- a/apps/03-security/trivy/overlays/prod/kustomization.yaml
+++ b/apps/03-security/trivy/overlays/prod/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
 components:
   - ../../../../_shared/components/sync-wave/wave-3
   - ../../../../_shared/components/goldilocks/enabled
-  - ../../../../_shared/components/revision-history-limit
 
 patches:
   - path: resources-patch.yaml

--- a/apps/10-home/mosquitto/base/kustomization.yaml
+++ b/apps/10-home/mosquitto/base/kustomization.yaml
@@ -15,3 +15,5 @@ labels:
       app.kubernetes.io/version: 2.0.20
       vixens.lab/managed-by: argocd
     includeSelectors: true
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/10-home/mosquitto/overlays/dev/kustomization.yaml
+++ b/apps/10-home/mosquitto/overlays/dev/kustomization.yaml
@@ -2,7 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/revision-history-limit
 kind: Kustomization
 namespace: mosquitto
 resources:

--- a/apps/10-home/mosquitto/overlays/prod/kustomization.yaml
+++ b/apps/10-home/mosquitto/overlays/prod/kustomization.yaml
@@ -10,6 +10,5 @@ resources:
 components:
   - ../../../../_shared/components/sync-wave/wave-6
   - ../../../../_shared/components/goldilocks/enabled
-  - ../../../../_shared/components/revision-history-limit
 
 patches:

--- a/apps/20-media/birdnet-go/base/kustomization.yaml
+++ b/apps/20-media/birdnet-go/base/kustomization.yaml
@@ -11,3 +11,5 @@ resources:
   - deployment.yaml
   - service.yaml
   - pdb.yaml
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/20-media/birdnet-go/overlays/dev/kustomization.yaml
+++ b/apps/20-media/birdnet-go/overlays/dev/kustomization.yaml
@@ -2,7 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/revision-history-limit
 kind: Kustomization
 namespace: birdnet-go
 resources:

--- a/apps/20-media/birdnet-go/overlays/prod/kustomization.yaml
+++ b/apps/20-media/birdnet-go/overlays/prod/kustomization.yaml
@@ -9,7 +9,6 @@ resources:
 components:
   - ../../../../_shared/components/sync-wave/wave-8
   - ../../../../_shared/components/goldilocks/enabled
-  - ../../../../_shared/components/revision-history-limit
   - ../../../../_shared/components/poddisruptionbudget/1
 
 patches:

--- a/apps/20-media/hydrus-client/base/kustomization.yaml
+++ b/apps/20-media/hydrus-client/base/kustomization.yaml
@@ -13,3 +13,5 @@ resources:
   - infisical-secret.yaml
   - litestream-config.yaml
   - servicemonitor.yaml
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/20-media/hydrus-client/overlays/dev/kustomization.yaml
+++ b/apps/20-media/hydrus-client/overlays/dev/kustomization.yaml
@@ -2,7 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/revision-history-limit
 kind: Kustomization
 namespace: media
 resources:

--- a/apps/20-media/hydrus-client/overlays/prod/kustomization.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/kustomization.yaml
@@ -16,7 +16,6 @@ resources:
 components:
   - ../../../../_shared/components/sync-wave/wave-11
   - ../../../../_shared/components/goldilocks/enabled
-  - ../../../../_shared/components/revision-history-limit
   - ../../../../_shared/components/base
   - ../../../../_shared/components/metrics
   - ../../../../_shared/components/poddisruptionbudget/0

--- a/apps/20-media/jellyfin/base/kustomization.yaml
+++ b/apps/20-media/jellyfin/base/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
   - service.yaml
   - pvc.yaml
   - networkpolicy.yaml
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/20-media/jellyfin/overlays/dev/kustomization.yaml
+++ b/apps/20-media/jellyfin/overlays/dev/kustomization.yaml
@@ -2,7 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/revision-history-limit
 kind: Kustomization
 resources:
 - ../../base

--- a/apps/20-media/jellyfin/overlays/prod/kustomization.yaml
+++ b/apps/20-media/jellyfin/overlays/prod/kustomization.yaml
@@ -9,6 +9,5 @@ components:
   - ../../../../_shared/components/sync-wave/wave-15
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics
-  - ../../../../_shared/components/revision-history-limit
 
 patches:

--- a/apps/20-media/jellyseerr/base/kustomization.yaml
+++ b/apps/20-media/jellyseerr/base/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
   - service.yaml
   - pvc.yaml
   - networkpolicy.yaml
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/20-media/jellyseerr/overlays/dev/kustomization.yaml
+++ b/apps/20-media/jellyseerr/overlays/dev/kustomization.yaml
@@ -2,7 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/revision-history-limit
 kind: Kustomization
 resources:
 - ../../base

--- a/apps/20-media/jellyseerr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/jellyseerr/overlays/prod/kustomization.yaml
@@ -9,6 +9,5 @@ components:
   - ../../../../_shared/components/sync-wave/wave-15
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics
-  - ../../../../_shared/components/revision-history-limit
 
 patches:

--- a/apps/20-media/lazylibrarian/base/kustomization.yaml
+++ b/apps/20-media/lazylibrarian/base/kustomization.yaml
@@ -10,3 +10,5 @@ resources:
   - litestream-config.yaml
   - servicemonitor.yaml
   - networkpolicy.yaml
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/20-media/lazylibrarian/overlays/dev/kustomization.yaml
+++ b/apps/20-media/lazylibrarian/overlays/dev/kustomization.yaml
@@ -2,7 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/revision-history-limit
 kind: Kustomization
 resources:
 - ../../base

--- a/apps/20-media/lazylibrarian/overlays/prod/kustomization.yaml
+++ b/apps/20-media/lazylibrarian/overlays/prod/kustomization.yaml
@@ -9,6 +9,5 @@ components:
   - ../../../../_shared/components/infisical/env-prod
   - ../../../../_shared/components/sync-wave/wave-10
   - ../../../../_shared/components/goldilocks/enabled
-  - ../../../../_shared/components/revision-history-limit
 
 patches:

--- a/apps/20-media/music-assistant/base/kustomization.yaml
+++ b/apps/20-media/music-assistant/base/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
   - pvc.yaml
   - ingressroute-slimproto.yaml
   - networkpolicy.yaml
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/20-media/music-assistant/overlays/dev/kustomization.yaml
+++ b/apps/20-media/music-assistant/overlays/dev/kustomization.yaml
@@ -2,7 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/revision-history-limit
 kind: Kustomization
 resources:
 - ../../base

--- a/apps/20-media/music-assistant/overlays/prod/kustomization.yaml
+++ b/apps/20-media/music-assistant/overlays/prod/kustomization.yaml
@@ -9,7 +9,6 @@ components:
   - ../../../../_shared/components/sync-wave/wave-11
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics
-  - ../../../../_shared/components/revision-history-limit
 
 patches:
   - target:

--- a/apps/40-network/contacts/base/kustomization.yaml
+++ b/apps/40-network/contacts/base/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - namespace.yaml
   - service.yaml
   - endpoints.yaml
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/40-network/contacts/overlays/dev/kustomization.yaml
+++ b/apps/40-network/contacts/overlays/dev/kustomization.yaml
@@ -2,7 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/revision-history-limit
 kind: Kustomization
 namespace: contacts
 resources:

--- a/apps/40-network/contacts/overlays/prod/kustomization.yaml
+++ b/apps/40-network/contacts/overlays/prod/kustomization.yaml
@@ -6,6 +6,5 @@ resources:
   - ingress.yaml
 
 components:
-  - ../../../../_shared/components/revision-history-limit
 
 patches:

--- a/apps/40-network/mail-gateway/base/kustomization.yaml
+++ b/apps/40-network/mail-gateway/base/kustomization.yaml
@@ -15,3 +15,5 @@ resources:
   - service.yaml
   - endpoints.yaml
   - middleware.yaml
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/40-network/mail-gateway/overlays/dev/kustomization.yaml
+++ b/apps/40-network/mail-gateway/overlays/dev/kustomization.yaml
@@ -4,7 +4,6 @@ bases:
 - ../../base
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/revision-history-limit
 kind: Kustomization
 namespace: mail-gateway
 resources:

--- a/apps/40-network/mail-gateway/overlays/prod/kustomization.yaml
+++ b/apps/40-network/mail-gateway/overlays/prod/kustomization.yaml
@@ -7,6 +7,5 @@ resources:
   - ingress.yaml
 
 components:
-  - ../../../../_shared/components/revision-history-limit
 
 patches:

--- a/apps/40-network/netbird/base/kustomization.yaml
+++ b/apps/40-network/netbird/base/kustomization.yaml
@@ -11,3 +11,5 @@ resources:
   - networkpolicy-netbird-management.yaml
   - networkpolicy-netbird-signal.yaml
   - networkpolicy-netbird-relay.yaml
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/40-network/netbird/overlays/dev/kustomization.yaml
+++ b/apps/40-network/netbird/overlays/dev/kustomization.yaml
@@ -2,7 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/revision-history-limit
 kind: Kustomization
 namespace: networking
 patches:

--- a/apps/40-network/netbird/overlays/prod/kustomization.yaml
+++ b/apps/40-network/netbird/overlays/prod/kustomization.yaml
@@ -11,7 +11,6 @@ components:
   - ../../../../_shared/components/sync-wave/wave-15
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics
-  - ../../../../_shared/components/revision-history-limit
   - ../../../../_shared/components/infisical/env-prod
 
 patches:

--- a/apps/70-tools/headlamp/base/kustomization.yaml
+++ b/apps/70-tools/headlamp/base/kustomization.yaml
@@ -9,3 +9,5 @@ resources:
   - serviceaccount.yaml
   - networkpolicy.yaml
   # vpa.yaml removed - Kyverno generates vixens-headlamp VPA via sizing-v2 label
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/70-tools/headlamp/overlays/dev/kustomization.yaml
+++ b/apps/70-tools/headlamp/overlays/dev/kustomization.yaml
@@ -2,7 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/revision-history-limit
 kind: Kustomization
 resources:
 - ../../base

--- a/apps/70-tools/headlamp/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/headlamp/overlays/prod/kustomization.yaml
@@ -8,6 +8,5 @@ resources:
 components:
   - ../../../../_shared/components/sync-wave/wave-11
   - ../../../../_shared/components/goldilocks/enabled
-  - ../../../../_shared/components/revision-history-limit
 
 patches:

--- a/apps/70-tools/it-tools/base/kustomization.yaml
+++ b/apps/70-tools/it-tools/base/kustomization.yaml
@@ -4,3 +4,5 @@ kind: Kustomization
 namespace: tools
 resources:
 # Base resources managed by Helm
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/70-tools/it-tools/overlays/dev/kustomization.yaml
+++ b/apps/70-tools/it-tools/overlays/dev/kustomization.yaml
@@ -2,7 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/revision-history-limit
 kind: Kustomization
 namespace: tools
 resources:

--- a/apps/70-tools/it-tools/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/it-tools/overlays/prod/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - ingress.yaml
 
 components:
-  - ../../../../_shared/components/revision-history-limit
 
 patches:
   # gold-maturity annotations via direct JSON patches (Helm chart doesn't support deploymentAnnotations)

--- a/apps/70-tools/penpot/base/kustomization.yaml
+++ b/apps/70-tools/penpot/base/kustomization.yaml
@@ -11,3 +11,5 @@ resources:
   - networkpolicy.yaml
   - networkpolicy-penpot-exporter.yaml
   - networkpolicy-penpot-frontend.yaml
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/70-tools/penpot/overlays/dev/kustomization.yaml
+++ b/apps/70-tools/penpot/overlays/dev/kustomization.yaml
@@ -2,7 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/revision-history-limit
 kind: Kustomization
 labels:
 - includeSelectors: false

--- a/apps/70-tools/penpot/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/penpot/overlays/prod/kustomization.yaml
@@ -7,7 +7,6 @@ components:
   - ../../../../_shared/components/sync-wave/wave-11
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics
-  - ../../../../_shared/components/revision-history-limit
 labels:
   - pairs:
       environment: prod

--- a/apps/99-test/whoami/base/kustomization.yaml
+++ b/apps/99-test/whoami/base/kustomization.yaml
@@ -7,3 +7,6 @@ resources:
   - service.yaml
   - pdb.yaml
   - networkpolicy.yaml
+components:
+  - ../../../_shared/components/revision-history-limit
+  - ../../../_shared/components/base

--- a/apps/99-test/whoami/overlays/dev/kustomization.yaml
+++ b/apps/99-test/whoami/overlays/dev/kustomization.yaml
@@ -7,6 +7,4 @@ resources:
 - ingress.yaml
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/base
-- ../../../../_shared/components/revision-history-limit
 - ../../../../_shared/components/probes/basic

--- a/apps/99-test/whoami/overlays/prod/kustomization.yaml
+++ b/apps/99-test/whoami/overlays/prod/kustomization.yaml
@@ -11,7 +11,5 @@ resources:
 components:
   - ../../../../_shared/components/sync-wave/wave-15
   - ../../../../_shared/components/goldilocks/enabled
-  - ../../../../_shared/components/base
   - ../../../../_shared/components/poddisruptionbudget/0
   - ../../../../_shared/components/priority/low
-  - ../../../../_shared/components/revision-history-limit


### PR DESCRIPTION
## Summary
Move \`revision-history-limit\` from both dev+prod overlays into \`app/base/kustomization.yaml\` for **21 apps**. Also moves \`base\` (securityContext) for whoami.

**Rule**: component in both dev AND prod → env-agnostic → belongs in \`base/\`.

## Apps migrated (21)
argocd, cilium-lb, reloader, traefik-dashboard, vpa, nfs-storage, trivy, mosquitto, birdnet-go, hydrus-client, jellyfin, jellyseerr, lazylibrarian, music-assistant, contacts, mail-gateway, netbird, headlamp, it-tools, penpot, whoami

## Validation
- 21/21 migrated, 0 regressions
- kustomize build kinds identical before/after on all 42 overlays
- `just lint` passes

Closes vixens-7kh4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized shared revision history limit components across infrastructure and deployed applications to improve configuration consistency and maintainability.
  * Updated kustomization structures in base configurations and environment-specific overlays for streamlined deployment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->