### PR TITLE
fix(mealie-dev): use emptyDir for DataAngel test

### DIFF
--- a/apps/10-home/mealie/overlays/dev/patches/dataangel-test.yaml
+++ b/apps/10-home/mealie/overlays/dev/patches/dataangel-test.yaml
@@ -108,3 +108,6 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /app/data
+      volumes:
+        - name: data
+          emptyDir: {}


### PR DESCRIPTION
iSCSI non disponible sur dev, PVC Pending. emptyDir suffit pour valider le restore S3 via DataAngel init container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to add persistent storage volume support for the application data directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->