### PR TITLE
fix(dataangel): use correct UID 911 for mealie LSIO image

### DIFF
--- a/apps/10-home/mealie/overlays/prod/dataangel.yaml
+++ b/apps/10-home/mealie/overlays/prod/dataangel.yaml
@@ -28,8 +28,8 @@ spec:
           $patch: delete
         - name: dataangel
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
+            runAsUser: 911
+            runAsGroup: 911
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:


### PR DESCRIPTION
## Summary
- Mealie uses linuxserver.io base image where `abc` user is UID 911:911
- DataAngel sidecar was running as 1000:1000 (correct for hotio/*arr apps, wrong for LSIO)
- Litestream couldn't write WAL to the database: `attempt to write a readonly database`
- Changed securityContext to `runAsUser: 911, runAsGroup: 911`

## Context
Follow-up to PR #2350. Credentials are now correct but litestream can't write to the DB due to UID mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system configuration settings for the production environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->