### PR TITLE
fix(prometheus): SB-2xlarge sizing to prevent OOMKill during WAL replay

### DIFF
--- a/apps/02-monitoring/prometheus/base/values.yaml
+++ b/apps/02-monitoring/prometheus/base/values.yaml
@@ -5,7 +5,7 @@
 server:
   priorityClassName: vixens-critical
   podLabels:
-    vixens.io/sizing.prometheus-server: "G-xlarge"
+    vixens.io/sizing.prometheus-server: "SB-2xlarge"
   podAnnotations:
     vixens.io/fast-start: "true"
     prometheus.io/scrape: "true"
@@ -25,13 +25,6 @@ server:
     storageClass: synelia-iscsi-retain
     size: 50Gi
   retention: 30d
-  resources:
-    requests:
-      cpu: 1000m
-      memory: 4Gi
-    limits:
-      cpu: 1000m
-      memory: 4Gi
   # WAL replay on 50Gi data takes 10+ minutes — startup probe prevents liveness kill
   startupProbe:
     enabled: true


### PR DESCRIPTION
## Summary
- Change sizing from `G-xlarge` (200m/2Gi guaranteed) to `SB-2xlarge` (500m/4Gi request, 2000m/16Gi limit)
- Remove hardcoded `resources:` block — Kyverno sizing system handles it

## Root Cause
Prometheus OOMKilled during WAL replay on 50Gi data with 4Gi memory limit. WAL replay is memory-intensive and needs burst capacity beyond 4Gi.

SB-2xlarge allows bursting to 16Gi during WAL replay while keeping requests at 4Gi for normal operation.

## Test plan
- [ ] Verify prometheus survives WAL replay without OOMKill
- [ ] Verify Kyverno injects correct resources from SB-2xlarge label
- [ ] Verify prometheus becomes Ready after WAL replay completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)