### PR TITLE
fix(mealie-dev): use JSON patch to replace data volume with emptyDir

### DIFF
--- a/apps/10-home/mealie/overlays/dev/kustomization.yaml
+++ b/apps/10-home/mealie/overlays/dev/kustomization.yaml
@@ -14,3 +14,12 @@ patches:
   target:
     kind: Deployment
     name: mealie
+- patch: |-
+    - op: replace
+      path: /spec/template/spec/volumes/0
+      value:
+        name: data
+        emptyDir: {}
+  target:
+    kind: Deployment
+    name: mealie

--- a/apps/10-home/mealie/overlays/dev/patches/dataangel-test.yaml
+++ b/apps/10-home/mealie/overlays/dev/patches/dataangel-test.yaml
@@ -108,6 +108,4 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /app/data
-      volumes:
-        - name: data
-          emptyDir: {}
+


### PR DESCRIPTION
SMP ne peut pas remplacer un volume PVC par emptyDir (merge invalide). JSON patch op:replace sur volumes[0] corrige le problème.