### PR TITLE
fix(synology-csi): drop edge image on dev node, use v1.2.0

### DIFF
--- a/apps/01-storage/synology-csi/overlays/dev/kustomization.yaml
+++ b/apps/01-storage/synology-csi/overlays/dev/kustomization.yaml
@@ -30,19 +30,5 @@ patches:
     target:
       kind: StorageClass
       name: synelia-iscsi-delete
-  - patch: |-
-      apiVersion: apps/v1
-      kind: DaemonSet
-      metadata:
-        name: synology-csi-node
-      spec:
-        template:
-          spec:
-            containers:
-              - name: synology-csi-plugin
-                image: ghcr.io/zebernst/synology-csi:edge
-    target:
-      kind: DaemonSet
-      name: synology-csi-node
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Remove the dev overlay patch that forced the CSI node DaemonSet to use `ghcr.io/zebernst/synology-csi:edge`
- Node now uses `v1.2.0` from base, matching prod
- Fixes iSCSI volume mount failures on dev (`iscsiadm: No such file or directory`)

## Root cause
The `edge` image's `nsenter.sh` wrapper can't find `iscsiadm` in the Talos `iscsid` extension's mount namespace. The `v1.2.0` image handles this correctly.

## Test plan
- [ ] ArgoCD syncs synology-csi on dev
- [ ] CSI node pod restarts with v1.2.0 image
- [ ] Scale up an app with iSCSI PVC, verify volume mounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the development environment container image override for the Synology CSI storage plugin so the plugin now uses the default image configuration.
  * Retained StorageClass-related adjustments; no runtime container image override is applied from this development overlay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->