### PR TITLE
perf(homeassistant): reduce dev resource requests (#2182)

### DIFF
--- a/apps/10-home/homeassistant/overlays/dev/kustomization.yaml
+++ b/apps/10-home/homeassistant/overlays/dev/kustomization.yaml
@@ -12,3 +12,16 @@ components:
   - ../../../../_shared/components/dataangel
 patches:
   - path: dataangel.yaml
+  - target:
+      kind: Deployment
+      name: homeassistant
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 50m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi


### PR DESCRIPTION
## Summary
- Reduce homeassistant container requests from 1Gi to 256Mi on dev
- Dev node at 84% memory allocation, pod was stuck in Pending
- No real HA activity in dev, just validation

## Test plan
- [ ] Pod schedules and starts on dev node
- [ ] DataAngel init container runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment resource configuration for optimized container performance in development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->