### PR TITLE
feat(snapshots): enable iSCSI snapshots on prod

### DIFF
--- a/apps/00-infra/snapshot-controller/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/snapshot-controller/overlays/prod/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+  - includeTemplates: true
+    pairs:
+      vixens.lab/environment: prod
+resources:
+  - ../../base
+components:
+  - ../../../../_shared/components/sync-wave/wave-0
+  - ../../../../_shared/components/goldilocks/enabled

--- a/argocd/overlays/prod/apps/snapshot-controller.yaml
+++ b/argocd/overlays/prod/apps/snapshot-controller.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: snapshot-controller
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "-5"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/charchess/vixens.git
+    path: apps/00-infra/snapshot-controller/overlays/prod
+    targetRevision: prod-stable
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: snapshot-controller
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - PrunePropagationPolicy=foreground

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -28,6 +28,7 @@ resources:
   - apps/cert-manager-secrets.yaml
   - apps/cert-manager-webhook-gandi.yaml
   - apps/cert-manager-config.yaml
+  - apps/snapshot-controller.yaml
   - apps/synology-csi-secrets.yaml
   - apps/synology-csi.yaml
   - apps/nfs-storage.yaml


### PR DESCRIPTION
## Summary

- Add **prod overlay** for snapshot-controller (2 replicas, goldilocks, sync-wave-0)
- Register **snapshot-controller** in ArgoCD prod app-of-apps (sync-wave `-5`, ServerSideApply, `targetRevision: prod-stable`)
- synology-csi base changes (csi-snapshotter sidecar + snapshot RBAC) already apply to prod via existing overlay

Follows #2403 (dev deployment validated)

## Expected impact on prod

| Component | Effect |
|---|---|
| snapshot-controller | New app — no existing resources affected |
| synology-csi controller | **Rolling restart** (new sidecar container) — provisioning interrupted ~10s |
| synology-csi node DaemonSet | No change, no restart |
| Existing PVCs/volumes | No impact — already mounted volumes unaffected |

## Test plan

- [ ] Merge + promote `prod-stable` tag
- [ ] snapshot-controller: Synced/Healthy, 2/2 pods running
- [ ] CRDs installed: `kubectl api-resources | grep snapshot`
- [ ] VolumeSnapshotClasses: `kubectl get volumesnapshotclass`
- [ ] synology-csi controller: restarts with 5 containers (includes csi-snapshotter)
- [ ] No impact on node DaemonSet or running workloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added production deployment infrastructure configuration for the snapshot-controller system component, including automated sync settings and namespace management to enable production environment deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->