### PR TITLE
fix(booklore): increase dataangel sizing B-nano → B-small

### DIFF
--- a/apps/20-media/booklore/overlays/prod/dataangel.yaml
+++ b/apps/20-media/booklore/overlays/prod/dataangel.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.dataangel: B-nano
+        vixens.io/sizing.dataangel: B-small
         vixens.io/sizing.config-syncer: null
         vixens.io/sizing.restore-config: null
       annotations:


### PR DESCRIPTION
## Summary
- DataAngel sidecar on booklore was hitting CPU limit (46m/50m) causing rclone sync backup loop to fail with `signal: terminated`
- Upgrade sizing from B-nano (5m/50m CPU, 64Mi/128Mi mem) to B-small (25m/250m CPU, 256Mi mem)
- Restore phase works fine (3m27s), only the ongoing sync loop was affected

## Test plan
- [ ] Merge and promote to prod
- [ ] Hard-refresh booklore in ArgoCD
- [ ] Verify rclone sync loop succeeds (no more `signal: terminated` in dataangel logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)