### PR TITLE
fix(dataangel): re-enable startupProbe after #29 fix

### DIFF
--- a/apps/_shared/components/dataangel/kustomization.yaml
+++ b/apps/_shared/components/dataangel/kustomization.yaml
@@ -83,13 +83,12 @@ patches:
             - containerPort: 9090
               name: metrics
               protocol: TCP
-          # startupProbe temporarily disabled pending dataAngel#29 fix
-          # startupProbe:
-          #   httpGet:
-          #     path: /ready
-          #     port: 9090
-          #   periodSeconds: 2
-          #   failureThreshold: 150
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 9090
+            periodSeconds: 2
+            failureThreshold: 150
           readinessProbe:
             httpGet:
               path: /ready


### PR DESCRIPTION
## Summary
- Re-enables the startupProbe on the dataangel sidecar component
- Was temporarily disabled in PR #2333 due to first-deploy deadlock (#29)
- dataAngel commit `f952dfb5258b` fixes #29 by only exiting on DB deletion when DB was previously seen

## Test plan
- [ ] Verify startupProbe is present on pod spec
- [ ] Test first-deploy scenario (clear S3 backups, delete pod) — no deadlock
- [ ] Verify mealie starts AFTER restore completes (T15 retest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Re-enabled health checks for improved service reliability and system monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->