### PR TITLE
feat(homeassistant): add ArgoCD Application for dev (#2182)

### DIFF
--- a/argocd/overlays/dev/apps/homeassistant.yaml
+++ b/argocd/overlays/dev/apps/homeassistant.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: homeassistant
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "6"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: main
+    path: apps/10-home/homeassistant/overlays/dev
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: homeassistant
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: false
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/overlays/dev/kustomization.yaml
+++ b/argocd/overlays/dev/kustomization.yaml
@@ -84,3 +84,6 @@ resources:
   # - apps/firefly-iii-importer.yaml
   # - apps/radar.yaml
   # - apps/n8n.yaml
+
+  # Home
+  - apps/homeassistant.yaml


### PR DESCRIPTION
## Summary
- Add ArgoCD Application for homeassistant on dev cluster
- Mirrors prod structure (sync-wave 6, CreateNamespace, automated prune)
- selfHeal disabled (dev pattern), targets `main` branch
- Deploys with 0 replicas via `dev-hibernate` component

## Test plan
- [ ] ArgoCD creates homeassistant app
- [ ] Namespace + resources deployed (0 replicas)
- [ ] Scale to 1 replica to validate DataAngel migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Home Assistant is now integrated into the development environment deployment configuration, enabling automated deployments via Argo CD.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->