### PR TITLE
fix(prometheus): downsize SB-2xlarge → SB-xlarge (1.6Gi usage, 8Gi limit)

### DIFF
--- a/apps/02-monitoring/prometheus/base/values.yaml
+++ b/apps/02-monitoring/prometheus/base/values.yaml
@@ -5,7 +5,7 @@
 server:
   priorityClassName: vixens-critical
   podLabels:
-    vixens.io/sizing.prometheus-server: "SB-2xlarge"
+    vixens.io/sizing.prometheus-server: "SB-xlarge"
   podAnnotations:
     vixens.io/fast-start: "true"
     prometheus.io/scrape: "true"


### PR DESCRIPTION
## Summary
- Change sizing from `SB-2xlarge` to `SB-xlarge`

| | SB-2xlarge (before) | SB-xlarge (after) | Usage réel |
|---|---|---|---|
| Memory request | 4Gi | **2Gi** | 1.6Gi |
| Memory limit | 16Gi | **8Gi** | ~5Gi peak (WAL replay) |
| CPU request | 500m | **200m** | 43m |
| CPU limit | 2000m | 2000m | — |

## Why
- `SB-2xlarge` was a knee-jerk reaction to OOMKill at 4Gi
- Actual usage is 1.6Gi steady state, ~5Gi during WAL replay
- 4Gi request wastes 2.4Gi cluster capacity on a cluster at 99% memory allocation
- 16Gi limit risks node starvation

## Test plan
- [ ] Verify prometheus survives WAL replay under 8Gi
- [ ] Verify cluster memory pressure decreases

🤖 Generated with [Claude Code](https://claude.com/claude-code)