### PR TITLE
fix(g4f): use default storageClass instead of synology-iscsi

### DIFF
--- a/apps/60-services/g4f/base/pvc.yaml
+++ b/apps/60-services/g4f/base/pvc.yaml
@@ -8,7 +8,6 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: synology-iscsi
   resources:
     requests:
       storage: 1Gi


### PR DESCRIPTION
## Summary
- PVC provisioning failed: `storageclass "synology-iscsi" not found` in prod
- Prod cluster uses `synelia-iscsi-retain` as default SC
- Fix: remove explicit `storageClassName` to use cluster default

## Test plan
- [ ] PVC binds successfully
- [ ] g4f pod starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)