### PR TITLE
fix(homeassistant): upgrade dataangel to sha-72826be (30min rclone timeout)

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
@@ -30,7 +30,7 @@ spec:
         - name: restore-db
           $patch: delete
         - name: dataangel
-          image: charchess/dataangel:sha-5b802c1
+          image: charchess/dataangel:sha-72826be
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000


### PR DESCRIPTION
## Summary
- HA rclone restore killed after 10min with `signal: terminated` (issue truxonline/dataAngel#41)
- `sha-72826be` raises default restore timeout from 10min to 30min

## Test plan
- [ ] HA dataangel completes rclone restore without being killed
- [ ] HA reaches 2/2 Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment container image configuration to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->