### PR TITLE
feat: add preStop hooks to 8 critical apps for graceful drain (#2298)

### DIFF
--- a/apps/03-security/authentik/base/deployment-server.yaml
+++ b/apps/03-security/authentik/base/deployment-server.yaml
@@ -28,7 +28,6 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9300"
         prometheus.io/path: "/metrics"
-        vixens.io/no-long-connections: "true"
     spec:
       priorityClassName: vixens-critical
       tolerations:
@@ -148,6 +147,10 @@ spec:
             - name: blueprints
               mountPath: /blueprints/vixens-hydrus.yaml
               subPath: vixens-hydrus.yaml
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "3"]
           resources:
             requests:
               memory: 512Mi

--- a/apps/20-media/booklore/base/mariadb-deployment.yaml
+++ b/apps/20-media/booklore/base/mariadb-deployment.yaml
@@ -72,6 +72,10 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "3"]
           startupProbe:
             exec:
               command: ["mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]

--- a/apps/20-media/jellyfin/base/deployment.yaml
+++ b/apps/20-media/jellyfin/base/deployment.yaml
@@ -16,7 +16,6 @@ spec:
     metadata:
       annotations:
         vixens.io/fast-start: "true"
-        vixens.io/no-long-connections: "true"
       labels:
         app: jellyfin
         vixens.io/sizing.jellyfin: V-medium
@@ -68,6 +67,10 @@ spec:
             failureThreshold: 30
             periodSeconds: 10
             timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "3"]
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/20-media/music-assistant/base/deployment.yaml
+++ b/apps/20-media/music-assistant/base/deployment.yaml
@@ -19,7 +19,6 @@ spec:
         vixens.io/sizing.music-assistant: V-medium
         vixens.io/backup-profile: "relaxed"
       annotations:
-        vixens.io/no-long-connections: "true"
         vixens.io/explicitly-allow-root: "true"
     spec:
       securityContext:
@@ -56,6 +55,10 @@ spec:
               value: "1000"
             - name: TZ
               value: Europe/Paris
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "3"]
           volumeMounts:
             - name: config
               mountPath: /data

--- a/apps/40-network/netbird/base/management.yaml
+++ b/apps/40-network/netbird/base/management.yaml
@@ -24,7 +24,6 @@ spec:
         vixens.io/backup-profile: "relaxed"
       annotations:
         vixens.io/fast-start: "true"
-        vixens.io/no-long-connections: "true"
     spec:
       priorityClassName: vixens-low
       tolerations:
@@ -135,6 +134,10 @@ spec:
               name: http
             - containerPort: 33073
               name: grpc
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "3"]
           volumeMounts:
             - name: config-writable
               mountPath: /etc/netbird

--- a/apps/60-services/firefly-iii/base/deployment.yaml
+++ b/apps/60-services/firefly-iii/base/deployment.yaml
@@ -28,7 +28,6 @@ spec:
         prometheus.io/port: "8080"
         prometheus.io/path: "/metrics"
         vixens.io/service-binding: "false"
-        vixens.io/no-long-connections: "true"
         vixens.io/fast-start: "true"
     spec:
       priorityClassName: vixens-medium
@@ -127,6 +126,10 @@ spec:
             limits:
               cpu: 1000m
               memory: 512Mi
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "3"]
           volumeMounts:
             - name: static
               mountPath: /var/www/html/storage/upload

--- a/apps/60-services/n8n/base/deployment.yaml
+++ b/apps/60-services/n8n/base/deployment.yaml
@@ -96,6 +96,10 @@ spec:
               port: http
             failureThreshold: 30
             periodSeconds: 10
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "3"]
           volumeMounts:
             - name: data
               mountPath: /home/node/.n8n

--- a/apps/60-services/vaultwarden/base/deployment.yaml
+++ b/apps/60-services/vaultwarden/base/deployment.yaml
@@ -28,7 +28,6 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9090"
         prometheus.io/path: "/metrics"
-        vixens.io/no-long-connections: "true"
         kubectl.kubernetes.io/restartedAt: "2026-03-11T22:20:00Z"
         vixens.io/explicitly-allow-root: "true"
     spec:
@@ -109,6 +108,10 @@ spec:
             failureThreshold: 15
             periodSeconds: 10
             timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "3"]
           volumeMounts:
             - name: data
               mountPath: /data


### PR DESCRIPTION
## Summary
Add `preStop: exec: command: ["sleep", "3"]` to 8 critical apps that handle active connections (SSO, WebSocket, streaming, DB, webhooks). Gives 3 seconds for in-flight requests to complete after pod is removed from Service endpoints.

## Apps modified
| App | Reason |
|---|---|
| authentik-server | SSO — dropping auth requests causes cascading failures |
| vaultwarden | WebSocket browser extension connections |
| n8n | Active webhook listeners and long-running workflows |
| booklore-mariadb | Database — flush writes before SIGTERM |
| jellyfin | Active media streaming sessions |
| music-assistant | Audio streaming sessions |
| netbird-management | VPN agents connected |
| firefly-iii | Financial transactions in progress |

Also removes `vixens.io/no-long-connections: "true"` bypass annotation from the 6 apps that had it.

**Not modified:** homeassistant (per user request).

## Risk assessment
**Very low.** preStop sleep adds 3 seconds to pod termination time. No functional change — just delays SIGTERM to allow connection draining.

## Test plan
- [ ] ArgoCD syncs all 8 apps
- [ ] Pods terminate gracefully with 3s delay

Closes #2298

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configurations across multiple services to implement controlled shutdown behavior with ordered termination sequences, enhancing reliability during maintenance windows and service restarts.
  * Removed legacy connection handling annotations from select service deployments to streamline operational configuration and reduce technical debt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->