### PR TITLE
fix(frigate): remove /data volumeMount from dev DataAngel

### DIFF
--- a/apps/20-media/frigate/overlays/dev/dataangel.yaml
+++ b/apps/20-media/frigate/overlays/dev/dataangel.yaml
@@ -49,6 +49,8 @@ spec:
                   name: frigate-secrets
                   key: LITESTREAM_SECRET_ACCESS_KEY
           volumeMounts:
+            - mountPath: /data
+              $patch: delete
             - name: config
               mountPath: /config
             - name: cache


### PR DESCRIPTION
Fix kustomize build error: shared DataAngel component adds /data mount but frigate has no volume named data. Add $patch:delete to dev overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)