### PR TITLE
fix(dataangel): remove commonLabels, breaks immutable selector

### DIFF
--- a/apps/_shared/components/dataangel/kustomization.yaml
+++ b/apps/_shared/components/dataangel/kustomization.yaml
@@ -5,8 +5,6 @@ kind: Component
 metadata:
   name: dataangel
 
-commonLabels:
-  data-guard.io/enabled: "true"
 
 patches:
   - target:


### PR DESCRIPTION
commonLabels in kustomize component modifies spec.selector.matchLabels which is immutable on existing Deployments. Removing it — the data-guard.io/enabled label can be added explicitly per-app if needed.