### PR TITLE
chore(dataangel): upgrade sizing B-nano → V-small for SQLite apps

### DIFF
--- a/apps/10-home/mealie/overlays/dev/patches/dataangel-test.yaml
+++ b/apps/10-home/mealie/overlays/dev/patches/dataangel-test.yaml
@@ -8,7 +8,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.dataangel: B-nano
+        vixens.io/sizing.dataangel: V-small
       annotations:
         dataangel.io/bucket: "vixens-dev-mealie"
         dataangel.io/sqlite-paths: "/app/data/mealie.db"

--- a/apps/10-home/mealie/overlays/prod/dataangel.yaml
+++ b/apps/10-home/mealie/overlays/prod/dataangel.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.dataangel: B-nano
+        vixens.io/sizing.dataangel: V-small
         vixens.io/sizing.litestream: null
         vixens.io/sizing.config-syncer: null
         vixens.io/sizing.restore-config: null

--- a/apps/20-media/hydrus-client/overlays/prod/dataangel.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/dataangel.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.dataangel: B-nano
+        vixens.io/sizing.dataangel: V-small
         vixens.io/sizing.litestream: null
         vixens.io/sizing.fix-permissions: null
         vixens.io/sizing.check-integrity: null

--- a/apps/20-media/lazylibrarian/overlays/prod/dataangel.yaml
+++ b/apps/20-media/lazylibrarian/overlays/prod/dataangel.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.dataangel: B-nano
+        vixens.io/sizing.dataangel: V-small
         vixens.io/sizing.litestream: null
         vixens.io/sizing.config-syncer: null
         vixens.io/sizing.fix-permissions: null

--- a/apps/20-media/lidarr/overlays/prod/dataangel.yaml
+++ b/apps/20-media/lidarr/overlays/prod/dataangel.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.dataangel: B-nano
+        vixens.io/sizing.dataangel: V-small
         vixens.io/sizing.litestream: null
         vixens.io/sizing.config-syncer: null
         vixens.io/sizing.fix-permissions: null

--- a/apps/20-media/mylar/overlays/prod/dataangel.yaml
+++ b/apps/20-media/mylar/overlays/prod/dataangel.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.dataangel: B-nano
+        vixens.io/sizing.dataangel: V-small
         vixens.io/sizing.litestream: null
         vixens.io/sizing.config-syncer: null
         vixens.io/sizing.fix-permissions: null

--- a/apps/20-media/prowlarr/overlays/prod/dataangel.yaml
+++ b/apps/20-media/prowlarr/overlays/prod/dataangel.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.dataangel: B-nano
+        vixens.io/sizing.dataangel: V-small
         vixens.io/sizing.litestream: null
         vixens.io/sizing.config-syncer: null
         vixens.io/sizing.fix-permissions: null

--- a/apps/20-media/radarr/overlays/prod/dataangel.yaml
+++ b/apps/20-media/radarr/overlays/prod/dataangel.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.dataangel: B-nano
+        vixens.io/sizing.dataangel: V-small
         vixens.io/sizing.litestream: null
         vixens.io/sizing.config-syncer: null
         vixens.io/sizing.fix-permissions: null

--- a/apps/20-media/sabnzbd/overlays/prod/dataangel.yaml
+++ b/apps/20-media/sabnzbd/overlays/prod/dataangel.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.dataangel: B-nano
+        vixens.io/sizing.dataangel: V-small
         vixens.io/sizing.litestream: null
         vixens.io/sizing.config-syncer: null
         vixens.io/sizing.fix-permissions: null

--- a/apps/20-media/sonarr/overlays/prod/dataangel.yaml
+++ b/apps/20-media/sonarr/overlays/prod/dataangel.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.dataangel: B-nano
+        vixens.io/sizing.dataangel: V-small
         vixens.io/sizing.litestream: null
         vixens.io/sizing.config-syncer: null
         vixens.io/sizing.fix-permissions: null

--- a/apps/20-media/whisparr/overlays/prod/dataangel.yaml
+++ b/apps/20-media/whisparr/overlays/prod/dataangel.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.dataangel: B-nano
+        vixens.io/sizing.dataangel: V-small
         vixens.io/sizing.litestream: null
         vixens.io/sizing.config-syncer: null
         vixens.io/sizing.fix-permissions: null

--- a/apps/60-services/vaultwarden/overlays/prod/dataangel.yaml
+++ b/apps/60-services/vaultwarden/overlays/prod/dataangel.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.dataangel: B-nano
+        vixens.io/sizing.dataangel: V-small
         vixens.io/sizing.litestream: null
         vixens.io/sizing.config-syncer: null
         vixens.io/sizing.fix-permissions: null


### PR DESCRIPTION
## Summary
- Upgrade dataangel sizing from `B-nano` (128Mi limit) to `V-small` (1Gi limit, VPA auto-tuned) for all apps with `sqlite-paths`
- Prevents OOMKill during `PRAGMA quick_check` and litestream WAL replay as databases grow
- Same fix as homeassistant (#2384) and booklore (#2380), applied to all remaining SQLite apps

## Apps updated (12 files)
- **home:** mealie (prod + dev)
- **media:** prowlarr, radarr, sonarr, lidarr, mylar, whisparr, sabnzbd, lazylibrarian, hydrus-client
- **services:** vaultwarden

## Apps unchanged
- **adguard-home** — FS-only (no SQLite), stays B-nano

## Sizing comparison
| | B-nano (before) | V-small (after) |
|---|---|---|
| CPU req/lim | 5m / 50m | 25m / 100m |
| Mem req/lim | 64Mi / 128Mi | 256Mi / 1Gi |
| VPA | No | Auto-tuned |

Closes #2367

## Test plan
- [ ] All pods restart without OOMKill
- [ ] ArgoCD apps Synced/Healthy
- [ ] VPA recommendations generated for dataangel containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resource sizing configuration labels across 11 services (Mealie, Hydrus Client, LazyLibrarian, Lidarr, Mylar, Prowlarr, Radarr, Sabnzbd, Sonarr, Whisparr, Vaultwarden) in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->