### PR TITLE
fix(infra): add PDBs to ArgoCD, cert-manager, Traefik dev

### DIFF
--- a/apps/00-infra/argocd/base/kustomization.yaml
+++ b/apps/00-infra/argocd/base/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
   - argocd-crds.yaml
   - argocd-install.yaml
   - servicemonitor.yaml
+  - pdb.yaml
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/00-infra/argocd/base/pdb.yaml
+++ b/apps/00-infra/argocd/base/pdb.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: argocd-server
+  namespace: argocd
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-server
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: argocd-repo-server
+  namespace: argocd
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-repo-server
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: argocd-applicationset-controller
+  namespace: argocd
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-applicationset-controller
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: argocd-redis
+  namespace: argocd
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-redis

--- a/apps/00-infra/cert-manager/base/kustomization.yaml
+++ b/apps/00-infra/cert-manager/base/kustomization.yaml
@@ -5,3 +5,4 @@ namespace: cert-manager
 resources:
   - cluster-issuer-prod.yaml
   - servicemonitor.yaml
+  - pdb.yaml

--- a/apps/00-infra/cert-manager/base/pdb.yaml
+++ b/apps/00-infra/cert-manager/base/pdb.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cert-manager
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cert-manager-webhook
+  namespace: cert-manager
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: webhook
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cert-manager-cainjector
+  namespace: cert-manager
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cainjector

--- a/apps/00-infra/traefik/values/dev.yaml
+++ b/apps/00-infra/traefik/values/dev.yaml
@@ -29,3 +29,7 @@ resources:
 # Single replica for dev
 deployment:
   replicas: 0
+# PDB (match prod pattern)
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 0

--- a/docs/reference/talos-platform-constraints.md
+++ b/docs/reference/talos-platform-constraints.md
@@ -1,0 +1,48 @@
+# Talos Linux — Platform Constraints
+
+**Last Updated:** 2026-03-25
+
+## Overview
+
+Talos Linux is an immutable, API-driven OS designed for Kubernetes. Its minimal design means several standard Kubernetes features are **not available**. This document tracks evaluated features and their applicability.
+
+---
+
+## Not Available on Talos
+
+### AppArmor Profiles (evaluated 2026-03-25, issue #2280)
+
+**Status:** Not applicable.
+
+Talos does not ship the AppArmor kernel module or userspace tools (`apparmor_parser`). Kubernetes 1.30+ made AppArmor GA with `appArmorProfile` in `securityContext`, but it requires the **node** to have AppArmor loaded.
+
+**Alternatives for container hardening:**
+- **seccomp profiles** — supported by Talos
+- **Pod Security Standards (PSA)** — built into Kubernetes
+- **Trivy** — already deployed for vulnerability scanning
+
+### NodeLogQuery / KEP-2258 (evaluated 2026-03-25, issue #2281)
+
+**Status:** Not applicable.
+
+NodeLogQuery allows querying node-level logs via the kubelet API. It relies on either:
+- **journald** (systemd journal) — Talos does not use systemd
+- **File-based log providers** — not available on Talos's read-only filesystem
+
+Still in Beta as of Kubernetes 1.34. Not GA.
+
+**Alternatives:**
+- `talosctl logs` / `talosctl dmesg` — for node-level logs
+- **Promtail + Loki** — already deployed for centralized log collection
+
+---
+
+## Available on Talos
+
+| Feature | Status | Notes |
+|---|---|---|
+| seccomp profiles | Supported | Default seccomp provided by containerd |
+| iSCSI (via extension) | Supported | `iscsi-tools` extension required |
+| Native sidecars (KEP-753) | Supported | K8s 1.28+, `restartPolicy: Always` on init containers |
+| fsGroupChangePolicy | Supported | Requires explicit configuration per pod |
+| VPA | Supported | Deployed via `apps/00-infra/vpa/` |


### PR DESCRIPTION
## Summary
Add PodDisruptionBudgets (minAvailable: 0) to 3 critical infrastructure apps:
- **ArgoCD**: server, repo-server, applicationset-controller, redis
- **cert-manager**: controller, webhook, cainjector
- **Traefik dev**: enable PDB via Helm values

Also adds `docs/reference/talos-platform-constraints.md` (AppArmor, NodeLogQuery non-applicability).

## Risk assessment
**Very low.** minAvailable: 0 allows full eviction. PDB exists for awareness and Kyverno compliance.

Closes #2300

🤖 Generated with [Claude Code](https://claude.com/claude-code)