### PR TITLE
fix(dataangel): add AWS_REGION for MinIO lock

### DIFF
--- a/apps/10-home/mealie/overlays/dev/patches/dataangel-test.yaml
+++ b/apps/10-home/mealie/overlays/dev/patches/dataangel-test.yaml
@@ -47,6 +47,8 @@ spec:
                   key: LITESTREAM_ENDPOINT
             - name: DATA_GUARD_DEPLOYMENT_NAME
               value: "mealie"
+            - name: AWS_REGION
+              value: "us-east-1"
             - name: DATA_GUARD_RCLONE_INTERVAL
               value: "60s"
             - name: DATA_GUARD_METRICS_ENABLED


### PR DESCRIPTION
Phase 2 (distributed lock) fails with 'A region must be set'. AWS SDK v2 requires AWS_REGION even for MinIO. Adding us-east-1 (MinIO convention).