### PR TITLE
feat(dataangel): upgrade to sha-5b802c1 fast path + progress logging

### DIFF
--- a/apps/20-media/booklore/overlays/prod/dataangel.yaml
+++ b/apps/20-media/booklore/overlays/prod/dataangel.yaml
@@ -24,7 +24,7 @@ spec:
           $patch: delete
         - name: dataangel
           restartPolicy: Always
-          image: charchess/dataangel:sha-308d69b
+          image: charchess/dataangel:sha-5b802c1
           imagePullPolicy: IfNotPresent
           command: ["./dataangel"]
           securityContext:

--- a/apps/_shared/components/dataangel/kustomization.yaml
+++ b/apps/_shared/components/dataangel/kustomization.yaml
@@ -105,4 +105,4 @@ patches:
 
 images:
   - name: charchess/dataangel
-    newTag: "sha-308d69b"
+    newTag: "sha-5b802c1"


### PR DESCRIPTION
## Summary
- Update dataangel image to `sha-5b802c1`
- Addresses truxonline/dataangel#39 (fast verification for existing DBs)
- Addresses truxonline/dataangel#40 (progress logging during restore)

## Test plan
- [ ] hydrus-client and homeassistant start significantly faster
- [ ] Progress logs visible during restore phase
- [ ] All 15 apps reach 2/2 Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal service component to a new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->