### PR TITLE
feat(monitoring): swap Prometheus for VictoriaMetrics in prod

### DIFF
--- a/apps/02-monitoring/grafana/base/values.yaml
+++ b/apps/02-monitoring/grafana/base/values.yaml
@@ -19,9 +19,9 @@ datasources:
   datasources.yaml:
     apiVersion: 1
     datasources:
-      - name: Prometheus
+      - name: VictoriaMetrics
         type: prometheus
-        url: http://prometheus-server.monitoring.svc.cluster.local
+        url: http://vmsingle-victoria-metrics-victoria-metrics-k8s-stack.monitoring.svc.cluster.local:8428
         access: proxy
         isDefault: true
         editable: true

--- a/argocd/overlays/prod/apps/victoria-metrics.yaml
+++ b/argocd/overlays/prod/apps/victoria-metrics.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: victoria-metrics
+  namespace: argocd
+  labels:
+    vixens.lab/environment: prod
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "7"
+spec:
+  project: default
+  sources:
+    - repoURL: https://victoriametrics.github.io/helm-charts
+      chart: victoria-metrics-k8s-stack
+      targetRevision: 0.72.5
+      helm:
+        releaseName: victoria-metrics
+        valueFiles:
+          - $values/apps/02-monitoring/victoria-metrics/base/values.yaml
+    - repoURL: https://github.com/charchess/vixens.git
+      targetRevision: prod-stable
+      ref: values
+    - repoURL: https://github.com/charchess/vixens.git
+      targetRevision: prod-stable
+      path: apps/02-monitoring/victoria-metrics/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -36,8 +36,9 @@ resources:
   - apps/mosquitto.yaml
   - apps/mealie.yaml
   - apps/birdnet-go.yaml
-  - apps/prometheus.yaml
-  - apps/prometheus-ingress.yaml
+  - apps/victoria-metrics.yaml
+  # - apps/prometheus.yaml  # replaced by victoria-metrics (issue #2354)
+  # - apps/prometheus-ingress.yaml  # replaced by victoria-metrics (issue #2354)
   - apps/grafana.yaml
   - apps/grafana-ingress.yaml
   - apps/homepage.yaml


### PR DESCRIPTION
## Summary
- Replace Prometheus (1.6GiB RAM) with VictoriaMetrics k8s-stack (estimated 300-500Mi)
- Grafana datasource updated to VictoriaMetrics (drop-in Prometheus-compatible)
- VM operator auto-converts existing ServiceMonitors
- Prometheus apps commented out (ArgoCD prune will clean up)

Closes #2354 (Phase 3)

## Changes
- **New:** `argocd/overlays/prod/apps/victoria-metrics.yaml`
- **Modified:** `argocd/overlays/prod/kustomization.yaml` — swap prometheus → victoria-metrics
- **Modified:** `apps/02-monitoring/grafana/base/values.yaml` — datasource URL

## Test plan
- [ ] VictoriaMetrics pods Running in prod
- [ ] Prometheus pods pruned by ArgoCD
- [ ] Grafana connects to VictoriaMetrics datasource
- [ ] Dashboards display metrics
- [ ] Alertmanager receives alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Grafana datasource configuration to use VictoriaMetrics for metrics collection
  * Updated production deployment configuration for monitoring infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->