### PR TITLE
fix(monitoring): disable node-exporter-full dashboard ConfigMap

### DIFF
--- a/apps/02-monitoring/victoria-metrics/base/values.yaml
+++ b/apps/02-monitoring/victoria-metrics/base/values.yaml
@@ -204,6 +204,9 @@ grafana:
 # --- Default scrape configs ---
 defaultDashboards:
   enabled: true
+  dashboards:
+    node-exporter-full:
+      enabled: false  # Too large for K8s annotation limit (>262144 bytes)
 
 kubelet:
   enabled: true


### PR DESCRIPTION
## Summary

The `node-exporter-full` Grafana dashboard ConfigMap exceeds the Kubernetes 262144-byte annotation limit, even with `ServerSideApply=true` (added in #2400). This is the last remaining sync failure for victoria-metrics.

Disables this specific dashboard via chart values. It can be imported directly in Grafana from community dashboards if needed.

## Test plan

- [ ] ArgoCD syncs victoria-metrics to Synced+Healthy (0 failures)
- [ ] Other dashboards still present in Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled the node-exporter-full dashboard by default in monitoring configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->