### PR TITLE
fix(homeassistant): pin python to 3.13 on dev for hass-web-proxy-lib compat

### DIFF
--- a/apps/10-home/homeassistant/overlays/dev/kustomization.yaml
+++ b/apps/10-home/homeassistant/overlays/dev/kustomization.yaml
@@ -31,3 +31,6 @@ patches:
           - containerPort: 9091
             name: metrics
             protocol: TCP
+      - op: replace
+        path: /spec/template/spec/initContainers/1/image
+        value: "python:3.13-alpine"


### PR DESCRIPTION
## Summary
- Pin `install-python-deps` init container to `python:3.13-alpine` on dev
- `hass-web-proxy-lib==0.0.7` requires `Python >=3.12,<3.14`, base was bumped to 3.14.3

## Test plan
- [ ] Init container installs packages successfully
- [ ] HA pod reaches Running state

🤖 Generated with [Claude Code](https://claude.com/claude-code)