### PR TITLE
feat(homeassistant): align dev on DataAngel (#2182)

### DIFF
--- a/apps/10-home/homeassistant/overlays/dev/dataangel.yaml
+++ b/apps/10-home/homeassistant/overlays/dev/dataangel.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homeassistant
+spec:
+  template:
+    metadata:
+      labels:
+        vixens.io/sizing.dataangel: V-small
+        vixens.io/sizing.litestream: null
+        vixens.io/sizing.config-syncer: null
+        vixens.io/sizing.restore-config: null
+        vixens.io/sizing.restore-db: null
+      annotations:
+        dataangel.io/bucket: "vixens-dev-homeassistant"
+        dataangel.io/sqlite-paths: "/config/home-assistant_v2.db"
+        dataangel.io/fs-paths: "/config"
+        dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
+        dataangel.io/deployment-name: "homeassistant"
+        dataangel.io/rclone-interval: "60s"
+        dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
+    spec:
+      initContainers:
+        - name: fix-perms
+          $patch: delete
+        - name: restore-config
+          $patch: delete
+        - name: restore-db
+          $patch: delete
+        - name: dataangel
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 9090
+            periodSeconds: 2
+            failureThreshold: 3600
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: homeassistant-secrets
+                  key: LITESTREAM_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: homeassistant-secrets
+                  key: LITESTREAM_SECRET_ACCESS_KEY
+          volumeMounts:
+            - mountPath: /data
+              $patch: delete
+            - name: config
+              mountPath: /config
+      containers:
+        - name: litestream
+          $patch: delete
+        - name: config-syncer
+          $patch: delete

--- a/apps/10-home/homeassistant/overlays/dev/kustomization.yaml
+++ b/apps/10-home/homeassistant/overlays/dev/kustomization.yaml
@@ -1,11 +1,14 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
-components:
-- ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/revision-history-limit
 kind: Kustomization
 namespace: homeassistant
 resources:
-- ../../base
-- ingress.yaml
-- ingressroute-udp.yaml
+  - ../../base
+  - ingress.yaml
+  - ingressroute-udp.yaml
+components:
+  - ../../../../_shared/components/dev-hibernate
+  - ../../../../_shared/components/revision-history-limit
+  - ../../../../_shared/components/dataangel
+patches:
+  - path: dataangel.yaml


### PR DESCRIPTION
## Summary
- Dev now uses DataAngel sidecar (same as prod) instead of separate litestream + config-syncer + fix-perms + restore-* chain
- Ensures dev/prod parity for the backup stack
- Bucket: `vixens-dev-homeassistant`

## Changes
- **New:** `overlays/dev/dataangel.yaml` — DataAngel annotations + container deletions (mirrors prod)
- **Modified:** `overlays/dev/kustomization.yaml` — add dataangel component + patch

## Resulting dev pod structure
```
Init: dataangel (sidecar) → install-python-deps → config-init
Run:  homeassistant
```
Same as prod (minus prod-specific resource patches).

## Test plan
- [ ] `kustomize build` passes (verified locally)
- [ ] ArgoCD syncs without errors
- [ ] Scale up: verify DataAngel init container starts and restores from S3
- [ ] Verify homeassistant container starts with restored config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new deployment configuration for the home application development environment with updated initialization parameters, infrastructure settings, security credential management, and enhanced startup verification processes.
  * Reorganized and updated kustomization configuration to include new components and deployment patches, improving overall application deployment management and configuration organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->