### PR TITLE
fix(dataangel): add lock-ttl and increase timeout for slow starters

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
@@ -20,6 +20,7 @@ spec:
         dataangel.io/deployment-name: "homeassistant"
         dataangel.io/rclone-interval: "60s"
         dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-ttl: "120s"
     spec:
       initContainers:
         - name: fix-perms
@@ -37,7 +38,7 @@ spec:
               path: /ready
               port: 9090
             periodSeconds: 2
-            failureThreshold: 600
+            failureThreshold: 900
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/apps/20-media/hydrus-client/overlays/prod/dataangel.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/dataangel.yaml
@@ -23,6 +23,7 @@ spec:
         dataangel.io/deployment-name: "hydrus-client"
         dataangel.io/rclone-interval: "60s"
         dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-ttl: "120s"
     spec:
       initContainers:
         - name: fix-permissions
@@ -46,7 +47,7 @@ spec:
               path: /ready
               port: 9090
             periodSeconds: 2
-            failureThreshold: 600
+            failureThreshold: 900
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:


### PR DESCRIPTION
## Summary
- hydrus-client and homeassistant fail to start due to S3 lock contention (dataangel issue #17)
- With 15 dataangel instances hitting MinIO simultaneously, lock acquisition takes 10-20+ minutes
- Set `dataangel.io/lock-ttl: 120s` to reduce lock renewal pressure
- Increase startup probe to 30min (`failureThreshold: 900`) to survive worst-case lock delays

## Context
Previous attempts: PR #2356 (10min), PR #2357 (20min) - both insufficient.

## Test plan
- [x] `kubectl kustomize` builds verified
- [ ] Verify both pods reach 2/2 Running after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated lock TTL configuration across production deployments for optimized resource management
  * Increased startup probe failure threshold to improve system reliability during service initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->