### PR TITLE
feat(dataangel): disable S3 lock for single-replica deployments

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
@@ -20,7 +20,7 @@ spec:
         dataangel.io/deployment-name: "homeassistant"
         dataangel.io/rclone-interval: "60s"
         dataangel.io/metrics-enabled: "true"
-        dataangel.io/lock-ttl: "120s"
+        dataangel.io/lock-enabled: "false"
     spec:
       initContainers:
         - name: fix-perms
@@ -33,12 +33,6 @@ spec:
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
-          startupProbe:
-            httpGet:
-              path: /ready
-              port: 9090
-            periodSeconds: 2
-            failureThreshold: 900
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/apps/10-home/mealie/overlays/prod/dataangel.yaml
+++ b/apps/10-home/mealie/overlays/prod/dataangel.yaml
@@ -20,6 +20,7 @@ spec:
         dataangel.io/deployment-name: "mealie"
         dataangel.io/rclone-interval: "60s"
         dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
     spec:
       initContainers:
         - name: restore-config

--- a/apps/20-media/booklore/overlays/prod/dataangel.yaml
+++ b/apps/20-media/booklore/overlays/prod/dataangel.yaml
@@ -17,13 +17,14 @@ spec:
         dataangel.io/deployment-name: "booklore"
         dataangel.io/rclone-interval: "60s"
         dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
     spec:
       initContainers:
         - name: restore-config
           $patch: delete
         - name: dataangel
           restartPolicy: Always
-          image: charchess/dataangel:sha-77460f9
+          image: charchess/dataangel:sha-308d69b
           imagePullPolicy: IfNotPresent
           command: ["./dataangel"]
           securityContext:
@@ -56,6 +57,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.annotations['dataangel.io/metrics-enabled']
+            - name: DATA_GUARD_LOCK_ENABLED
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['dataangel.io/lock-enabled']
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/apps/20-media/frigate/overlays/prod/dataangel.yaml
+++ b/apps/20-media/frigate/overlays/prod/dataangel.yaml
@@ -18,6 +18,7 @@ spec:
         dataangel.io/deployment-name: "frigate"
         dataangel.io/rclone-interval: "60s"
         dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
     spec:
       initContainers:
         - name: restore-config

--- a/apps/20-media/hydrus-client/overlays/prod/dataangel.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/dataangel.yaml
@@ -23,7 +23,7 @@ spec:
         dataangel.io/deployment-name: "hydrus-client"
         dataangel.io/rclone-interval: "60s"
         dataangel.io/metrics-enabled: "true"
-        dataangel.io/lock-ttl: "120s"
+        dataangel.io/lock-enabled: "false"
     spec:
       initContainers:
         - name: fix-permissions
@@ -42,12 +42,6 @@ spec:
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
-          startupProbe:
-            httpGet:
-              path: /ready
-              port: 9090
-            periodSeconds: 2
-            failureThreshold: 900
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/apps/20-media/lazylibrarian/overlays/prod/dataangel.yaml
+++ b/apps/20-media/lazylibrarian/overlays/prod/dataangel.yaml
@@ -21,6 +21,7 @@ spec:
         dataangel.io/deployment-name: "lazylibrarian"
         dataangel.io/rclone-interval: "60s"
         dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
     spec:
       initContainers:
         - name: fix-permissions

--- a/apps/20-media/lidarr/overlays/prod/dataangel.yaml
+++ b/apps/20-media/lidarr/overlays/prod/dataangel.yaml
@@ -21,6 +21,7 @@ spec:
         dataangel.io/deployment-name: "lidarr"
         dataangel.io/rclone-interval: "60s"
         dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
     spec:
       initContainers:
         - name: fix-permissions

--- a/apps/20-media/mylar/overlays/prod/dataangel.yaml
+++ b/apps/20-media/mylar/overlays/prod/dataangel.yaml
@@ -21,6 +21,7 @@ spec:
         dataangel.io/deployment-name: "mylar"
         dataangel.io/rclone-interval: "60s"
         dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
     spec:
       initContainers:
         - name: fix-permissions

--- a/apps/20-media/prowlarr/overlays/prod/dataangel.yaml
+++ b/apps/20-media/prowlarr/overlays/prod/dataangel.yaml
@@ -21,6 +21,7 @@ spec:
         dataangel.io/deployment-name: "prowlarr"
         dataangel.io/rclone-interval: "60s"
         dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
     spec:
       initContainers:
         - name: fix-permissions

