### PR TITLE
fix(reliability): promtail OOM + mariadb/gluetun probes + mosquitto rclone

### DIFF
--- a/apps/02-monitoring/promtail/base/daemonset.yaml
+++ b/apps/02-monitoring/promtail/base/daemonset.yaml
@@ -52,7 +52,7 @@ spec:
               memory: 256Mi
             limits:
               cpu: 50m
-              memory: 256Mi
+              memory: 512Mi
           readinessProbe:
             httpGet:
               path: /ready

--- a/apps/04-databases/mariadb-shared/base/statefulset.yaml
+++ b/apps/04-databases/mariadb-shared/base/statefulset.yaml
@@ -51,6 +51,26 @@ spec:
                 secretKeyRef:
                   name: mariadb-shared-credentials
                   key: MARIADB_ROOT_PASSWORD
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - mysqladmin ping -h localhost -u root -p$MARIADB_ROOT_PASSWORD
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - mysqladmin ping -h localhost -u root -p$MARIADB_ROOT_PASSWORD
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           volumeMounts:
             - name: data
               mountPath: /var/lib/mysql

--- a/apps/10-home/mosquitto/base/statefulset.yaml
+++ b/apps/10-home/mosquitto/base/statefulset.yaml
@@ -46,6 +46,8 @@ spec:
                 --transfers 4 \
                 --exclude "*.log" \
                 --exclude "lost+found/**" \
+                --exclude "**/*-litestream" \
+                --exclude "**/*-litestream/**" \
                 || true
               # Fix ownership so mosquitto (uid 1883) can write its data files
               chown -R 1883:1883 /mosquitto/data 2>/dev/null || true
@@ -150,7 +152,9 @@ spec:
               sync_s3() {
                 rclone sync /mosquitto/data s3:$LITESTREAM_BUCKET/data \
                   --exclude "*.log" \
-                  --exclude "lost+found/**";
+                  --exclude "lost+found/**" \
+                  --exclude "**/*-litestream" \
+                  --exclude "**/*-litestream/**";
               }
               while true; do
                 sync_s3;

--- a/apps/60-services/gluetun/base/deployment.yaml
+++ b/apps/60-services/gluetun/base/deployment.yaml
@@ -90,6 +90,25 @@ spec:
             - containerPort: 1080
               name: socks5-proxy
               protocol: TCP
+            - containerPort: 8000
+              name: control
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: control
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: control
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch


### PR DESCRIPTION
- **promtail**: memory 256→512Mi (OOMKilled, 252+ restarts)
- **mariadb-shared**: liveness+readiness probes (mysqladmin ping)
- **gluetun**: liveness+readiness probes (HTTP control port 8000)
- **mosquitto**: add litestream exclusions to rclone (restore + sync)

Closes vixens-ye70, vixens-vpcf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced monitoring service with increased resource allocation for improved system performance
  * Implemented health check monitoring for database and network gateway services to improve reliability and service availability
  * Refined data synchronization process to exclude temporary artifacts, improving transfer efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->