### PR TITLE
fix(loki): upgrade sizing to V-small (1Gi memory limit)

### DIFF
--- a/apps/02-monitoring/loki/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/loki/overlays/prod/kustomization.yaml
@@ -28,5 +28,5 @@ patches:
         template:
           metadata:
             labels:
-              vixens.io/sizing.loki: G-medium
+              vixens.io/sizing.loki: V-small
   - path: resources-patch.yaml

--- a/apps/02-monitoring/loki/overlays/prod/resources-patch.yaml
+++ b/apps/02-monitoring/loki/overlays/prod/resources-patch.yaml
@@ -1,10 +1,8 @@
 ---
 # Explicit resource override for loki prod.
-# Bypasses Kyverno 'G-medium' sizing (512Mi req/limit) via PolicyException.
-# Actual usage: ~162Mi. Using 256Mi request / 512Mi limit to:
-# - Reduce memory pressure on cluster (512Mi -> 256Mi request = 256Mi freed)
-# - Keep 512Mi limit to avoid OOMKill during log ingestion spikes
-# - Free 256Mi on powder node to allow robusta-runner scheduling
+# V-small sizing (25m/256Mi req, 100m/1Gi lim) is close but we keep
+# custom CPU limit (1 core) for log ingestion spikes.
+# Upgraded from 512Mi → 1Gi limit to handle Fluent Bit burst writes.
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -21,4 +19,4 @@ spec:
               memory: 256Mi
             limits:
               cpu: "1"
-              memory: 512Mi
+              memory: 1Gi


### PR DESCRIPTION
## Summary
- Loki OOMKills under Fluent Bit burst writes (9 restarts, "empty ring" errors)
- Upgrade memory limit from 512Mi → 1Gi (sizing label G-medium → V-small)
- CPU limit unchanged (1 core)

## Test plan
- [ ] Loki stable without restarts
- [ ] Fluent Bit logs flowing successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production environment configuration for Loki monitoring service with adjustments to resource sizing and memory allocation parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->