### PR TITLE
chore(dataangel): temporarily disable startupProbe pending dataAngel#29

### DIFF
--- a/apps/_shared/components/dataangel/kustomization.yaml
+++ b/apps/_shared/components/dataangel/kustomization.yaml
@@ -83,12 +83,13 @@ patches:
             - containerPort: 9090
               name: metrics
               protocol: TCP
-          startupProbe:
-            httpGet:
-              path: /ready
-              port: 9090
-            periodSeconds: 2
-            failureThreshold: 150
+          # startupProbe temporarily disabled pending dataAngel#29 fix
+          # startupProbe:
+          #   httpGet:
+          #     path: /ready
+          #     port: 9090
+          #   periodSeconds: 2
+          #   failureThreshold: 150
           readinessProbe:
             httpGet:
               path: /ready


### PR DESCRIPTION
## Summary
Temporarily disable the startupProbe on the dataangel sidecar component pending upstream fix for dataAngel#29.

## Problem
The startupProbe (#25) + DB deletion detection (#22) creates a deadlock on first deployment:
- DataAngel exits because the DB doesn't exist (fix #22)
- App can't create the DB because the startupProbe blocks it (fix #25)

## Action
Will re-enable once truxonline/dataAngel#29 is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment probe configuration to remove the startup probe while retaining the readiness probe for continued health monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->