--- a/apps/20-media/radarr/overlays/prod/dataangel.yaml
+++ b/apps/20-media/radarr/overlays/prod/dataangel.yaml
@@ -20,6 +20,7 @@ spec:
         dataangel.io/deployment-name: "radarr"
         dataangel.io/rclone-interval: "60s"
         dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
     spec:
       initContainers:
         - name: fix-permissions

--- a/apps/20-media/sabnzbd/overlays/prod/dataangel.yaml
+++ b/apps/20-media/sabnzbd/overlays/prod/dataangel.yaml
@@ -21,6 +21,7 @@ spec:
         dataangel.io/deployment-name: "sabnzbd"
         dataangel.io/rclone-interval: "60s"
         dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
     spec:
       initContainers:
         - name: fix-permissions

--- a/apps/20-media/sonarr/overlays/prod/dataangel.yaml
+++ b/apps/20-media/sonarr/overlays/prod/dataangel.yaml
@@ -21,6 +21,7 @@ spec:
         dataangel.io/deployment-name: "sonarr"
         dataangel.io/rclone-interval: "60s"
         dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
     spec:
       initContainers:
         - name: fix-permissions

--- a/apps/20-media/whisparr/overlays/prod/dataangel.yaml
+++ b/apps/20-media/whisparr/overlays/prod/dataangel.yaml
@@ -21,6 +21,7 @@ spec:
         dataangel.io/deployment-name: "whisparr"
         dataangel.io/rclone-interval: "60s"
         dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
     spec:
       initContainers:
         - name: fix-permissions

--- a/apps/40-network/adguard-home/overlays/prod/dataangel.yaml
+++ b/apps/40-network/adguard-home/overlays/prod/dataangel.yaml
@@ -19,6 +19,7 @@ spec:
         dataangel.io/deployment-name: "adguard-home"
         dataangel.io/rclone-interval: "60s"
         dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
     spec:
       initContainers:
         - name: restore-config

--- a/apps/60-services/vaultwarden/overlays/prod/dataangel.yaml
+++ b/apps/60-services/vaultwarden/overlays/prod/dataangel.yaml
@@ -20,6 +20,7 @@ spec:
         dataangel.io/deployment-name: "vaultwarden"
         dataangel.io/rclone-interval: "60s"
         dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
     spec:
       initContainers:
         - name: fix-permissions

--- a/apps/_shared/components/dataangel/kustomization.yaml
+++ b/apps/_shared/components/dataangel/kustomization.yaml
@@ -43,6 +43,10 @@ patches:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.annotations['dataangel.io/lock-ttl']
+            - name: DATA_GUARD_LOCK_ENABLED
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['dataangel.io/lock-enabled']
             - name: DATA_GUARD_RCLONE_INTERVAL
               valueFrom:
                 fieldRef:
@@ -101,4 +105,4 @@ patches:
 
 images:
   - name: charchess/dataangel
-    newTag: "sha-77460f9"
+    newTag: "sha-308d69b"


### PR DESCRIPTION
## Summary
- Disable S3 distributed lock for all 15 prod apps (all single-replica Recreate strategy)
- Add `dataangel.io/lock-enabled: "false"` annotation to all apps
- Update dataangel image to `sha-308d69b` (lock disable feature from truxonline/dataangel)
- Clean up homeassistant/hydrus-client: remove `lock-ttl` and oversized `startupProbe` overrides

## Context
Lock contention (issue truxonline/dataangel#17) caused 20-30 min startup delays for homeassistant and hydrus-client, and restart storms across all 15 apps when image updates rolled out simultaneously. Since all prod apps use single-replica Recreate strategy, the distributed lock provides no benefit.

## Test plan
- [ ] All 15 apps reach 2/2 Running in prod
- [ ] hydrus-client and homeassistant start within default 5 min startup probe
- [ ] No CrashLoopBackOff on frigate or other apps
- [ ] Verify dataangel logs show lock disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled DataAngel lock functionality across multiple production deployments
  * Removed lock TTL configurations where applicable
  * Updated DataAngel component image version
  * Removed startup probe configurations from select deployments
  * Added lock-disabled annotation configuration to align runtime behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->