### PR TITLE
feat(dataangel): upgrade all apps to sha-72826be

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
@@ -30,7 +30,6 @@ spec:
         - name: restore-db
           $patch: delete
         - name: dataangel
-          image: charchess/dataangel:sha-72826be
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/apps/20-media/booklore/overlays/prod/dataangel.yaml
+++ b/apps/20-media/booklore/overlays/prod/dataangel.yaml
@@ -24,7 +24,7 @@ spec:
           $patch: delete
         - name: dataangel
           restartPolicy: Always
-          image: charchess/dataangel:sha-308d69b
+          image: charchess/dataangel:sha-72826be
           imagePullPolicy: IfNotPresent
           command: ["./dataangel"]
           securityContext:

--- a/apps/_shared/components/dataangel/kustomization.yaml
+++ b/apps/_shared/components/dataangel/kustomization.yaml
@@ -105,4 +105,4 @@ patches:
 
 images:
   - name: charchess/dataangel
-    newTag: "sha-308d69b"
+    newTag: "sha-72826be"


### PR DESCRIPTION
## Summary
- Upgrade all 15 dataangel apps from `sha-308d69b` to `sha-72826be`
- Remove HA image pin (now inherits from shared component)
- Fixes hydrus-client restart loop (same issue as HA — no fast path on sha-308d69b)

### What's in sha-72826be
- **Fast path**: existing DBs validated via PRAGMA quick_check instead of full litestream restore
- **Progress logging**: visibility into restore operations
- **30min rclone timeout**: was hardcoded 10min, killed large filesystem restores (#41)

## Changes
- `_shared/components/dataangel/kustomization.yaml`: `sha-308d69b` → `sha-72826be`
- `booklore/overlays/prod/dataangel.yaml`: inline image tag update
- `homeassistant/overlays/prod/dataangel.yaml`: remove image pin (DRY)

## Test plan
- [ ] All 15 apps sync and reach 2/2 Running
- [ ] hydrus-client recovers from restart loop
- [ ] HA stays Running (no regression from removing pin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image versions for internal deployment infrastructure across multiple services. These changes ensure consistent versioning across different deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->