### PR TITLE
fix(dataangel): use prod S3 endpoint hostname for MinIO

### DIFF
--- a/apps/10-home/mealie/overlays/prod/dataangel.yaml
+++ b/apps/10-home/mealie/overlays/prod/dataangel.yaml
@@ -16,7 +16,7 @@ spec:
         dataangel.io/bucket: "vixens-prod-mealie"
         dataangel.io/sqlite-paths: "/app/data/mealie.db"
         dataangel.io/fs-paths: "/app/data"
-        dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
+        dataangel.io/s3-endpoint: "http://synelia.internal.truxonline.com:9000"
         dataangel.io/deployment-name: "mealie"
         dataangel.io/rclone-interval: "60s"
         dataangel.io/metrics-enabled: "true"

--- a/apps/20-media/prowlarr/overlays/prod/dataangel.yaml
+++ b/apps/20-media/prowlarr/overlays/prod/dataangel.yaml
@@ -17,7 +17,7 @@ spec:
         dataangel.io/bucket: "vixens-prod-prowlarr"
         dataangel.io/sqlite-paths: "/config/prowlarr.db"
         dataangel.io/fs-paths: "/config"
-        dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
+        dataangel.io/s3-endpoint: "http://synelia.internal.truxonline.com:9000"
         dataangel.io/deployment-name: "prowlarr"
         dataangel.io/rclone-interval: "60s"
         dataangel.io/metrics-enabled: "true"

--- a/apps/20-media/radarr/overlays/prod/dataangel.yaml
+++ b/apps/20-media/radarr/overlays/prod/dataangel.yaml
@@ -16,7 +16,7 @@ spec:
         dataangel.io/bucket: "vixens-prod-radarr"
         dataangel.io/sqlite-paths: "/config/radarr.db"
         dataangel.io/fs-paths: "/config"
-        dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
+        dataangel.io/s3-endpoint: "http://synelia.internal.truxonline.com:9000"
         dataangel.io/deployment-name: "radarr"
         dataangel.io/rclone-interval: "60s"
         dataangel.io/metrics-enabled: "true"


### PR DESCRIPTION
## Summary

- Fix 403 Forbidden on rclone restore — prod secrets use `synelia.internal.truxonline.com:9000`, not the IP `192.168.111.69:9000`
- Mealie CrashLoopBackOff in prod due to this mismatch

## Test plan

- [ ] Mealie pod restarts and completes restore successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated S3 storage endpoint configuration across Meal-ie, Prowlarr, and Radarr services to use updated infrastructure endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->