### PR TITLE
fix(synology-csi): correct image tag to v1.2.0

### DIFF
--- a/apps/01-storage/synology-csi/base/controller.yaml
+++ b/apps/01-storage/synology-csi/base/controller.yaml
@@ -74,7 +74,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: synology-csi-plugin
-          image: ghcr.io/zebernst/synology-csi:v1.2.1
+          image: ghcr.io/zebernst/synology-csi:v1.2.0
           args:
             - --nodeid=$(KUBE_NODE_NAME)
             - --endpoint=$(CSI_ENDPOINT)

--- a/apps/01-storage/synology-csi/base/kustomization.yaml
+++ b/apps/01-storage/synology-csi/base/kustomization.yaml
@@ -19,5 +19,5 @@ labels:
       vixens.lab/managed-by: argocd
     includeSelectors: true
   - pairs:
-      app.kubernetes.io/version: v1.2.1
+      app.kubernetes.io/version: v1.2.0
     includeSelectors: false

--- a/apps/01-storage/synology-csi/base/node.yaml
+++ b/apps/01-storage/synology-csi/base/node.yaml
@@ -54,7 +54,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: synology-csi-plugin
-          image: ghcr.io/zebernst/synology-csi:v1.2.1
+          image: ghcr.io/zebernst/synology-csi:v1.2.0
           args:
             - --nodeid=$(KUBE_NODE_NAME)
             - --endpoint=$(CSI_ENDPOINT)


### PR DESCRIPTION
## Summary
- Tag `v1.2.1` does not exist on `ghcr.io/zebernst/synology-csi` — latest release is `v1.2.0`
- Fixes `ImagePullBackOff` on controller and node pods after PR #2407 forced workload recreation
- Corrects image tag in controller.yaml, node.yaml, and version label in kustomization.yaml

## Context
PR #2406 incorrectly pinned image to `v1.2.1`. Available tags: v1.1.0–v1.2.0, edge, latest.

## Test plan
- [ ] Pods pull `v1.2.0` image successfully
- [ ] Controller 5/5 containers running
- [ ] Node DaemonSet fully rolled out on all nodes
- [ ] No impact on existing iSCSI volumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Synology CSI plugin version to v1.2.0 across storage configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->