### PR TITLE
fix(dataangel): increase startup probe to 2h for HA and hydrus-client

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
@@ -38,7 +38,7 @@ spec:
               path: /ready
               port: 9090
             periodSeconds: 2
-            failureThreshold: 900
+            failureThreshold: 3600
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/apps/20-media/hydrus-client/overlays/prod/dataangel.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/dataangel.yaml
@@ -47,7 +47,7 @@ spec:
               path: /ready
               port: 9090
             periodSeconds: 2
-            failureThreshold: 900
+            failureThreshold: 3600
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:


### PR DESCRIPTION
## Summary
- Increase startup probe to 2h (3600 * 2s) for homeassistant and hydrus-client
- DB verification phase takes >30 min for these large databases

## Test plan
- [ ] Both apps eventually reach 2/2 Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to improve system resilience and startup stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->