### PR TITLE
fix(g4f): use immediate binding SC to avoid ArgoCD deadlock

### DIFF
--- a/apps/60-services/g4f/base/pvc.yaml
+++ b/apps/60-services/g4f/base/pvc.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  storageClassName: synelia-iscsi-delete
   resources:
     requests:
       storage: 1Gi


### PR DESCRIPTION
## Summary
- PVC with `WaitForFirstConsumer` deadlocks ArgoCD sync (PVC Pending → ArgoCD won't create Deployment → PVC stays Pending)
- Switch to `synelia-iscsi-delete` (Immediate binding) to break the cycle
- Delete reclaim policy is fine for cookie/session storage

## Test plan
- [ ] PVC binds immediately
- [ ] g4f pod starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)