### PR TITLE
fix(gluetun): enable control server for health probes

### DIFF
--- a/apps/60-services/gluetun/base/deployment.yaml
+++ b/apps/60-services/gluetun/base/deployment.yaml
@@ -29,13 +29,6 @@ spec:
       priorityClassName: vixens-medium
       containers:
         - name: gluetun
-          resources:
-            requests:
-              cpu: 5m
-              memory: 64Mi
-            limits:
-              cpu: 50m
-              memory: 128Mi
           image: ghcr.io/qdm12/gluetun:v3.41.1
           securityContext:
             capabilities:
@@ -69,7 +62,7 @@ spec:
               value: on
             # Firewall settings to allow access from other pods
             - name: FIREWALL_INPUT_PORTS
-              value: 8888,1080
+              value: 8888,1080,8000
             # Allow outbound to Kubernetes pod and service networks
             - name: FIREWALL_OUTBOUND_SUBNETS
               value: 10.244.0.0/16,10.96.0.0/12
@@ -83,6 +76,9 @@ spec:
               value: on
             - name: SOCKS5PROXY
               value: on
+            # Control server for health probes
+            - name: HTTP_CONTROL_SERVER_ADDRESS
+              value: :8000
           ports:
             - containerPort: 8888
               name: http-proxy
@@ -93,11 +89,17 @@ spec:
             - containerPort: 8000
               name: control
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /
+              port: control
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 18
           livenessProbe:
             httpGet:
               path: /
               port: control
-            initialDelaySeconds: 30
             periodSeconds: 20
             timeoutSeconds: 5
             failureThreshold: 3
@@ -105,7 +107,6 @@ spec:
             httpGet:
               path: /
               port: control
-            initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3


### PR DESCRIPTION
## Summary
- Enable HTTP control server (`HTTP_CONTROL_SERVER_ADDRESS=:8000`) required by liveness/readiness probes
- Add port 8000 to `FIREWALL_INPUT_PORTS` so gluetun's firewall allows probe traffic
- Add `startupProbe` (18×10s = 3min) for WireGuard connection establishment
- Remove hardcoded `resources:` block — Kyverno sizing label `B-nano` handles it

## Root Cause
Health probes target port 8000 (control server) but:
1. The control server was never enabled (missing `HTTP_CONTROL_SERVER_ADDRESS`)
2. Port 8000 was blocked by gluetun's internal firewall

This caused immediate CrashLoopBackOff on any new RS rollout.

## Test plan
- [ ] Verify new gluetun pod starts and passes startup probe
- [ ] Verify VPN connectivity (WireGuard) works
- [ ] Verify health probes succeed on port 8000

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HTTP control server accessible on port 8000.

* **Improvements**
  * Enhanced service health checks with startup probe for better initialization reliability.
  * Adjusted health check timing to optimize pod startup behavior.
  * Removed container resource constraints for improved scheduling flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->