### PR TITLE
fix(gluetun): bind health server to 0.0.0.0 for K8s probes

### DIFF
--- a/apps/60-services/gluetun/base/deployment.yaml
+++ b/apps/60-services/gluetun/base/deployment.yaml
@@ -88,6 +88,8 @@ spec:
               value: on
             - name: VPN_IPV6_ENABLED
               value: "off"
+            - name: HEALTH_SERVER_ADDRESS
+              value: :9999
           ports:
             - containerPort: 8888
               name: http-proxy


### PR DESCRIPTION
## Summary
- Add `HEALTH_SERVER_ADDRESS=:9999` to bind health server to all interfaces
- Increase startup probe from 18×10s to 30×10s (5 min)

## Root Cause
Gluetun's health server defaults to `127.0.0.1:9999` (localhost only). K8s probes connect via the pod IP, so they can't reach it. Setting `HEALTH_SERVER_ADDRESS=:9999` binds to all interfaces.

Additionally, gluetun's startup takes ~70s (server list creation + WireGuard connection), and may need multiple VPN connection attempts. Increasing the startup probe window to 5 minutes ensures reliable startup.

## Test plan
- [ ] Verify gluetun health probes succeed on port 9999
- [ ] Verify VPN connectivity works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated gluetun container port configuration from 8000 to 9999 and modified the firewall inbound port allowlist from `8888,1080,8000` to `8888,1080,9999`.
  * Increased startup probe failure threshold from 18 to 30.
  * Synchronized all container health checks (startup, liveness, readiness) to use the updated port configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->