### PR TITLE
perf: right-size 16 containers to V-* profiles (free 3.1Gi)

### DIFF
--- a/apps/03-security/authentik/overlays/prod/server-resources.yaml
+++ b/apps/03-security/authentik/overlays/prod/server-resources.yaml
@@ -8,6 +8,6 @@ spec:
     metadata:
       labels:
         vixens.io/sizing.authentik-server: G-large
-        vixens.io/sizing.config-syncer: G-small
+        vixens.io/sizing.config-syncer: V-nano
     spec:
       priorityClassName: vixens-critical

--- a/apps/04-databases/redis-shared/base/deployment.yaml
+++ b/apps/04-databases/redis-shared/base/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     metadata:
       labels:
         app: redis-shared
-        vixens.io/sizing.redis: V-small
+        vixens.io/sizing.redis: V-micro
         vixens.io/backup-profile: "relaxed"
       annotations:
         vixens.io/fast-start: "true"

--- a/apps/10-home/mosquitto/base/statefulset.yaml
+++ b/apps/10-home/mosquitto/base/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
         app: mosquitto
         vixens.io/sizing.restore-data: B-nano
         vixens.io/sizing.create-mosquitto-users: G-nano
-        vixens.io/sizing.mosquitto: V-small
+        vixens.io/sizing.mosquitto: V-nano
         vixens.io/sizing.config-syncer: V-nano
         vixens.io/backup-profile: "relaxed"
       annotations:

--- a/apps/20-media/birdnet-go/base/deployment.yaml
+++ b/apps/20-media/birdnet-go/base/deployment.yaml
@@ -19,8 +19,8 @@ spec:
       labels:
         app: birdnet-go
         vixens.io/sizing.birdnet-go: V-medium
-        vixens.io/sizing.litestream: V-nano
-        vixens.io/sizing.data-syncer: V-nano
+        vixens.io/sizing.litestream: V-micro
+        vixens.io/sizing.data-syncer: V-micro
         vixens.io/sizing.fix-permissions: G-nano
         vixens.io/backup-profile: "relaxed"
       annotations:

--- a/apps/20-media/birdnet-go/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/birdnet-go/overlays/prod/resources-patch.yaml
@@ -8,5 +8,5 @@ spec:
     metadata:
       labels:
         vixens.io/sizing.birdnet-go: G-medium
-        vixens.io/sizing.litestream: G-small
-        vixens.io/sizing.data-syncer: G-small
+        vixens.io/sizing.litestream: V-micro
+        vixens.io/sizing.data-syncer: V-micro

--- a/apps/20-media/mylar/base/deployment.yaml
+++ b/apps/20-media/mylar/base/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         app: mylar
-        vixens.io/sizing.mylar: V-medium
+        vixens.io/sizing.mylar: V-micro
         vixens.io/sizing.litestream: V-nano
         vixens.io/sizing.config-syncer: V-nano
         vixens.io/sizing.fix-permissions: G-nano

--- a/apps/20-media/prowlarr/base/deployment.yaml
+++ b/apps/20-media/prowlarr/base/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         app: prowlarr
-        vixens.io/sizing.prowlarr: V-medium
+        vixens.io/sizing.prowlarr: V-small
         vixens.io/sizing.litestream: V-nano
         vixens.io/sizing.config-syncer: V-nano
         vixens.io/sizing.fix-permissions: G-nano

--- a/apps/20-media/prowlarr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/prowlarr/overlays/prod/resources-patch.yaml
@@ -4,9 +4,9 @@ kind: Deployment
 metadata:
   name: prowlarr
   labels:
-    vixens.io/sizing.prowlarr: V-medium
+    vixens.io/sizing.prowlarr: V-small
 spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.prowlarr: V-medium
+        vixens.io/sizing.prowlarr: V-small

--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         app: sabnzbd
-        vixens.io/sizing.sabnzbd: V-medium
+        vixens.io/sizing.sabnzbd: V-micro
         vixens.io/sizing.litestream: V-nano
         vixens.io/sizing.config-syncer: V-nano
         vixens.io/sizing.restore-config: B-nano

--- a/apps/20-media/whisparr/base/deployment.yaml
+++ b/apps/20-media/whisparr/base/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         app: whisparr
-        vixens.io/sizing.whisparr: B-medium
+        vixens.io/sizing.whisparr: V-small
         vixens.io/sizing.litestream: V-nano
         vixens.io/sizing.config-syncer: V-nano
         vixens.io/sizing.fix-permissions: G-nano

--- a/apps/20-media/whisparr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/whisparr/overlays/prod/resources-patch.yaml
@@ -4,13 +4,13 @@ kind: Deployment
 metadata:
   name: whisparr
   labels:
-    vixens.io/sizing.whisparr: B-medium
+    vixens.io/sizing.whisparr: V-small
     vixens.io/sizing.litestream: V-nano
     vixens.io/sizing.config-syncer: V-nano
 spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.whisparr: B-medium
