### PR TITLE
fix(synology-csi): remove version label from immutable selectors

### DIFF
--- a/apps/01-storage/synology-csi/base/kustomization.yaml
+++ b/apps/01-storage/synology-csi/base/kustomization.yaml
@@ -16,6 +16,8 @@ patches:
 labels:
   - pairs:
       app.kubernetes.io/name: synology-csi
-      app.kubernetes.io/version: v1.2.1
       vixens.lab/managed-by: argocd
     includeSelectors: true
+  - pairs:
+      app.kubernetes.io/version: v1.2.1
+    includeSelectors: false


### PR DESCRIPTION
## Summary

- Split kustomize `labels` block to keep `app.kubernetes.io/version` out of `matchLabels` selectors
- Fixes immutable selector error when bumping version (`v1.1.1` → `v1.2.1`)

## Required manual action (prod)

After merge + prod-stable promotion, the existing StatefulSet/DaemonSets must be deleted and recreated because their current selectors contain `app.kubernetes.io/version: v1.1.1` which is immutable:

```bash
kubectl -n synology-csi delete statefulset synology-csi-controller --cascade=orphan
kubectl -n synology-csi delete daemonset synology-csi-node --cascade=orphan
kubectl -n synology-csi delete daemonset iscsi-lock-cleanup --cascade=orphan
# ArgoCD will recreate them with correct selectors
```

`--cascade=orphan` keeps pods running during the delete, minimizing disruption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)