### PR TITLE
refactor(kyverno): auto-detect VPA mode from V-* sizing prefix

### DIFF
--- a/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
+++ b/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
@@ -89,8 +89,10 @@ spec:
               kind: "{{ request.object.kind }}"
               name: "{{ request.object.metadata.name }}"
             updatePolicy:
+              # V-* sizing label present → Auto (VPA manages resources)
+              # B-*/SB-*/G-* only → Off (Goldilocks recommend-only)
               updateMode: >-
-                {{ contains(keys(request.object.metadata.labels), 'vixens.io/vpa-mode') && request.object.metadata.labels."vixens.io/vpa-mode" || 'Auto' }}
+                {{ request.object.spec.template.metadata.labels | values(@) | [?starts_with(@, 'V-')] | length(@) > `0` && 'Auto' || 'Off' }}
             resourcePolicy:
               containerPolicies:
                 - containerName: "*"

--- a/apps/04-databases/mariadb-shared/base/statefulset.yaml
+++ b/apps/04-databases/mariadb-shared/base/statefulset.yaml
@@ -6,7 +6,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "2"
   labels:
-    vixens.io/vpa-mode: Auto
 spec:
   serviceName: mariadb-shared
   replicas: 1

--- a/apps/04-databases/redis-shared/base/deployment.yaml
+++ b/apps/04-databases/redis-shared/base/deployment.yaml
@@ -4,7 +4,6 @@ kind: Deployment
 metadata:
   name: redis-shared
   labels:
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   selector:

--- a/apps/10-home/mealie/base/deployment.yaml
+++ b/apps/10-home/mealie/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: mealie
   labels:
     app: mealie
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:

--- a/apps/10-home/mosquitto/base/statefulset.yaml
+++ b/apps/10-home/mosquitto/base/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app: mosquitto
     app.kubernetes.io/name: mosquitto
     app.kubernetes.io/component: mqtt-broker
-    vixens.io/vpa-mode: Auto
 spec:
   serviceName: mosquitto
   replicas: 1

--- a/apps/20-media/amule/base/deployment.yaml
+++ b/apps/20-media/amule/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: amule
   labels:
     app: amule
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:

--- a/apps/20-media/birdnet-go/base/deployment.yaml
+++ b/apps/20-media/birdnet-go/base/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: birdnet-go
     app.kubernetes.io/managed-by: argocd
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:

--- a/apps/20-media/booklore/base/deployment.yaml
+++ b/apps/20-media/booklore/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: booklore
   labels:
     app: booklore
-    vixens.io/vpa-mode: "Off"
 spec:
   replicas: 1
   strategy:

--- a/apps/20-media/booklore/base/mariadb-deployment.yaml
+++ b/apps/20-media/booklore/base/mariadb-deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: booklore-mariadb
   labels:
     app: booklore-mariadb
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:

--- a/apps/20-media/hydrus-client/base/deployment.yaml
+++ b/apps/20-media/hydrus-client/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: hydrus-client
   labels:
     app: hydrus-client
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:

--- a/apps/20-media/jellyfin/base/deployment.yaml
+++ b/apps/20-media/jellyfin/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: jellyfin
   labels:
     app: jellyfin
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:

--- a/apps/20-media/jellyseerr/base/deployment.yaml
+++ b/apps/20-media/jellyseerr/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: jellyseerr
   labels:
     app: jellyseerr
-    vixens.io/vpa-mode: "Off"
 spec:
   replicas: 1
   strategy:

--- a/apps/20-media/lazylibrarian/base/deployment.yaml
+++ b/apps/20-media/lazylibrarian/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: lazylibrarian
   labels:
     app: lazylibrarian
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:

--- a/apps/20-media/lidarr/base/deployment.yaml
+++ b/apps/20-media/lidarr/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: lidarr
   labels:
     app: lidarr
-    vixens.io/vpa-mode: Auto
 spec:
   strategy:
     type: Recreate

--- a/apps/20-media/music-assistant/base/deployment.yaml
+++ b/apps/20-media/music-assistant/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: music-assistant
   labels:
     app: music-assistant
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:

--- a/apps/20-media/mylar/base/deployment.yaml
+++ b/apps/20-media/mylar/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: mylar
   labels:
     app: mylar
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:

--- a/apps/20-media/prowlarr/base/deployment.yaml
+++ b/apps/20-media/prowlarr/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: prowlarr
   labels:
     app: prowlarr
-    vixens.io/vpa-mode: Auto
 spec:
   strategy:
     type: Recreate

--- a/apps/20-media/pyload/base/deployment.yaml
+++ b/apps/20-media/pyload/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: pyload
   labels:
     app: pyload
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:

