### PR TITLE
fix(g4f): add fsGroup for PVC write permissions

### DIFF
--- a/apps/60-services/g4f/base/deployment.yaml
+++ b/apps/60-services/g4f/base/deployment.yaml
@@ -23,6 +23,8 @@ spec:
         app.kubernetes.io/name: g4f
         vixens.io/sizing: V-medium
     spec:
+      securityContext:
+        fsGroup: 1201
       priorityClassName: vixens-low
       tolerations:
         - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
## Summary
- g4f-api crashes with `PermissionError: Permission denied: './har_and_cookies/private_key.pem'`
- Container runs as `seluser` (1200:1201), PVC owned by root
- Fix: add `fsGroup: 1201` to pod securityContext

## Test plan
- [ ] g4f-api starts without PermissionError
- [ ] Pod reaches Ready 1/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pod security configuration to enhance system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->