### PR TITLE
feat(g4f): deploy gpt4free multi-provider LLM proxy

### DIFF
--- a/apps/60-services/g4f/base/deployment.yaml
+++ b/apps/60-services/g4f/base/deployment.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: g4f
+  labels:
+    app.kubernetes.io/name: g4f
+    vixens.io/vpa-mode: Auto
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: g4f
+  template:
+    metadata:
+      annotations:
+        vixens.io/fast-start: "true"
+        vixens.io/service-binding: "false"
+        vixens.io/no-long-connections: "true"
+      labels:
+        app.kubernetes.io/name: g4f
+        vixens.io/sizing: V-medium
+    spec:
+      priorityClassName: vixens-low
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: g4f
+          image: hlohaus789/g4f:latest
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 7900
+              name: vnc
+          env:
+            - name: TZ
+              value: "Europe/Paris"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 4Gi
+          volumeMounts:
+            - name: har-and-cookies
+              mountPath: /app/har_and_cookies
+            - name: generated-media
+              mountPath: /app/generated_media
+            - name: shm
+              mountPath: /dev/shm
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+      volumes:
+        - name: har-and-cookies
+          persistentVolumeClaim:
+            claimName: g4f-data
+        - name: generated-media
+          emptyDir: {}
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 2Gi

--- a/apps/60-services/g4f/base/ingress.yaml
+++ b/apps/60-services/g4f/base/ingress.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: g4f
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  rules:
+    - host: g4f.truxonline.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: g4f
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - g4f.truxonline.com
+      secretName: g4f-tls

--- a/apps/60-services/g4f/base/kustomization.yaml
+++ b/apps/60-services/g4f/base/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: services
+resources:
+  - deployment.yaml
+  - pvc.yaml
+  - service.yaml
+  - ingress.yaml

--- a/apps/60-services/g4f/base/pvc.yaml
+++ b/apps/60-services/g4f/base/pvc.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: g4f-data
+  labels:
+    app.kubernetes.io/name: g4f
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: synology-iscsi
+  resources:
+    requests:
+      storage: 1Gi

--- a/apps/60-services/g4f/base/service.yaml
+++ b/apps/60-services/g4f/base/service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: g4f
+spec:
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: g4f

--- a/apps/60-services/g4f/overlays/prod/kustomization.yaml
+++ b/apps/60-services/g4f/overlays/prod/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+components:
+  - ../../../../_shared/components/sync-wave/wave-9
+  - ../../../../_shared/components/goldilocks/enabled
+  - ../../../../_shared/components/nometrics

--- a/argocd/overlays/prod/apps/g4f.yaml
+++ b/argocd/overlays/prod/apps/g4f.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: g4f
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "9"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    path: apps/60-services/g4f/overlays/prod
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: prod-stable
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -81,6 +81,7 @@ resources:
   - apps/renovate.yaml
   - apps/stirling-pdf.yaml
   - apps/it-tools.yaml
+  - apps/g4f.yaml
   # apps/it-tools-ingress.yaml removed 2026-03-07 — ingress now managed by it-tools app directly (overlays/prod/kustomization.yaml)
   - apps/contacts.yaml
   - apps/external-dns-gandi.yaml


### PR DESCRIPTION
## Summary
- Deploy **gpt4free (g4f)** in prod as OpenAI-compatible API proxy for browser-based LLMs (Gemini, Grok, Kimi, etc.)
- Replaces originally planned webai-to-api (Gemini-only) with multi-provider solution
- Full image with Chrome + GUI, VNC for initial cookie auth, PVC for session persistence

## Details
- **Image:** `hlohaus789/g4f:latest`
- **Ingress:** `g4f.truxonline.com`
- **Namespace:** `services`
- **Sizing:** V-medium (100m/512Mi → 1cpu/4Gi) + 2Gi shm for Chrome
- **Storage:** 1Gi PVC (`synology-iscsi`) for `har_and_cookies/`
- **Strategy:** Recreate (RWO PVC)

## Post-deploy steps
1. `kubectl port-forward -n services svc/g4f 7900:7900`
2. VNC connect (password: `secret`), login to Gemini/Grok/Kimi
3. Cookies auto-persisted in PVC
4. API available at `https://g4f.truxonline.com/v1/chat/completions`

Closes #2375

## Test plan
- [ ] ArgoCD sync healthy
- [ ] Pod Running 1/1
- [ ] VNC accessible via port-forward
- [ ] `curl https://g4f.truxonline.com` returns GUI
- [ ] API endpoint responds at `/v1/chat/completions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added deployment configuration for the g4f service, now accessible at g4f.truxonline.com with HTTPS support and automated health monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->