### PR TITLE
fix(security): set fsGroupChangePolicy OnRootMismatch on 7 apps

### DIFF
--- a/apps/02-monitoring/loki/base/statefulset.yaml
+++ b/apps/02-monitoring/loki/base/statefulset.yaml
@@ -25,6 +25,7 @@ spec:
       securityContext:
         runAsNonRoot: true
         fsGroup: 10001
+        fsGroupChangePolicy: OnRootMismatch
         runAsGroup: 10001
         runAsUser: 10001
       volumes:

--- a/apps/10-home/mosquitto/base/statefulset.yaml
+++ b/apps/10-home/mosquitto/base/statefulset.yaml
@@ -173,6 +173,7 @@ spec:
       securityContext:
         # runAsNonRoot: true  # DISABLED: init container rclone runs as root — verify image before re-enabling
         fsGroup: 1883
+        fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
       volumes:

--- a/apps/20-media/jellyseerr/base/deployment.yaml
+++ b/apps/20-media/jellyseerr/base/deployment.yaml
@@ -79,4 +79,4 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         fsGroup: 1000
-        fsGroupChangePolicy: Always
+        fsGroupChangePolicy: OnRootMismatch

--- a/apps/60-services/g4f/base/deployment.yaml
+++ b/apps/60-services/g4f/base/deployment.yaml
@@ -25,6 +25,7 @@ spec:
     spec:
       securityContext:
         fsGroup: 1201
+        fsGroupChangePolicy: OnRootMismatch
       priorityClassName: vixens-low
       tolerations:
         - key: node-role.kubernetes.io/control-plane

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -33,6 +33,7 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       priorityClassName: vixens-high
       tolerations:
         - key: node-role.kubernetes.io/control-plane

--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -94,6 +94,8 @@ spec:
             claimName: penpot-data
       securityContext:
         # runAsNonRoot: true  # DISABLED: penpot/backend uses non-numeric user — verify image before re-enabling
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
       restartPolicy: Always

--- a/apps/70-tools/trilium/base/deployment.yaml
+++ b/apps/70-tools/trilium/base/deployment.yaml
@@ -95,6 +95,6 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
-        fsGroupChangePolicy: Always
+        fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault


### PR DESCRIPTION
## Summary
Add `fsGroupChangePolicy: OnRootMismatch` to 7 apps that were missing it or had `Always`, avoiding unnecessary recursive chown on every pod restart.

## Changes
**Added OnRootMismatch (5 apps — was missing):**
- mosquitto (fsGroup 1883)
- g4f (fsGroup 1201)
- openclaw (fsGroup 1000) — 97k+ files, was causing 5min+ chown
- loki (fsGroup 10001) — growing log storage
- penpot backend (also added fsGroup 1000)

**Changed Always → OnRootMismatch (2 apps):**
- jellyseerr
- trilium

## Risk assessment
**Low risk.** OnRootMismatch only runs chown when the root dir GID doesn't match fsGroup. All apps already had the correct ownership (they were running fine). This just skips the redundant recursive chown on restart.

## Test plan
- [ ] kustomize build passes for all 7 apps
- [ ] ArgoCD syncs without issues

Closes #2301

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container security configurations across multiple services to optimize filesystem group ownership handling during pod startup, ensuring group ownership adjustments occur only when necessary while maintaining existing security standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->