### PR TITLE
fix(homeassistant): change DataAngel metrics port to 9091 on dev

### DIFF
--- a/apps/10-home/homeassistant/overlays/dev/dataangel.yaml
+++ b/apps/10-home/homeassistant/overlays/dev/dataangel.yaml
@@ -33,13 +33,25 @@ spec:
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
+          ports:
+            - containerPort: 9091
+              name: metrics
+              protocol: TCP
           startupProbe:
             httpGet:
               path: /ready
-              port: 9090
+              port: 9091
             periodSeconds: 2
             failureThreshold: 3600
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 9091
+            periodSeconds: 5
+            failureThreshold: 3
           env:
+            - name: DATA_GUARD_METRICS_PORT
+              value: "9091"
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/apps/10-home/homeassistant/overlays/dev/kustomization.yaml
+++ b/apps/10-home/homeassistant/overlays/dev/kustomization.yaml
@@ -25,3 +25,9 @@ patches:
           limits:
             cpu: 500m
             memory: 512Mi
+      - op: replace
+        path: /spec/template/spec/initContainers/0/ports
+        value:
+          - containerPort: 9091
+            name: metrics
+            protocol: TCP


### PR DESCRIPTION
## Summary
- Change DataAngel metrics port from 9090 to 9091 in dev overlay to avoid `hostNetwork` port conflict
- Port 9090 is already in use on the dev host by another process, preventing the pod from starting
- Uses JSON patch to replace the inherited ports array from the shared DataAngel component

## Changes
- `dataangel.yaml`: ports, probes (startup + readiness), and `DATA_GUARD_METRICS_PORT` env all set to 9091
- `kustomization.yaml`: JSON patch `op: replace` on `initContainers/0/ports` to override shared component

## Test plan
- [ ] `kustomize build` shows only port 9091 on DataAngel init container (verified locally)
- [ ] Scale up homeassistant on dev, verify pod starts without port conflict
- [ ] Verify DataAngel metrics endpoint responds on :9091

Closes part of #2182

🤖 Generated with [Claude Code](https://claude.com/claude-code)