### PR TITLE
feat(argocd-dev): enable mealie app on dev cluster for DataAngel test

### DIFF
--- a/argocd/overlays/dev/apps/mealie.yaml
+++ b/argocd/overlays/dev/apps/mealie.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mealie
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: main
+    path: apps/10-home/mealie/overlays/dev
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: mealie
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/overlays/dev/kustomization.yaml
+++ b/argocd/overlays/dev/kustomization.yaml
@@ -72,7 +72,7 @@ resources:
   # - apps/it-tools.yaml
   # - apps/contacts.yaml
   # - apps/firefly-iii.yaml
-  # - apps/mealie.yaml
+  - apps/mealie.yaml
   # - apps/nocodb.yaml
   # - apps/vikunja.yaml
   # - apps/mariadb-shared.yaml


### PR DESCRIPTION
Active mealie sur le cluster dev (targetRevision: main, overlays/dev) pour tester DataAngel (#2264).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added and enabled mealie application configuration for the development environment through ArgoCD deployment automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->