### PR TITLE
fix(openclaw): fix DataAngel volume mount

### DIFF
--- a/apps/60-services/openclaw/overlays/prod/dataangel.yaml
+++ b/apps/60-services/openclaw/overlays/prod/dataangel.yaml
@@ -44,7 +44,5 @@ spec:
                   name: openclaw-secrets
                   key: RCLONE_SECRET_ACCESS_KEY
           volumeMounts:
-            - mountPath: /data
-              $patch: delete
             - name: data
               mountPath: /data


### PR DESCRIPTION
## Summary
Fix missing `/data` volume mount on DataAngel init container. The `$patch: delete` on mountPath `/data` also prevented the replacement mount from being added (same strategic merge key).

## Test plan
- [x] `kustomize build` shows DataAngel with `/data` mount
- [ ] Pod starts, DataAngel restores from S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the data volume mounting configuration in the production environment to simplify the existing setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->