--- a/apps/20-media/qbittorrent/base/deployment.yaml
+++ b/apps/20-media/qbittorrent/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: qbittorrent
   labels:
     app: qbittorrent
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:

--- a/apps/20-media/radarr/base/deployment.yaml
+++ b/apps/20-media/radarr/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: radarr
   labels:
     app: radarr
-    vixens.io/vpa-mode: Auto
     vixens.io/backup-profile: "standard"
 spec:
   strategy:

--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: sabnzbd
   labels:
     app: sabnzbd
-    vixens.io/vpa-mode: Auto
 spec:
   strategy:
     type: Recreate

--- a/apps/20-media/sonarr/base/deployment.yaml
+++ b/apps/20-media/sonarr/base/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: sonarr
     app.kubernetes.io/managed-by: kustomize
-    vixens.io/vpa-mode: Auto
 spec:
   strategy:
     type: Recreate

--- a/apps/20-media/whisparr/base/deployment.yaml
+++ b/apps/20-media/whisparr/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: whisparr
   labels:
     app: whisparr
-    vixens.io/vpa-mode: "Off"
 spec:
   strategy:
     type: Recreate

--- a/apps/40-network/netbird/base/dashboard.yaml
+++ b/apps/40-network/netbird/base/dashboard.yaml
@@ -7,7 +7,6 @@ metadata:
     vpa.kubernetes.io/updateMode: "Off"
     goldilocks.fairwinds.com/enabled: "true"
   labels:
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   revisionHistoryLimit: 3

--- a/apps/40-network/netbird/base/management.yaml
+++ b/apps/40-network/netbird/base/management.yaml
@@ -7,7 +7,6 @@ metadata:
     vpa.kubernetes.io/updateMode: "Off"
     goldilocks.fairwinds.com/enabled: "true"
   labels:
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   revisionHistoryLimit: 3

--- a/apps/40-network/netbird/base/signal-relay.yaml
+++ b/apps/40-network/netbird/base/signal-relay.yaml
@@ -7,7 +7,6 @@ metadata:
     vpa.kubernetes.io/updateMode: "Off"
     goldilocks.fairwinds.com/enabled: "true"
   labels:
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -76,7 +75,6 @@ metadata:
     vpa.kubernetes.io/updateMode: "Off"
     goldilocks.fairwinds.com/enabled: "true"
   labels:
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   revisionHistoryLimit: 3

--- a/apps/40-network/netvisor/base/server-deployment.yaml
+++ b/apps/40-network/netvisor/base/server-deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: netvisor-server
   labels:
     app: netvisor-server
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   selector:

--- a/apps/60-services/docspell/base/statefulset-joex.yaml
+++ b/apps/60-services/docspell/base/statefulset-joex.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: docspell
     component: joex
-    vixens.io/vpa-mode: Auto
 spec:
   serviceName: docspell-joex
   replicas: 1

--- a/apps/60-services/docspell/base/statefulset-restserver.yaml
+++ b/apps/60-services/docspell/base/statefulset-restserver.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: docspell
     component: restserver
-    vixens.io/vpa-mode: Auto
 spec:
   serviceName: docspell-restserver
   replicas: 1

--- a/apps/60-services/firefly-iii-importer/base/deployment.yaml
+++ b/apps/60-services/firefly-iii-importer/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: firefly-iii-importer
   labels:
     app.kubernetes.io/name: firefly-iii-importer
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   selector:

--- a/apps/60-services/firefly-iii/base/deployment.yaml
+++ b/apps/60-services/firefly-iii/base/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app.kubernetes.io/name: firefly-iii
     app.kubernetes.io/managed-by: argocd
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:

--- a/apps/60-services/g4f/base/deployment.yaml
+++ b/apps/60-services/g4f/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: g4f
   labels:
     app.kubernetes.io/name: g4f
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:

--- a/apps/60-services/gluetun/base/deployment.yaml
+++ b/apps/60-services/gluetun/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: gluetun
   labels:
     app: gluetun
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   selector:

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: services
   labels:
     app: openclaw
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   revisionHistoryLimit: 3

--- a/apps/60-services/vaultwarden/base/deployment.yaml
+++ b/apps/60-services/vaultwarden/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: vaultwarden
   labels:
     app: vaultwarden
-    vixens.io/vpa-mode: Auto
 spec:
   strategy:
     type: Recreate

--- a/apps/70-tools/changedetection/base/deployment.yaml
+++ b/apps/70-tools/changedetection/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: changedetection
   labels:
     app: changedetection
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:

