### PR TITLE
fix(dataangel): increase startup probe timeout for hydrus-client and homeassistant

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
@@ -32,6 +32,12 @@ spec:
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 9090
+            periodSeconds: 2
+            failureThreshold: 300
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/apps/20-media/hydrus-client/overlays/prod/dataangel.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/dataangel.yaml
@@ -41,6 +41,12 @@ spec:
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 9090
+            periodSeconds: 2
+            failureThreshold: 300
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:


### PR DESCRIPTION
## Summary
- hydrus-client and homeassistant hit the 5-minute startup probe limit (150*2s) during dataAngel restore phase
- S3 lock acquisition takes 2+ minutes (known issue #17), leaving insufficient time for restore
- Increases `failureThreshold` to 300 (10 minutes) for both apps

## Test plan
- [x] `kubectl kustomize` builds verified for both apps
- [ ] Verify both pods reach 2/2 Running after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment startup reliability through improved health checks across services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->