### PR TITLE
fix(dataangel): increase startup probe to 20min for slow-restore apps

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
@@ -38,7 +38,7 @@ spec:
               path: /ready
               port: 9090
             periodSeconds: 2
-            failureThreshold: 300
+            failureThreshold: 600
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/apps/20-media/frigate/overlays/prod/dataangel.yaml
+++ b/apps/20-media/frigate/overlays/prod/dataangel.yaml
@@ -36,7 +36,7 @@ spec:
               path: /ready
               port: 9090
             periodSeconds: 2
-            failureThreshold: 450
+            failureThreshold: 600
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/apps/20-media/hydrus-client/overlays/prod/dataangel.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/dataangel.yaml
@@ -47,7 +47,7 @@ spec:
               path: /ready
               port: 9090
             periodSeconds: 2
-            failureThreshold: 300
+            failureThreshold: 600
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:


### PR DESCRIPTION
## Summary
- Increase startup probe from 10/15 min to 20 min for homeassistant, hydrus-client, and frigate
- 10 min was insufficient: hydrus-client hit 301 probe failures before restore completed

## Context
Follow-up to #2361 which set initial probe overrides (300/300/450). The restore phase itself takes 10-15 min for these apps:
- **hydrus-client**: 4 SQLite databases + filesystem restore
- **homeassistant**: Large DB + rclone filesystem restore  
- **frigate**: 139 WAL file replay on emptyDir (full restore every restart)

## Test plan
- [ ] All 3 apps reach 2/2 Running within 20 min
- [ ] No startup probe failures in pod events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased startup probe tolerance across multiple services to improve reliability during initialization. Services now allow more consecutive failures during startup before being marked as unavailable, reducing false startup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->