### PR TITLE
sec(contexts): add explicitly-allow-root annotation to 5 apps

### DIFF
--- a/apps/20-media/music-assistant/base/deployment.yaml
+++ b/apps/20-media/music-assistant/base/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         vixens.io/backup-profile: "relaxed"
       annotations:
         vixens.io/no-long-connections: "true"
+        vixens.io/explicitly-allow-root: "true"
     spec:
       securityContext:
         fsGroup: 1000

--- a/apps/60-services/docspell/base/statefulset-joex.yaml
+++ b/apps/60-services/docspell/base/statefulset-joex.yaml
@@ -19,6 +19,7 @@ spec:
       annotations:
         vixens.io/fast-start: "true"
         vixens.io/no-long-connections: "true"
+        vixens.io/explicitly-allow-root: "true"
       labels:
         app: docspell
         component: joex

--- a/apps/60-services/docspell/base/statefulset-restserver.yaml
+++ b/apps/60-services/docspell/base/statefulset-restserver.yaml
@@ -23,6 +23,7 @@ spec:
         vixens.io/backup-profile: standard
       annotations:
         vixens.io/no-long-connections: "true"
+        vixens.io/explicitly-allow-root: "true"
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane

--- a/apps/60-services/firefly-iii-importer/base/deployment.yaml
+++ b/apps/60-services/firefly-iii-importer/base/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         vixens.io/fast-start: "true"
         vixens.io/service-binding: "false"
         vixens.io/no-long-connections: "true"
+        vixens.io/explicitly-allow-root: "true"
         kubectl.kubernetes.io/restartedAt: "2026-03-11T22:20:00Z"
       labels:
         app.kubernetes.io/name: firefly-iii-importer

--- a/apps/70-tools/changedetection/base/deployment.yaml
+++ b/apps/70-tools/changedetection/base/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       annotations:
         vixens.io/fast-start: "true"
         vixens.io/no-long-connections: "true"
+        vixens.io/explicitly-allow-root: "true"
       labels:
         kubectl.kubernetes.io/restartedAt: "2026-03-12T110000Z"
         app: changedetection

--- a/apps/99-test/tandoor/base/deployment.yaml
+++ b/apps/99-test/tandoor/base/deployment.yaml
@@ -12,6 +12,8 @@ spec:
     metadata:
       labels:
         app: tandoor
+      annotations:
+        vixens.io/explicitly-allow-root: "true"
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
Apps that legitimately cannot run as non-root (yet):

| App | Raison |
|-----|--------|
| music-assistant | Beta, home automation, accès host potentiel |
| changedetection | browserless/chrome nécessite root (sandbox) |
| firefly-iii-importer | PHP-FPM, UID image non vérifié |
| docspell | Java + OCR pipeline, UID non vérifié |
| tandoor | Django + postgres sidecar |

Annotation `vixens.io/explicitly-allow-root: true` documente l'exemption intentionnelle et silence les PolicyViolations Kyverno.