### PR TITLE
revert(dataangel): rollback to sha-308d69b - CRITICAL prod outage

### DIFF
--- a/apps/20-media/booklore/overlays/prod/dataangel.yaml
+++ b/apps/20-media/booklore/overlays/prod/dataangel.yaml
@@ -24,7 +24,7 @@ spec:
           $patch: delete
         - name: dataangel
           restartPolicy: Always
-          image: charchess/dataangel:sha-5b802c1
+          image: charchess/dataangel:sha-308d69b
           imagePullPolicy: IfNotPresent
           command: ["./dataangel"]
           securityContext:

--- a/apps/_shared/components/dataangel/kustomization.yaml
+++ b/apps/_shared/components/dataangel/kustomization.yaml
@@ -105,4 +105,4 @@ patches:
 
 images:
   - name: charchess/dataangel
-    newTag: "sha-5b802c1"
+    newTag: "sha-308d69b"


### PR DESCRIPTION
## Summary
- **CRITICAL**: All 15 dataangel-enabled prod apps are in `ImagePullBackOff`
- Image `charchess/dataangel:sha-5b802c1` does not exist on Docker Hub
- Rolling back to last known working image `sha-308d69b`

## Changes
- `apps/_shared/components/dataangel/kustomization.yaml`: `sha-5b802c1` → `sha-308d69b`
- `apps/20-media/booklore/overlays/prod/dataangel.yaml`: inline image tag rollback

## Test plan
- [ ] Merge and promote to prod
- [ ] Verify all 15 apps recover from ImagePullBackOff
- [ ] Investigate why sha-5b802c1 is missing from Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)