### PR TITLE
chore: add immutable: true to 11 eligible ConfigMaps

### DIFF
--- a/apps/00-infra/vpa/base/manifests.yaml
+++ b/apps/00-infra/vpa/base/manifests.yaml
@@ -927,6 +927,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+immutable: true
 data:
   verticalpodautoscalercheckpoints.yaml: |
     apiVersion: apiextensions.k8s.io/v1
@@ -1791,6 +1792,7 @@ metadata:
     app.kubernetes.io/component: tests
   annotations:
     helm.sh/hook: test
+immutable: true
 data:
   test_all.py: |
     import requests

--- a/apps/02-monitoring/grafana/base/dashboards/homeassistant.yaml
+++ b/apps/02-monitoring/grafana/base/dashboards/homeassistant.yaml
@@ -5,5 +5,6 @@ metadata:
   name: grafana-dashboard-homeassistant
   labels:
     grafana_dashboard: "1"
+immutable: true
 data:
   homeassistant.json: '{} # Placeholder - user to populate with JSON from suitable HA dashboard'

--- a/apps/02-monitoring/grafana/base/dashboards/postgresql.yaml
+++ b/apps/02-monitoring/grafana/base/dashboards/postgresql.yaml
@@ -5,5 +5,6 @@ metadata:
   name: grafana-dashboard-postgresql
   labels:
     grafana_dashboard: "1"
+immutable: true
 data:
   postgresql.json: '{} # Placeholder - user to populate with JSON from https://grafana.com/grafana/dashboards/20417 (CNPG)'

--- a/apps/02-monitoring/grafana/base/dashboards/traefik.yaml
+++ b/apps/02-monitoring/grafana/base/dashboards/traefik.yaml
@@ -5,5 +5,6 @@ metadata:
   name: grafana-dashboard-traefik
   labels:
     grafana_dashboard: "1"
+immutable: true
 data:
   traefik.json: '{} # Placeholder - user to populate with JSON from https://grafana.com/grafana/dashboards/13391'

--- a/apps/02-monitoring/grafana/base/dashboards/trivy.yaml
+++ b/apps/02-monitoring/grafana/base/dashboards/trivy.yaml
@@ -5,5 +5,6 @@ metadata:
   name: grafana-dashboard-trivy
   labels:
     grafana_dashboard: "1"
+immutable: true
 data:
   trivy.json: '{} # Placeholder - user to populate with JSON from https://grafana.com/grafana/dashboards/17813'

--- a/apps/02-monitoring/loki/base/configmap.yaml
+++ b/apps/02-monitoring/loki/base/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: loki-config
+immutable: true
 data:
   loki.yaml: |
     auth_enabled: false

--- a/apps/02-monitoring/promtail/base/configmap.yaml
+++ b/apps/02-monitoring/promtail/base/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: promtail-config
+immutable: true
 data:
   promtail-config.yaml: |
     server:

--- a/apps/40-network/netbird/base/ca-bundle.yaml
+++ b/apps/40-network/netbird/base/ca-bundle.yaml
@@ -4,6 +4,7 @@ kind: ConfigMap
 metadata:
   name: netbird-ca-bundle
   namespace: networking
+immutable: true
 data:
   ca-certificates.crt: |
     -----BEGIN CERTIFICATE-----

--- a/apps/60-services/docspell/base/configmap-joex-entrypoint.yaml
+++ b/apps/60-services/docspell/base/configmap-joex-entrypoint.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: docspell
     component: joex
+immutable: true
 data:
   entrypoint.sh: |
     #!/bin/sh

--- a/apps/60-services/docspell/base/configmap-joex.yaml
+++ b/apps/60-services/docspell/base/configmap-joex.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: docspell
     component: joex
+immutable: true
 data:
   config: |
     docspell.joex {


### PR DESCRIPTION
## Summary
Add `immutable: true` to 11 ConfigMaps that contain static configuration never modified at runtime.

Benefits: reduces API server load (no watch needed), prevents accidental modification.

## ConfigMaps made immutable
VPA CRDs, VPA tests, netbird-ca-bundle, 4 Grafana dashboards, 2 docspell configs, loki-config, promtail-config

## Risk assessment
**Low.** Only applied to ConfigMaps NOT watched by Stakater Reloader and NOT modified at runtime. If a ConfigMap needs updating, remove `immutable: true`, delete and recreate it.

Closes #2302

🤖 Generated with [Claude Code](https://claude.com/claude-code)