### PR TITLE
feat(dataangel): migrate mealie dev to annotation-based component pattern

### DIFF
--- a/apps/10-home/mealie/overlays/dev/kustomization.yaml
+++ b/apps/10-home/mealie/overlays/dev/kustomization.yaml
@@ -9,6 +9,11 @@ resources:
 - ingress.yaml
 components:
 - ../../../../_shared/components/dev-hibernate
+- ../../../../_shared/components/dataangel
+
+images:
+- name: charchess/dataangel
+  newTag: dev
 patches:
 - path: patches/dataangel-test.yaml
   target:

--- a/apps/10-home/mealie/overlays/dev/patches/dataangel-test.yaml
+++ b/apps/10-home/mealie/overlays/dev/patches/dataangel-test.yaml
@@ -9,6 +9,14 @@ spec:
     metadata:
       labels:
         vixens.io/sizing.dataangel: B-nano
+      annotations:
+        data-guard.io/bucket: "vixens-dev-mealie"
+        data-guard.io/sqlite-paths: "/app/data/mealie.db"
+        data-guard.io/fs-paths: "/app/data"
+        data-guard.io/s3-endpoint: "http://synelia.internal.truxonline.com:9000"
+        data-guard.io/deployment-name: "mealie"
+        data-guard.io/rclone-interval: "60s"
+        data-guard.io/metrics-enabled: "true"
     spec:
       initContainers:
         - name: restore-config
@@ -16,10 +24,7 @@ spec:
         - name: restore-db
           $patch: delete
         - name: dataangel
-          image: charchess/dataangel:dev
           imagePullPolicy: Always
-          restartPolicy: Always
-          command: ["./dataangel"]
           securityContext:
             runAsUser: 911
             runAsGroup: 911
@@ -31,28 +36,6 @@ spec:
               cpu: 100m
               memory: 256Mi
           env:
-            - name: DATA_GUARD_BUCKET
-              valueFrom:
-                secretKeyRef:
-                  name: mealie-secrets
-                  key: LITESTREAM_BUCKET
-            - name: DATA_GUARD_SQLITE_PATHS
-              value: "/app/data/mealie.db"
-            - name: DATA_GUARD_FS_PATHS
-              value: "/app/data"
-            - name: DATA_GUARD_S3_ENDPOINT
-              valueFrom:
-                secretKeyRef:
-                  name: mealie-secrets
-                  key: LITESTREAM_ENDPOINT
-            - name: DATA_GUARD_DEPLOYMENT_NAME
-              value: "mealie"
-            - name: DATA_GUARD_RCLONE_INTERVAL
-              value: "60s"
-            - name: DATA_GUARD_METRICS_ENABLED
-              value: "true"
-            - name: DATA_GUARD_METRICS_PORT
-              value: "9090"
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -63,16 +46,6 @@ spec:
                 secretKeyRef:
                   name: mealie-secrets
                   key: LITESTREAM_SECRET_ACCESS_KEY
-          ports:
-            - containerPort: 9090
-              name: metrics
-              protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 9090
-            initialDelaySeconds: 0
-            periodSeconds: 2
           volumeMounts:
             - name: data
               mountPath: /app/data

--- a/apps/_shared/components/dataangel/kustomization.yaml
+++ b/apps/_shared/components/dataangel/kustomization.yaml
@@ -1,0 +1,100 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+metadata:
+  name: dataangel
+
+commonLabels:
+  data-guard.io/enabled: "true"
+
+patches:
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: add
+        path: /spec/template/spec/initContainers/-
+        value:
+          name: dataangel
+          restartPolicy: Always
+          image: charchess/dataangel:0.3.1
+          imagePullPolicy: IfNotPresent
+          command: ["./dataangel"]
+          env:
+            - name: DATA_GUARD_BUCKET
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['data-guard.io/bucket']
+            - name: DATA_GUARD_SQLITE_PATHS
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['data-guard.io/sqlite-paths']
+            - name: DATA_GUARD_FS_PATHS
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['data-guard.io/fs-paths']
+            - name: DATA_GUARD_S3_ENDPOINT
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['data-guard.io/s3-endpoint']
+            - name: DATA_GUARD_DEPLOYMENT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['data-guard.io/deployment-name']
+            - name: DATA_GUARD_LOCK_TTL
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['data-guard.io/lock-ttl']
+            - name: DATA_GUARD_RCLONE_INTERVAL
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['data-guard.io/rclone-interval']
+            - name: DATA_GUARD_METRICS_PORT
+              value: "9090"
+            - name: DATA_GUARD_METRICS_ENABLED
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['data-guard.io/metrics-enabled']
+            - name: DATA_GUARD_FULL_LOGS
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['data-guard.io/full-logs']
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: AWS_REGION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['data-guard.io/aws-region']
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: data-guard-credentials
+                  key: access-key
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: data-guard-credentials
+                  key: secret-key
+          ports:
+            - containerPort: 9090
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 9090
+            initialDelaySeconds: 0
+            periodSeconds: 2
+          volumeMounts:
+            - name: data
+              mountPath: /data
+
+images:
+  - name: charchess/dataangel
+    newTag: "0.3.1"


### PR DESCRIPTION
Proper prod-like integration of DataAngel using the kustomize component + annotations.

**Before:** direct env vars hardcoded in patch (not testing the real usage)
**After:** full annotation-driven config via `data-guard.io/*` annotations on pod template

Changes:
- `apps/_shared/components/dataangel/` — shared component (pinned to 0.3.1, overridden to `:dev` in dev overlay)
- Pod template annotations carry all DataAngel config (bucket, paths, endpoint, deployment-name, intervals)
- Strategic merge patch overrides credentials (`mealie-secrets`) and mountPath (`/app/data`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared data-management component to provide data protection/init-container behavior across deployments.

* **Updates**
  * Development overlay now uses the dev image variant for the data component.
  * Dev-specific patch adjusts runtime annotations and environment settings, removing metrics port/probe and some data-guard env overrides while preserving credentials and data volume mounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->