### PR TITLE
perf: right-size 5 more containers to V-* (batch 2)

### DIFF
--- a/apps/20-media/birdnet-go/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/birdnet-go/overlays/prod/resources-patch.yaml
@@ -7,6 +7,6 @@ spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.birdnet-go: G-medium
+        vixens.io/sizing.birdnet-go: V-medium
         vixens.io/sizing.litestream: V-micro
         vixens.io/sizing.data-syncer: V-micro

--- a/apps/20-media/jellyseerr/base/deployment.yaml
+++ b/apps/20-media/jellyseerr/base/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         app: jellyseerr
-        vixens.io/sizing.jellyseerr: B-medium
+        vixens.io/sizing.jellyseerr: V-medium
         vixens.io/backup-profile: "relaxed"
       annotations:
         vixens.io/no-long-connections: "true"

--- a/apps/20-media/lidarr/overlays/prod/resources-patch.yaml
+++ b/apps/20-media/lidarr/overlays/prod/resources-patch.yaml
@@ -4,13 +4,13 @@ kind: Deployment
 metadata:
   name: lidarr
   labels:
-    vixens.io/sizing.lidarr: SB-medium
+    vixens.io/sizing.lidarr: V-medium
     vixens.io/sizing.litestream: V-nano
     vixens.io/sizing.config-syncer: V-nano
 spec:
   template:
     metadata:
       labels:
-        vixens.io/sizing.lidarr: SB-medium
+        vixens.io/sizing.lidarr: V-medium
         vixens.io/sizing.litestream: V-nano
         vixens.io/sizing.config-syncer: V-nano

--- a/apps/60-services/n8n/base/deployment.yaml
+++ b/apps/60-services/n8n/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         app: n8n
-        vixens.io/sizing.n8n: B-medium
+        vixens.io/sizing.n8n: V-medium
         vixens.io/backup-profile: "standard"
       annotations:
         reloader.stakater.com/auto: "true"

--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -24,7 +24,7 @@ spec:
       labels:
         app: penpot-backend
         component: backend
-        vixens.io/sizing.backend: B-large
+        vixens.io/sizing.backend: V-large
         vixens.io/backup-profile: standard
     spec:
       priorityClassName: vixens-medium


### PR DESCRIPTION
## Summary
Switch 5 more containers from fixed profiles (B-*/SB-*/G-*) to VPA-managed V-* profiles. All neutral or positive impact on memory requests.

| Container | Old | New | Impact |
|---|---|---|---|
| jellyseerr | B-medium (512Mi) | V-medium (512Mi) | neutral |
| n8n | B-medium (512Mi) | V-medium (512Mi) | neutral |
| penpot-backend | B-large (1Gi) | V-large (1Gi) | neutral |
| birdnet-go | G-medium (512Mi) | V-medium (512Mi) | neutral |
| lidarr | SB-medium (512Mi) | V-medium (512Mi) | neutral |

## Risk assessment
**Very low.** All V-* tiers match current request sizes. VPA will auto-adjust if usage changes. No homeassistant or adguard-home touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pod sizing classifications across multiple services to standardize resource allocation profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->