### PR TITLE
fix: add preStop hooks to all sidecar containers (Kyverno compliance)

### DIFF
--- a/apps/03-security/authentik/base/deployment-server.yaml
+++ b/apps/03-security/authentik/base/deployment-server.yaml
@@ -183,6 +183,10 @@ spec:
           envFrom:
             - secretRef:
                 name: authentik-secrets
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "3"]
           resources:
             requests:
               cpu: 10m

--- a/apps/20-media/booklore/base/mariadb-deployment.yaml
+++ b/apps/20-media/booklore/base/mariadb-deployment.yaml
@@ -124,6 +124,10 @@ spec:
                 - pgrep -f mariadb-dump || exit 1
             initialDelaySeconds: 30
             periodSeconds: 60
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "3"]
           readinessProbe:
             exec:
               command:

--- a/apps/60-services/firefly-iii/base/deployment.yaml
+++ b/apps/60-services/firefly-iii/base/deployment.yaml
@@ -184,6 +184,10 @@ spec:
           envFrom:
             - secretRef:
                 name: firefly-iii-secrets
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "3"]
           readinessProbe:
             exec:
               command:

--- a/apps/60-services/vaultwarden/base/deployment.yaml
+++ b/apps/60-services/vaultwarden/base/deployment.yaml
@@ -144,6 +144,10 @@ spec:
               port: 9090
             initialDelaySeconds: 10
             periodSeconds: 30
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "3"]
           envFrom:
             - secretRef:
                 name: vaultwarden-secrets
@@ -182,6 +186,10 @@ spec:
                 sync_s3
                 sleep 60
               done
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "3"]
           volumeMounts:
             - name: data
               mountPath: /data


### PR DESCRIPTION
## Summary
Add `preStop: sleep 3` to sidecar containers that were missing it in the 8 critical apps from PR #2441. The Kyverno `check-graceful-shutdown` policy requires preStop on **all** containers, not just the main one.

## Changes
| App | Sidecar(s) fixed |
|---|---|
| authentik-server | config-syncer |
| vaultwarden | litestream, config-syncer |
| booklore-mariadb | db-backup |
| firefly-iii | config-syncer |

n8n, jellyfin, music-assistant, netbird-management had no sidecars — already compliant.

## Risk assessment
**Very low.** Same `sleep 3` pattern as main containers. Sidecars are background processes that handle graceful shutdown via SIGTERM anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced container deployment configurations across authentik, booklore, firefly-iii, and vaultwarden applications to improve graceful shutdown handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->