### PR TITLE
fix(dataangel): re-enable mealie prod with corrected MinIO credentials

### DIFF
--- a/apps/10-home/mealie/overlays/prod/dataangel.yaml
+++ b/apps/10-home/mealie/overlays/prod/dataangel.yaml
@@ -15,9 +15,7 @@ spec:
       annotations:
         dataangel.io/bucket: "vixens-prod-mealie"
         dataangel.io/sqlite-paths: "/app/data/mealie.db"
-        # fs-paths disabled: MinIO credentials invalid (access key not found)
-        # TODO: re-enable after fixing credentials in Infisical prod /apps/10-home/mealie
-        # dataangel.io/fs-paths: "/app/data"
+        dataangel.io/fs-paths: "/app/data"
         dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
         dataangel.io/deployment-name: "mealie"
         dataangel.io/rclone-interval: "60s"

--- a/apps/10-home/mealie/overlays/prod/kustomization.yaml
+++ b/apps/10-home/mealie/overlays/prod/kustomization.yaml
@@ -9,12 +9,10 @@ components:
   - ../../../../_shared/components/infisical/env-prod
   - ../../../../_shared/components/sync-wave/wave-11
   - ../../../../_shared/components/goldilocks/enabled
-  # dataangel disabled: MinIO credentials invalid (access key not found in MinIO)
-  # Re-enable after fixing LITESTREAM_ACCESS_KEY_ID in Infisical prod /apps/10-home/mealie
-  # - ../../../../_shared/components/dataangel
+  - ../../../../_shared/components/dataangel
 
 patches:
-  # - path: dataangel.yaml
+  - path: dataangel.yaml
 labels:
   - pairs:
       environment: prod


### PR DESCRIPTION
## Summary
- Fixed mealie's MinIO credentials in Infisical prod (old access key `1FBQY1HM1J79AGUL932L` didn't exist on MinIO)
- Updated to shared `vixens-prod-litestream` credentials (`A5FCF49AAF50AA54E037`) — same as prowlarr/radarr
- Re-enabled dataAngel component and `fs-paths` annotation for mealie prod

## Context
Prowlarr and radarr are already running dataAngel successfully in prod. Mealie was reverted to legacy pattern (PR #2348) due to invalid MinIO credentials. This PR re-enables dataAngel now that credentials are fixed in Infisical.

Closes #2349

🤖 Generated with [Claude Code](https://claude.com/claude-code)