### PR TITLE
fix(homeassistant): pin dataangel to sha-5b802c1 fast path

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
@@ -30,6 +30,7 @@ spec:
         - name: restore-db
           $patch: delete
         - name: dataangel
+          image: charchess/dataangel:sha-5b802c1
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000


### PR DESCRIPTION
## Summary
- HA dataangel restart-looping for 12h — slow verification in sha-308d69b exceeds 2h startup probe
- Pin **only homeassistant** to `sha-5b802c1` (fast path for existing DBs)
- All other apps stay on `sha-308d69b` until validated

## Test plan
- [ ] HA dataangel starts and passes startup probe
- [ ] If successful, upgrade all apps to sha-5b802c1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image configuration for improved deployment reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->