### PR TITLE
fix(dataangel): remove AWS_REGION workaround, fixed upstream

### DIFF
--- a/apps/10-home/mealie/overlays/dev/patches/dataangel-test.yaml
+++ b/apps/10-home/mealie/overlays/dev/patches/dataangel-test.yaml
@@ -47,8 +47,6 @@ spec:
                   key: LITESTREAM_ENDPOINT
             - name: DATA_GUARD_DEPLOYMENT_NAME
               value: "mealie"
-            - name: AWS_REGION
-              value: "us-east-1"
             - name: DATA_GUARD_RCLONE_INTERVAL
               value: "60s"
             - name: DATA_GUARD_METRICS_ENABLED


### PR DESCRIPTION
AWS_REGION is now defaulted internally when DATA_GUARD_S3_ENDPOINT is set. Fixed in truxonline/dataAngel#13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development configuration by removing an environment variable setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->