--- a/apps/70-tools/headlamp/base/deployment.yaml
+++ b/apps/70-tools/headlamp/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: headlamp
   labels:
     app: headlamp
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   selector:

--- a/apps/70-tools/homepage/base/deployment.yaml
+++ b/apps/70-tools/homepage/base/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   name: homepage
   labels:
     app.kubernetes.io/name: homepage
-    vixens.io/vpa-mode: Auto
   annotations:
     secret.reloader.stakater.com/reload: homepage-config-secret,homepage-secrets
 spec:

--- a/apps/70-tools/linkwarden/base/deployment.yaml
+++ b/apps/70-tools/linkwarden/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: linkwarden
   labels:
     app: linkwarden
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:

--- a/apps/70-tools/netbox/base/deployment.yaml
+++ b/apps/70-tools/netbox/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: netbox
   labels:
     app: netbox
-    vixens.io/vpa-mode: "Off"
 spec:
   replicas: 1
   strategy:

--- a/apps/70-tools/nocodb/base/deployment.yaml
+++ b/apps/70-tools/nocodb/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: nocodb
   labels:
     app.kubernetes.io/name: nocodb
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:

--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: penpot-backend
     component: backend
-    vixens.io/vpa-mode: "Off"
 spec:
   replicas: 1
   revisionHistoryLimit: 3

--- a/apps/70-tools/penpot/base/deployment-exporter.yaml
+++ b/apps/70-tools/penpot/base/deployment-exporter.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: penpot-exporter
     component: exporter
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   revisionHistoryLimit: 3

--- a/apps/70-tools/penpot/base/deployment-frontend.yaml
+++ b/apps/70-tools/penpot/base/deployment-frontend.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: penpot-frontend
     component: frontend
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   revisionHistoryLimit: 3

--- a/apps/70-tools/radar/base/manifests.yaml
+++ b/apps/70-tools/radar/base/manifests.yaml
@@ -146,7 +146,6 @@ metadata:
     app.kubernetes.io/instance: radar
     app.kubernetes.io/version: "0.4.2"
     app.kubernetes.io/managed-by: Helm
-    vixens.io/vpa-mode: Off
 spec:
   replicas: 1
   selector:

--- a/apps/70-tools/trilium/base/deployment.yaml
+++ b/apps/70-tools/trilium/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: trilium
   labels:
     app.kubernetes.io/name: trilium
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:

--- a/apps/70-tools/vikunja/base/deployment.yaml
+++ b/apps/70-tools/vikunja/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: vikunja
   labels:
     app.kubernetes.io/name: vikunja
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   strategy:

--- a/apps/99-test/whoami/base/deployment.yaml
+++ b/apps/99-test/whoami/base/deployment.yaml
@@ -4,7 +4,6 @@ kind: Deployment
 metadata:
   name: whoami
   labels:
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   revisionHistoryLimit: 3

--- a/apps/template-app/base/deployment.yaml
+++ b/apps/template-app/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: template-app
   labels:
     app: template-app
-    vixens.io/vpa-mode: Auto
 spec:
   replicas: 1
   revisionHistoryLimit: 3


### PR DESCRIPTION
## Summary
The VPA updateMode is now **automatically derived** from the sizing label prefix:
- **V-*** labels present → `updateMode: Auto` (VPA manages resources)
- **B-*/SB-*/G-*** only → `updateMode: Off` (Goldilocks recommend-only)

Removes the manual `vixens.io/vpa-mode` label from all 48 apps. No more label to maintain — the sizing prefix IS the source of truth.

## How it works
```yaml
# Before (manual label)
updateMode: {{ labels."vixens.io/vpa-mode" || 'Auto' }}

# After (auto-detect from sizing prefix)
updateMode: {{ values(labels) | [?starts_with(@, 'V-')] | length > 0 → 'Auto' : 'Off' }}
```

## Risk assessment
**Medium.** This changes VPA mode for apps that had `Off` but now have V-* labels (jellyseerr, penpot-backend, whisparr, booklore, netbox, radar). They will switch to Auto — VPA will start evicting pods to right-size them. This is the desired behavior per the V-* migration.

Apps with only B-*/SB-*/G-* labels will switch to Off — this matches their static sizing intent.

## Test plan
- [ ] Kyverno policy syncs without error
- [ ] VPAs regenerated with correct updateMode
- [ ] V-* apps get Auto, non-V-* apps get Off

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Updated VPA (VerticalPodAutoscaler) configuration mechanism to automatically determine pod scaling modes based on pod template label patterns instead of explicit metadata labels.
- Removed explicit VPA mode labels from 47+ application deployments and statefulsets across the infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->