### PR TITLE
chore(dataangel): bump to sha-402e05f — skip validation on clean shutdown

### DIFF
--- a/apps/20-media/booklore/overlays/prod/dataangel.yaml
+++ b/apps/20-media/booklore/overlays/prod/dataangel.yaml
@@ -24,7 +24,7 @@ spec:
           $patch: delete
         - name: dataangel
           restartPolicy: Always
-          image: charchess/dataangel:sha-72826be
+          image: charchess/dataangel:sha-402e05f
           imagePullPolicy: IfNotPresent
           command: ["./dataangel"]
           securityContext:

--- a/apps/_shared/components/dataangel/kustomization.yaml
+++ b/apps/_shared/components/dataangel/kustomization.yaml
@@ -105,4 +105,4 @@ patches:
 
 images:
   - name: charchess/dataangel
-    newTag: "sha-72826be"
+    newTag: "sha-402e05f"


### PR DESCRIPTION
## Summary
- Bump DataAngel image from `sha-72826be` to `sha-402e05f` in shared component + booklore overlay
- New feature: writes sentinel file on graceful shutdown, skips `PRAGMA quick_check` on next startup
- Reduces restart time from ~7min to near-instant for graceful reboots (HA had 1.1GB DB taking 7m22s)

## Test plan
- [ ] ArgoCD syncs all DataAngel apps
- [ ] Verify sentinel file written on pod termination
- [ ] Next restart skips quick_check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dataangel container image to latest version in production environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->