### PR TITLE
fix(booklore): migrate to grimmory v2.3.0

### DIFF
--- a/apps/20-media/booklore/base/deployment.yaml
+++ b/apps/20-media/booklore/base/deployment.yaml
@@ -93,7 +93,7 @@ spec:
       priorityClassName: vixens-low
       containers:
         - name: booklore
-          image: ghcr.io/booklore-app/booklore:v2.2.1
+          image: ghcr.io/grimmory-tools/grimmory:v2.3.0
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
## Summary
- booklore-app/booklore project closed, GHCR repo returns 401
- Successor: `ghcr.io/grimmory-tools/grimmory:v2.3.0`
- Image swap only — same port, same config

Closes #2377

## Test plan
- [ ] booklore pod pulls new image and starts
- [ ] WebUI accessible at booklore.truxonline.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to use a new application image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->