### PR TITLE
fix(dataangel): upgrade to sha-77460f9 — exponential backoff on lock

### DIFF
--- a/apps/20-media/booklore/overlays/prod/dataangel.yaml
+++ b/apps/20-media/booklore/overlays/prod/dataangel.yaml
@@ -23,7 +23,7 @@ spec:
           $patch: delete
         - name: dataangel
           restartPolicy: Always
-          image: charchess/dataangel:sha-c95049b
+          image: charchess/dataangel:sha-77460f9
           imagePullPolicy: IfNotPresent
           command: ["./dataangel"]
           securityContext:

--- a/apps/_shared/components/dataangel/kustomization.yaml
+++ b/apps/_shared/components/dataangel/kustomization.yaml
@@ -101,4 +101,4 @@ patches:
 
 images:
   - name: charchess/dataangel
-    newTag: "sha-c95049b"
+    newTag: "sha-77460f9"


### PR DESCRIPTION
## Summary
- Upgrades dataAngel image from `sha-c95049b` to `sha-77460f9`
- Fixes lock contention issue (dataangel #17) causing hydrus-client and homeassistant restart loops
- New version: exponential backoff (2s→4s→8s→...→30s cap) with jitter on lock acquisition
- Reduces S3 API pressure from 15 concurrent instances

## Test plan
- [ ] Verify hydrus-client reaches 2/2 Running and stays stable
- [ ] Verify homeassistant reaches 2/2 Running and stays stable
- [ ] Confirm 13 other apps unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image dependencies to the latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->