### PR TITLE
fix(booklore): increase startup probe to 30min for grimmory first boot

### DIFF
--- a/apps/20-media/booklore/base/deployment.yaml
+++ b/apps/20-media/booklore/base/deployment.yaml
@@ -149,7 +149,7 @@ spec:
             httpGet:
               path: /
               port: http
-            failureThreshold: 40
+            failureThreshold: 180
             periodSeconds: 10
             timeoutSeconds: 5
         - name: config-syncer


### PR DESCRIPTION
## Summary
- Grimmory v2.3.0 scans NFS library on first boot, takes >7min
- Startup probe: 40 → 180 (30min)

## Test plan
- [ ] Grimmory completes initialization and reaches 2/2 Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced service startup resilience by extending the initialization period, reducing unnecessary restart cycles during peak startup conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->