### PR TITLE
fix(mariadb): use mariadb-admin for probes (12.2 rename)

### DIFF
--- a/apps/04-databases/mariadb-shared/base/statefulset.yaml
+++ b/apps/04-databases/mariadb-shared/base/statefulset.yaml
@@ -50,7 +50,7 @@ spec:
               command:
                 - sh
                 - -c
-                - mysqladmin ping -h localhost -u root -p$MARIADB_ROOT_PASSWORD
+                - mariadb-admin ping -h localhost -u root -p$MARIADB_ROOT_PASSWORD
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 30
@@ -59,7 +59,7 @@ spec:
               command:
                 - sh
                 - -c
-                - mysqladmin ping -h localhost -u root -p$MARIADB_ROOT_PASSWORD
+                - mariadb-admin ping -h localhost -u root -p$MARIADB_ROOT_PASSWORD
             periodSeconds: 20
             timeoutSeconds: 5
             failureThreshold: 3
@@ -68,8 +68,7 @@ spec:
               command:
                 - sh
                 - -c
-                - mysqladmin ping -h localhost -u root -p$MARIADB_ROOT_PASSWORD
-            initialDelaySeconds: 10
+                - mariadb-admin ping -h localhost -u root -p$MARIADB_ROOT_PASSWORD
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3


### PR DESCRIPTION
## Summary
- Replace `mysqladmin` with `mariadb-admin` in all health probes
- Remove redundant `initialDelaySeconds` from readiness probe (startup probe handles it)

## Root Cause
MariaDB 12.2 renamed `mysqladmin` to `mariadb-admin`. All three probes (startup, liveness, readiness) fail with `mysqladmin: not found`, keeping the pod in CrashLoopBackOff despite the database being healthy.

## Test plan
- [ ] Verify mariadb-shared-0 becomes 1/1 Ready
- [ ] Verify startup probe passes within 30×10s window
- [ ] Verify liveness/readiness probes work in steady state

🤖 Generated with [Claude Code](https://claude.com/claude-code)