### PR TITLE
fix(dataangel): increase startup probe to 20min for hydrus-client and homeassistant

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
@@ -37,7 +37,7 @@ spec:
               path: /ready
               port: 9090
             periodSeconds: 2
-            failureThreshold: 300
+            failureThreshold: 600
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/apps/20-media/hydrus-client/overlays/prod/dataangel.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/dataangel.yaml
@@ -46,7 +46,7 @@ spec:
               path: /ready
               port: 9090
             periodSeconds: 2
-            failureThreshold: 300
+            failureThreshold: 600
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:


### PR DESCRIPTION
## Summary
- 10-minute startup probe timeout was still insufficient for hydrus-client and homeassistant
- S3 lock acquisition alone takes 6+ minutes (known dataangel issue #17)
- hydrus-client has 4 SQLite DBs + large rclone restore
- homeassistant lock took 10+ minutes before being killed
- Increases `failureThreshold` from 300 to 600 (20 minutes)

## Test plan
- [x] `kubectl kustomize` builds verified
- [ ] Verify both pods reach 2/2 Running after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)