### PR TITLE
fix(synology-csi): pin image to v1.2.1, drop edge tag

### DIFF
--- a/apps/01-storage/synology-csi/base/controller.yaml
+++ b/apps/01-storage/synology-csi/base/controller.yaml
@@ -74,7 +74,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: synology-csi-plugin
-          image: ghcr.io/zebernst/synology-csi:edge
+          image: ghcr.io/zebernst/synology-csi:v1.2.1
           args:
             - --nodeid=$(KUBE_NODE_NAME)
             - --endpoint=$(CSI_ENDPOINT)

--- a/apps/01-storage/synology-csi/base/kustomization.yaml
+++ b/apps/01-storage/synology-csi/base/kustomization.yaml
@@ -16,6 +16,6 @@ patches:
 labels:
   - pairs:
       app.kubernetes.io/name: synology-csi
-      app.kubernetes.io/version: v1.1.1
+      app.kubernetes.io/version: v1.2.1
       vixens.lab/managed-by: argocd
     includeSelectors: true

--- a/apps/01-storage/synology-csi/base/node.yaml
+++ b/apps/01-storage/synology-csi/base/node.yaml
@@ -54,7 +54,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: synology-csi-plugin
-          image: ghcr.io/zebernst/synology-csi:v1.2.0
+          image: ghcr.io/zebernst/synology-csi:v1.2.1
           args:
             - --nodeid=$(KUBE_NODE_NAME)
             - --endpoint=$(CSI_ENDPOINT)


### PR DESCRIPTION
## Summary

- Pin `synology-csi-plugin` image to `v1.2.1` on both controller and node (was `edge` / `v1.2.0`)
- Update `app.kubernetes.io/version` label from `v1.1.1` to `v1.2.1`

Closes #2181

## Validation

- Dev: 1 week on `edge` (= v1.2.1), zero errors, zero iSCSI disconnects, zero mount failures
- Prod node: running v1.2.0 since initial deployment, zero issues

## Expected impact

- **Dev**: controller hibernated (0 replicas), node already on edge — image pull only on next start
- **Prod**: controller rolling restart (image change), **node DaemonSet rolling restart** (v1.2.0 → v1.2.1) — one node at a time, mounted volumes unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Synology CSI storage plugin to version v1.2.1 across all components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->