### PR TITLE
feat(dataangel): rename annotations for v1.0.0 compatibility

### DIFF
--- a/apps/10-home/mealie/overlays/dev/patches/dataangel-test.yaml
+++ b/apps/10-home/mealie/overlays/dev/patches/dataangel-test.yaml
@@ -10,13 +10,13 @@ spec:
       labels:
         vixens.io/sizing.dataangel: B-nano
       annotations:
-        data-guard.io/bucket: "vixens-dev-mealie"
-        data-guard.io/sqlite-paths: "/app/data/mealie.db"
-        data-guard.io/fs-paths: "/app/data"
-        data-guard.io/s3-endpoint: "http://synelia.internal.truxonline.com:9000"
-        data-guard.io/deployment-name: "mealie"
-        data-guard.io/rclone-interval: "60s"
-        data-guard.io/metrics-enabled: "true"
+        dataangel.io/bucket: "vixens-dev-mealie"
+        dataangel.io/sqlite-paths: "/app/data/mealie.db"
+        dataangel.io/fs-paths: "/app/data"
+        dataangel.io/s3-endpoint: "http://synelia.internal.truxonline.com:9000"
+        dataangel.io/deployment-name: "mealie"
+        dataangel.io/rclone-interval: "60s"
+        dataangel.io/metrics-enabled: "true"
     spec:
       initContainers:
         - name: restore-config

--- a/apps/_shared/components/dataangel/kustomization.yaml
+++ b/apps/_shared/components/dataangel/kustomization.yaml
@@ -22,41 +22,41 @@ patches:
             - name: DATA_GUARD_BUCKET
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.annotations['data-guard.io/bucket']
+                  fieldPath: metadata.annotations['dataangel.io/bucket']
             - name: DATA_GUARD_SQLITE_PATHS
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.annotations['data-guard.io/sqlite-paths']
+                  fieldPath: metadata.annotations['dataangel.io/sqlite-paths']
             - name: DATA_GUARD_FS_PATHS
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.annotations['data-guard.io/fs-paths']
+                  fieldPath: metadata.annotations['dataangel.io/fs-paths']
             - name: DATA_GUARD_S3_ENDPOINT
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.annotations['data-guard.io/s3-endpoint']
+                  fieldPath: metadata.annotations['dataangel.io/s3-endpoint']
             - name: DATA_GUARD_DEPLOYMENT_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.annotations['data-guard.io/deployment-name']
+                  fieldPath: metadata.annotations['dataangel.io/deployment-name']
             - name: DATA_GUARD_LOCK_TTL
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.annotations['data-guard.io/lock-ttl']
+                  fieldPath: metadata.annotations['dataangel.io/lock-ttl']
             - name: DATA_GUARD_RCLONE_INTERVAL
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.annotations['data-guard.io/rclone-interval']
+                  fieldPath: metadata.annotations['dataangel.io/rclone-interval']
             - name: DATA_GUARD_METRICS_PORT
               value: "9090"
             - name: DATA_GUARD_METRICS_ENABLED
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.annotations['data-guard.io/metrics-enabled']
+                  fieldPath: metadata.annotations['dataangel.io/metrics-enabled']
             - name: DATA_GUARD_FULL_LOGS
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.annotations['data-guard.io/full-logs']
+                  fieldPath: metadata.annotations['dataangel.io/full-logs']
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -68,7 +68,7 @@ patches:
             - name: AWS_REGION
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.annotations['data-guard.io/aws-region']
+                  fieldPath: metadata.annotations['dataangel.io/aws-region']
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
- Rename all Kubernetes annotations from `data-guard.io/*` to `dataangel.io/*` to align with upstream breaking change (truxonline/dataangel#15)
- Affects shared dataangel component and mealie dev patch
- Env vars (`DATA_GUARD_*`) remain unchanged — only annotation keys change

## Context
The `dev` image tag now includes the v1.0.0 rename. Without this change, `fieldRef` annotations resolve to empty values → pod crash.

## Test plan
- [ ] ArgoCD syncs mealie dev successfully
- [ ] Pod starts with correct `dataangel.io/*` annotations
- [ ] DataAngel init container completes restore phase
- [ ] Sidecar backup runs continuously

🤖 Generated with [Claude Code](https://claude.com/claude-code)