### PR TITLE
fix(dataangel): bump frigate sizing to B-small for WAL replay

### DIFF
--- a/apps/20-media/frigate/overlays/prod/dataangel.yaml
+++ b/apps/20-media/frigate/overlays/prod/dataangel.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.dataangel: B-nano
+        vixens.io/sizing.dataangel: B-small
         vixens.io/sizing.litestream: null
         vixens.io/sizing.config-syncer: null
       annotations:


### PR DESCRIPTION
## Summary
- Bump frigate dataangel sizing from B-nano (128Mi) to B-small (512Mi)
- Frigate was OOMKilled during WAL replay (139 WAL files on emptyDir)

## Test plan
- [ ] Frigate reaches 2/2 Running without OOMKill

🤖 Generated with [Claude Code](https://claude.com/claude-code)