### PR TITLE
fix(mealie-dev): run DataAngel as uid 911 to match mealie file ownership

### DIFF
--- a/apps/10-home/mealie/overlays/dev/patches/dataangel-test.yaml
+++ b/apps/10-home/mealie/overlays/dev/patches/dataangel-test.yaml
@@ -25,6 +25,9 @@ spec:
           image: charchess/dataangel:latest
           imagePullPolicy: Always
           command: ["./init"]
+          securityContext:
+            runAsUser: 911
+            runAsGroup: 911
           resources:
             requests:
               cpu: 10m
@@ -67,6 +70,9 @@ spec:
           image: charchess/dataangel:latest
           imagePullPolicy: Always
           command: ["./sidecar"]
+          securityContext:
+            runAsUser: 911
+            runAsGroup: 911
           resources:
             requests:
               cpu: 5m


### PR DESCRIPTION
mealie.db owned 911:911, DataAngel tournait en uid 1000 - attempt to write a readonly database. Fix: runAsUser/runAsGroup 911 sur les containers DataAngel.