### PR TITLE
fix(dataangel): disable mealie fs-paths pending MinIO credential fix

### DIFF
--- a/apps/10-home/mealie/overlays/prod/dataangel.yaml
+++ b/apps/10-home/mealie/overlays/prod/dataangel.yaml
@@ -15,7 +15,9 @@ spec:
       annotations:
         dataangel.io/bucket: "vixens-prod-mealie"
         dataangel.io/sqlite-paths: "/app/data/mealie.db"
-        dataangel.io/fs-paths: "/app/data"
+        # fs-paths disabled: MinIO credentials invalid (access key not found)
+        # TODO: re-enable after fixing credentials in Infisical prod /apps/10-home/mealie
+        # dataangel.io/fs-paths: "/app/data"
         dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
         dataangel.io/deployment-name: "mealie"
         dataangel.io/rclone-interval: "60s"


### PR DESCRIPTION
Pre-existing issue: mealie prod MinIO access key invalid. Disable fs-paths for now.