### PR TITLE
fix(gluetun): use health server port 9999 instead of control server

### DIFF
--- a/apps/60-services/gluetun/base/deployment.yaml
+++ b/apps/60-services/gluetun/base/deployment.yaml
@@ -62,7 +62,7 @@ spec:
               value: on
             # Firewall settings to allow access from other pods
             - name: FIREWALL_INPUT_PORTS
-              value: 8888,1080,8000
+              value: 8888,1080,9999
             # Allow outbound to Kubernetes pod and service networks
             - name: FIREWALL_OUTBOUND_SUBNETS
               value: 10.244.0.0/16,10.96.0.0/12
@@ -76,9 +76,6 @@ spec:
               value: on
             - name: SOCKS5PROXY
               value: on
-            # Control server for health probes
-            - name: HTTP_CONTROL_SERVER_ADDRESS
-              value: :8000
           ports:
             - containerPort: 8888
               name: http-proxy
@@ -86,27 +83,27 @@ spec:
             - containerPort: 1080
               name: socks5-proxy
               protocol: TCP
-            - containerPort: 8000
-              name: control
+            - containerPort: 9999
+              name: health
               protocol: TCP
           startupProbe:
             httpGet:
               path: /
-              port: control
+              port: health
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 18
           livenessProbe:
             httpGet:
               path: /
-              port: control
+              port: health
             periodSeconds: 20
             timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /
-              port: control
+              port: health
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3


### PR DESCRIPTION
## Summary
- Switch all probes from port 8000 (control server) to port 9999 (health server)
- Remove `HTTP_CONTROL_SERVER_ADDRESS` env var (no longer needed)
- Update `FIREWALL_INPUT_PORTS` to allow 9999 instead of 8000

## Root Cause
The control server on port 8000 requires authentication by default, causing all probes to return 401 Unauthorized → CrashLoopBackOff.

Gluetun's built-in health server on port 9999 checks VPN connectivity status without authentication.

## Test plan
- [ ] Verify gluetun pod becomes Ready with health server probes
- [ ] Verify VPN connectivity works through the proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)