### PR TITLE
feat(kyverno): add terminationMessagePolicy mutation

### DIFF
--- a/apps/00-infra/kyverno/base/policies/kustomization.yaml
+++ b/apps/00-infra/kyverno/base/policies/kustomization.yaml
@@ -41,6 +41,7 @@ resources:
   - mutate-revision-history-limit.yaml
   - mutate-security-context.yaml
   - mutate-sidecar-probes.yaml
+  - mutate-termination-message-policy.yaml
   - policy-exception-argocd.yaml
   - policy-exception-cainjector.yaml
   - policy-exception-mixed-sizing.yaml

--- a/apps/00-infra/kyverno/base/policies/mutate-termination-message-policy.yaml
+++ b/apps/00-infra/kyverno/base/policies/mutate-termination-message-policy.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: mutate-termination-message-policy
+  annotations:
+    policies.kyverno.io/title: Auto-inject terminationMessagePolicy
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: low
+    policies.kyverno.io/description: >-
+      Sets terminationMessagePolicy=FallbackToLogsOnError on all containers
+      so crash logs appear in kubectl describe and ArgoCD UI.
+spec:
+  background: false
+  rules:
+    - name: inject-containers-termination-policy
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kyverno
+      mutate:
+        foreach:
+          - list: "request.object.spec.containers"
+            patchStrategicMerge:
+              spec:
+                containers:
+                  - name: "{{ element.name }}"
+                    terminationMessagePolicy: FallbackToLogsOnError
+
+    - name: inject-initcontainers-termination-policy
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kyverno
+      preconditions:
+        all:
+          - key: '{{ length(request.object.spec.initContainers || `[]`) }}'
+            operator: GreaterThanOrEquals
+            value: 1
+      mutate:
+        foreach:
+          - list: "request.object.spec.initContainers"
+            patchStrategicMerge:
+              spec:
+                initContainers:
+                  - name: "{{ element.name }}"
+                    terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
## Summary
- Add Kyverno ClusterPolicy `mutate-termination-message-policy` that auto-injects `terminationMessagePolicy: FallbackToLogsOnError` on all containers and initContainers
- Excludes `kube-system` and `kyverno` namespaces
- Crash logs will now appear in `kubectl describe` and ArgoCD UI instead of empty `/dev/termination-log`

Closes #2305

## Test plan
- [ ] ArgoCD syncs Kyverno policies after merge
- [ ] Delete a pod: `kubectl delete pod <pod> -n <ns>`
- [ ] Verify: `kubectl get pod <pod> -o jsonpath='{.spec.containers[*].terminationMessagePolicy}'` → `FallbackToLogsOnError`
- [ ] Check initContainers also get the policy applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a cluster-wide policy that automatically configures termination message handling for Pod containers and init containers, with exclusions for designated system namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->