### PR TITLE
fix(monitoring): shorten VM resource names and enable ServerSideApply

### DIFF
--- a/apps/02-monitoring/victoria-metrics/base/values.yaml
+++ b/apps/02-monitoring/victoria-metrics/base/values.yaml
@@ -2,6 +2,10 @@
 # VictoriaMetrics K8s Stack — replaces Prometheus
 # Chart: victoria-metrics-k8s-stack 0.72.5
 
+# Shorten resource name prefix to avoid >63 char Service names
+# (victoria-metrics-victoria-metrics-k8s-stack-* was 45 chars before suffix)
+fullnameOverride: vm-stack
+
 # --- VM Operator ---
 victoria-metrics-operator:
   enabled: true

--- a/argocd/overlays/dev/apps/victoria-metrics.yaml
+++ b/argocd/overlays/dev/apps/victoria-metrics.yaml
@@ -33,3 +33,4 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=false
+      - ServerSideApply=true

--- a/argocd/overlays/prod/apps/victoria-metrics.yaml
+++ b/argocd/overlays/prod/apps/victoria-metrics.yaml
@@ -35,3 +35,4 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=false
+      - ServerSideApply=true


### PR DESCRIPTION
## Summary

Fixes two pre-existing ArgoCD sync failures on victoria-metrics:

- **Service name > 63 chars**: `victoria-metrics-victoria-metrics-k8s-stack-kube-controller-manager` (73 chars) — fixed by adding `fullnameOverride: vm-stack` which shortens all resource prefixes
- **ConfigMap annotations > 262144 bytes**: `node-exporter-full` Grafana dashboard too large for `last-applied-configuration` annotation — fixed by enabling `ServerSideApply=true` in ArgoCD syncOptions

**Trade-off**: VMSingle CR rename causes the operator to create a new PVC. Historical metrics (30d) are lost but will rebuild with the reduced-cardinality config from #2399.

## Test plan

- [ ] ArgoCD syncs victoria-metrics to Synced+Healthy (no more SyncFailed)
- [ ] All VM pods running (vmagent, vmsingle, vmalert, alertmanager)
- [ ] Grafana dashboards loading data
- [ ] Verify old orphaned PVC can be cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Victoria Metrics Helm chart configuration with a standardized resource naming override (`vm-stack`).
  * Enabled server-side apply synchronization for Victoria Metrics deployments in development and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->