### PR TITLE
sec(contexts): add runAsNonRoot to 5 apps (pkmh Group 2)

### DIFF
--- a/apps/04-databases/redis-shared/base/deployment.yaml
+++ b/apps/04-databases/redis-shared/base/deployment.yaml
@@ -62,5 +62,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch

--- a/apps/20-media/jellyfin/base/deployment.yaml
+++ b/apps/20-media/jellyfin/base/deployment.yaml
@@ -87,5 +87,7 @@ spec:
             server: 192.168.111.69
             path: /volume3/Content
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch

--- a/apps/20-media/jellyseerr/base/deployment.yaml
+++ b/apps/20-media/jellyseerr/base/deployment.yaml
@@ -76,5 +76,7 @@ spec:
           persistentVolumeClaim:
             claimName: jellyseerr-config-pvc
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
         fsGroup: 1000
         fsGroupChangePolicy: Always

--- a/apps/70-tools/headlamp/base/deployment.yaml
+++ b/apps/70-tools/headlamp/base/deployment.yaml
@@ -60,5 +60,7 @@ spec:
           operator: Exists
           effect: NoSchedule
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch

--- a/apps/70-tools/homepage/base/deployment.yaml
+++ b/apps/70-tools/homepage/base/deployment.yaml
@@ -113,5 +113,7 @@ spec:
           persistentVolumeClaim:
             claimName: homepage-config
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch


### PR DESCRIPTION
- **jellyseerr**: runAsUser:1000 (Node.js, fsGroup:1000 déjà set)
- **jellyfin**: runAsUser:1000 (supporte non-root depuis v10.9)
- **headlamp**: runAsUser:65532 (Dockerfile USER headlamp)
- **homepage**: runAsUser:1000 (image officielle non-root)
- **redis-shared**: runAsUser:999 (USER redis en Alpine)

Skipped: music-assistant (beta), changedetection (Chrome root), firefly-iii-importer, docspell, tandoor.

Closes vixens-pkmh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment security configurations across multiple applications (Redis-shared, Jellyfin, Jellyseerr, Headlamp, and Homepage) to enforce non-root user execution policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->