### PR TITLE
fix(security): disable runAsNonRoot on 13 apps where image runs as root

### DIFF
--- a/apps/10-home/mosquitto/base/statefulset.yaml
+++ b/apps/10-home/mosquitto/base/statefulset.yaml
@@ -171,7 +171,7 @@ spec:
           operator: Exists
           effect: NoSchedule
       securityContext:
-        runAsNonRoot: true
+        # runAsNonRoot: true  # DISABLED: init container rclone runs as root — verify image before re-enabling
         fsGroup: 1883
         seccompProfile:
           type: RuntimeDefault

--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -207,7 +207,7 @@ spec:
           configMap:
             name: sabnzbd-litestream-config
       securityContext:
-        runAsNonRoot: true
+        # runAsNonRoot: true  # DISABLED: init container fix-permissions runs as root — verify image before re-enabling
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:

--- a/apps/40-network/netbird/base/dashboard.yaml
+++ b/apps/40-network/netbird/base/dashboard.yaml
@@ -30,7 +30,7 @@ spec:
           operator: "Exists"
           effect: "NoSchedule"
       securityContext:
-        runAsNonRoot: true
+        # runAsNonRoot: true  # DISABLED: netbirdio/dashboard runs as root — verify image before re-enabling
         seccompProfile:
           type: RuntimeDefault
       initContainers:

--- a/apps/40-network/netbird/base/management.yaml
+++ b/apps/40-network/netbird/base/management.yaml
@@ -99,7 +99,7 @@ spec:
             - name: config-writable
               mountPath: /etc/netbird
       securityContext:
-        runAsNonRoot: true
+        # runAsNonRoot: true  # DISABLED: netbirdio/management runs as root — verify image before re-enabling
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/apps/40-network/netbird/base/signal-relay.yaml
+++ b/apps/40-network/netbird/base/signal-relay.yaml
@@ -30,7 +30,7 @@ spec:
           operator: "Exists"
           effect: "NoSchedule"
       securityContext:
-        runAsNonRoot: true
+        # runAsNonRoot: true  # DISABLED: netbirdio/signal runs as root — verify image before re-enabling
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/apps/70-tools/headlamp/base/deployment.yaml
+++ b/apps/70-tools/headlamp/base/deployment.yaml
@@ -60,7 +60,7 @@ spec:
           operator: Exists
           effect: NoSchedule
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
+        # runAsNonRoot: true  # DISABLED: image writes to /.config — verify image before re-enabling
+        # runAsUser: 65532   # DISABLED: causes mkdir /.config permission denied
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch

--- a/apps/70-tools/homepage/base/deployment.yaml
+++ b/apps/70-tools/homepage/base/deployment.yaml
@@ -113,7 +113,7 @@ spec:
           persistentVolumeClaim:
             claimName: homepage-config
       securityContext:
-        runAsNonRoot: true
+        # runAsNonRoot: true  # DISABLED: init container busybox runs as root — verify image before re-enabling
         runAsUser: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch

--- a/apps/70-tools/linkwarden/base/deployment.yaml
+++ b/apps/70-tools/linkwarden/base/deployment.yaml
@@ -98,7 +98,7 @@ spec:
           persistentVolumeClaim:
             claimName: linkwarden-data
       securityContext:
-        runAsNonRoot: true
+        # runAsNonRoot: true  # DISABLED: linkwarden image runs as root — verify image before re-enabling
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:

--- a/apps/70-tools/netbox/base/deployment.yaml
+++ b/apps/70-tools/netbox/base/deployment.yaml
@@ -105,7 +105,7 @@ spec:
           persistentVolumeClaim:
             claimName: netbox-media-pvc
       securityContext:
-        runAsNonRoot: true
+        # runAsNonRoot: true  # DISABLED: netbox image runs as root — verify image before re-enabling
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:

--- a/apps/70-tools/nocodb/base/deployment.yaml
+++ b/apps/70-tools/nocodb/base/deployment.yaml
@@ -98,7 +98,7 @@ spec:
           persistentVolumeClaim:
             claimName: nocodb-data
       securityContext:
-        runAsNonRoot: true
+        # runAsNonRoot: true  # DISABLED: nocodb image runs as root — verify image before re-enabling
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:

--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -93,7 +93,7 @@ spec:
           persistentVolumeClaim:
             claimName: penpot-data
       securityContext:
-        runAsNonRoot: true
+        # runAsNonRoot: true  # DISABLED: penpot/backend uses non-numeric user — verify image before re-enabling
         seccompProfile:
           type: RuntimeDefault
       restartPolicy: Always

--- a/apps/70-tools/penpot/base/deployment-exporter.yaml
+++ b/apps/70-tools/penpot/base/deployment-exporter.yaml
@@ -69,7 +69,7 @@ spec:
             failureThreshold: 20
             periodSeconds: 10
       securityContext:
-        runAsNonRoot: true
+        # runAsNonRoot: true  # DISABLED: penpot/exporter runs as root — verify image before re-enabling
         seccompProfile:
           type: RuntimeDefault
       restartPolicy: Always

--- a/apps/70-tools/penpot/base/deployment-frontend.yaml
+++ b/apps/70-tools/penpot/base/deployment-frontend.yaml
@@ -60,7 +60,7 @@ spec:
             periodSeconds: 30
             failureThreshold: 3
       securityContext:
-        runAsNonRoot: true
+        # runAsNonRoot: true  # DISABLED: penpot/frontend runs as root — verify image before re-enabling
         seccompProfile:
           type: RuntimeDefault
       restartPolicy: Always


### PR DESCRIPTION
## Summary
- Disables `runAsNonRoot: true` on 13 apps whose upstream images require root
- Reverts the breaking effect of #2176 which has caused **CreateContainerConfigError** on prod for 2 days
- Each line is commented out (not deleted) with a warning to verify the image before re-enabling

## Affected apps (13 files)
| App | Reason |
|-----|--------|
| mosquitto | init container rclone runs as root |
| sabnzbd | init container fix-permissions (busybox) runs as root |
| netbird signal | netbirdio/signal runs as root |
| netbird dashboard | netbirdio/dashboard runs as root |
| netbird management | netbirdio/management runs as root |
| linkwarden | image runs as root |
| netbox | image runs as root |
| nocodb | image runs as root |
| penpot backend | non-numeric user "penpot" |
| penpot frontend | image runs as root |
| penpot exporter | image runs as root |
| headlamp | image writes to /.config as root |
| homepage | init container busybox runs as root |

## Root cause
PR #2176 (`sec(contexts): add runAsNonRoot: true to 19 apps`) stated "all apps already run as non-root" but this was not verified against the actual container images.

## Test plan
- [ ] All 13 apps recover from CreateContainerConfigError after ArgoCD sync
- [ ] No new security regressions on apps not touched by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment security configurations across multiple services (Mosquitto, SABnzbd, Netbird, Headlamp, Homepage, Linkwarden, Netbox, Nocodb, Penpot) to adjust runtime user enforcement constraints in their respective container environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->