### PR TITLE
fix(homepage): init container runs as root to clean PVC files

### DIFF
--- a/apps/70-tools/homepage/base/deployment.yaml
+++ b/apps/70-tools/homepage/base/deployment.yaml
@@ -39,7 +39,10 @@ spec:
         - name: copy-initial-config
           image: busybox:1.37
           # Clear the destination first to avoid pollution, then copy and set
-          # ownership.
+          # ownership. Runs as root to handle files owned by previous pods.
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
           command:
             - sh
             - -c


### PR DESCRIPTION
## Summary
- Init container `copy-initial-config` needs root privileges to `rm -rf /config/*` — files may be owned by root from previous pod runs
- Adds explicit `securityContext: runAsUser: 0` on the init container only (main container stays as user 1000)
- Fixes CrashLoopBackOff in prod: `rm: can't remove '/config/logs/homepage.log': Permission denied`

## Test plan
- [ ] ArgoCD syncs and homepage pod starts without init container errors
- [ ] Homepage accessible at https://homepage.truxonline.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file permission and ownership handling during deployment initialization to ensure proper operation when application instances restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->