### PR TITLE
fix(dataangel): increase startup probe to 30min for HA and hydrus-client

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
@@ -38,7 +38,7 @@ spec:
               path: /ready
               port: 9090
             periodSeconds: 2
-            failureThreshold: 600
+            failureThreshold: 900
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/apps/20-media/hydrus-client/overlays/prod/dataangel.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/dataangel.yaml
@@ -47,7 +47,7 @@ spec:
               path: /ready
               port: 9090
             periodSeconds: 2
-            failureThreshold: 600
+            failureThreshold: 900
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:


### PR DESCRIPTION
## Summary
- Increase startup probe from 20 min to 30 min for homeassistant and hydrus-client
- Both apps hit the 20 min limit during restore/verification phase

## Context
These apps have large datasets:
- **hydrus-client**: 4 SQLite DBs + large filesystem (verify + rclone takes >20 min)
- **homeassistant**: Large DB + config filesystem (~19 min was not enough)

## Test plan
- [ ] homeassistant reaches 2/2 Running
- [ ] hydrus-client reaches 2/2 Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service initialization health check parameters in production environments. Adjusted failure tolerance thresholds to allow extended startup times before services are considered unavailable during the initialization phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->