### PR TITLE
fix(fluent-bit): remove unsupported Loki output properties

### DIFF
--- a/apps/02-monitoring/fluent-bit/base/values.yaml
+++ b/apps/02-monitoring/fluent-bit/base/values.yaml
@@ -83,6 +83,3 @@ config:
         Line_Format json
         Retry_Limit 5
         Workers 1
-        Batch_Size 1048576
-        net.connect_timeout 30
-        net.keepalive on


### PR DESCRIPTION
## Summary
- Remove `Batch_Size`, `net.connect_timeout`, `net.keepalive` — not supported by the Loki output plugin
- Keeps `Workers 1` which is valid

## Test plan
- [ ] Fluent Bit pods start without config errors
- [ ] Logs flowing to Loki

🤖 Generated with [Claude Code](https://claude.com/claude-code)