### PR TITLE
fix(dataangel): increase startup probe for slow-restore apps

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
@@ -33,6 +33,12 @@ spec:
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 9090
+            periodSeconds: 2
+            failureThreshold: 300
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/apps/20-media/frigate/overlays/prod/dataangel.yaml
+++ b/apps/20-media/frigate/overlays/prod/dataangel.yaml
@@ -31,6 +31,12 @@ spec:
           securityContext:
             runAsUser: 0
             runAsGroup: 0
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 9090
+            periodSeconds: 2
+            failureThreshold: 450
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/apps/20-media/hydrus-client/overlays/prod/dataangel.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/dataangel.yaml
@@ -42,6 +42,12 @@ spec:
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 9090
+            periodSeconds: 2
+            failureThreshold: 300
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:


### PR DESCRIPTION
## Summary
- Add startupProbe overrides for 3 apps with slow restore times
- homeassistant: 10 min (1 large DB + rclone filesystem)
- hydrus-client: 10 min (4 SQLite databases)
- frigate: 15 min (139 WAL files on emptyDir, full restore every restart)

## Context
PR #2360 disabled the S3 lock and removed the oversized startup probe overrides. However, these 3 apps genuinely need longer than the default 5 min startup probe to complete their restore phase, even without lock contention.

## Test plan
- [ ] homeassistant reaches 2/2 Running within 10 min
- [ ] hydrus-client reaches 2/2 Running within 10 min
- [ ] frigate reaches 2/2 Running within 15 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved service startup reliability across multiple deployments with health verification checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->