+        vixens.io/sizing.whisparr: V-small
         vixens.io/sizing.litestream: V-nano
         vixens.io/sizing.config-syncer: V-nano

--- a/apps/40-network/netbird/base/dashboard.yaml
+++ b/apps/40-network/netbird/base/dashboard.yaml
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         app: netbird-dashboard
-        vixens.io/sizing.dashboard: V-small
+        vixens.io/sizing.dashboard: V-micro
         vixens.io/backup-profile: "relaxed"
       annotations:
         vixens.io/fast-start: "true"

--- a/apps/40-network/netbird/base/management.yaml
+++ b/apps/40-network/netbird/base/management.yaml
@@ -21,7 +21,7 @@ spec:
       labels:
         app: netbird-management
         vixens.io/sizing.init-config: G-nano
-        vixens.io/sizing.management: V-medium
+        vixens.io/sizing.management: V-micro
         vixens.io/backup-profile: "relaxed"
       annotations:
         vixens.io/fast-start: "true"

--- a/apps/40-network/netbird/base/signal-relay.yaml
+++ b/apps/40-network/netbird/base/signal-relay.yaml
@@ -21,7 +21,7 @@ spec:
         vixens.io/no-long-connections: "true"
       labels:
         app: netbird-signal
-        vixens.io/sizing.signal: V-small
+        vixens.io/sizing.signal: V-micro
         vixens.io/backup-profile: "relaxed"
     spec:
       priorityClassName: vixens-low
@@ -89,7 +89,7 @@ spec:
         vixens.io/fast-start: "true"
       labels:
         app: netbird-relay
-        vixens.io/sizing.relay: V-small
+        vixens.io/sizing.relay: V-micro
     spec:
       priorityClassName: vixens-low
       tolerations:

--- a/apps/40-network/netvisor/base/server-deployment.yaml
+++ b/apps/40-network/netvisor/base/server-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         vixens.io/no-long-connections: "true"
       labels:
         app: netvisor-server
-        vixens.io/sizing.server: V-small
+        vixens.io/sizing.server: V-micro
         vixens.io/backup-profile: "relaxed"
     spec:
       tolerations:

--- a/apps/70-tools/headlamp/base/deployment.yaml
+++ b/apps/70-tools/headlamp/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         app: headlamp
-        vixens.io/sizing.headlamp: V-small
+        vixens.io/sizing.headlamp: V-micro
         vixens.io/backup-profile: "relaxed"
       annotations:
         reloader.stakater.com/auto: "true"

--- a/apps/70-tools/penpot/base/deployment-frontend.yaml
+++ b/apps/70-tools/penpot/base/deployment-frontend.yaml
@@ -22,7 +22,7 @@ spec:
       labels:
         app: penpot-frontend
         component: frontend
-        vixens.io/sizing.frontend: V-small
+        vixens.io/sizing.frontend: V-micro
         vixens.io/backup-profile: "standard"
     spec:
       priorityClassName: vixens-medium


### PR DESCRIPTION
## Summary
Right-size 16 over-provisioned containers based on VPA upperBound data, switching to V-* (VPA-managed) profiles. Frees **~3.1Gi of memory requests** across the cluster.

## Changes (label-only, no resource specs modified)
| Container | Old | New | Saving |
|---|---|---|---|
| mylar | V-medium (512Mi) | V-micro (128Mi) | -384Mi |
| sabnzbd | V-medium (512Mi) | V-micro (128Mi) | -384Mi |
| netbird-management | V-medium (512Mi) | V-micro (128Mi) | -384Mi |
| prowlarr | V-medium (512Mi) | V-small (256Mi) | -256Mi |
| whisparr | B-medium (512Mi) | V-small (256Mi) | -256Mi |
| authentik config-syncer | G-small (256Mi) | V-nano (64Mi) | -192Mi |
| mosquitto | G-small (256Mi) | V-nano (64Mi) | -192Mi |
| 9 others | 256Mi each | V-micro (128Mi) | -128Mi each |

## Risk assessment
**Low.** All changes are within VPA upperBound recommendations. V-* profiles let VPA auto-adjust if usage grows. No homeassistant files touched.

## Impact
- Frees ~3.1Gi of memory requests → unblocks scheduling of pending pods (mealie, lazylibrarian)
- VPA continues to optimize after initial right-sizing

## Test plan
- [ ] ArgoCD syncs all modified apps
- [ ] Kyverno mutates pods with new V-* sizing
- [ ] mealie and lazylibrarian schedule successfully
- [ ] No OOMKills in the next 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resource sizing and scaling configurations across multiple infrastructure components to optimize deployment performance and resource efficiency. Applied to authentication services, database systems, media processing applications, networking infrastructure, and operational tools throughout the platform to align sizing parameters with current operational requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->