### PR TITLE
fix(homeassistant): dataangel OOMKilled B-nano → V-small

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/dataangel.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.dataangel: B-nano
+        vixens.io/sizing.dataangel: V-small
         vixens.io/sizing.litestream: null
         vixens.io/sizing.config-syncer: null
         vixens.io/sizing.restore-config: null


### PR DESCRIPTION
## Summary
- dataangel init/sidecar OOMKilled in prod with `B-nano` sizing (128Mi limit)
- Root cause: `PRAGMA quick_check` on 794 MB SQLite DB exceeds memory limit
- Fix: upgrade to `V-small` (256Mi req / 1Gi limit, VPA auto-tuned)
- Same issue as booklore (#2380), but worse due to larger DB

## Test plan
- [ ] Pod restarts without OOMKill
- [ ] dataangel startup probe passes
- [ ] HA reaches Running 2/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated DataAngel deployment sizing tier from B-nano to V-small.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->