### PR TITLE
fix(audit): rename scanopy→netvisor + openclaw S3 IP + cleanup (#2286)

### DIFF
--- a/apps/04-databases/postgresql-shared/base/cluster.yaml
+++ b/apps/04-databases/postgresql-shared/base/cluster.yaml
@@ -41,11 +41,11 @@ spec:
       #        login: true
       #        passwordSecret:
       #          name: authentik-postgresql-credentials
-      - name: scanopy
+      - name: netvisor
         ensure: present
         login: true
         passwordSecret:
-          name: scanopy-postgresql-credentials
+          name: netvisor-postgresql-credentials
       - name: vaultwarden
         ensure: present
         login: true

--- a/apps/04-databases/postgresql-shared/base/credentials/netvisor-secret.yaml
+++ b/apps/04-databases/postgresql-shared/base/credentials/netvisor-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
-  name: scanopy-postgresql-credentials
+  name: netvisor-postgresql-credentials
   namespace: databases
   annotations:
     argocd.argoproj.io/sync-wave: "1"
@@ -19,6 +19,6 @@ spec:
         envSlug: dev
         secretsPath: /apps/40-network/netvisor
   managedSecretReference:
-    secretName: scanopy-postgresql-credentials
+    secretName: netvisor-postgresql-credentials
     creationPolicy: Owner
     secretNamespace: databases

--- a/apps/04-databases/postgresql-shared/base/databases/netvisor.yaml
+++ b/apps/04-databases/postgresql-shared/base/databases/netvisor.yaml
@@ -2,11 +2,11 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Database
 metadata:
-  name: scanopy
+  name: netvisor
   namespace: databases
 spec:
   cluster:
     name: postgresql-shared
-  name: scanopy
-  owner: scanopy
+  name: netvisor
+  owner: netvisor
   ensure: present

--- a/apps/04-databases/postgresql-shared/base/kustomization.yaml
+++ b/apps/04-databases/postgresql-shared/base/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
   - credentials/netbox-postgresql-credentials.yaml
   - credentials/authentik-secret.yaml
   - credentials/backup-s3-secret.yaml
-  - credentials/scanopy-secret.yaml
+  - credentials/netvisor-secret.yaml
   - credentials/vaultwarden-secret.yaml
   - credentials/nocodb-secret.yaml
   - credentials/firefly-iii-secret.yaml
@@ -19,7 +19,7 @@ resources:
   - credentials/vikunja-secret.yaml
   - credentials/n8n-secret.yaml
   - databases/docspell.yaml
-  - databases/scanopy.yaml
+  - databases/netvisor.yaml
   - databases/linkwarden.yaml
   - databases/netbox-database.yaml
   - databases/authentik.yaml

--- a/apps/04-databases/postgresql-shared/overlays/prod/patch-credentials-env.yaml
+++ b/apps/04-databases/postgresql-shared/overlays/prod/patch-credentials-env.yaml
@@ -67,7 +67,7 @@ spec:
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
-  name: scanopy-postgresql-credentials
+  name: netvisor-postgresql-credentials
   namespace: databases
 spec:
   authentication:

--- a/apps/60-services/openclaw/overlays/prod/dataangel.yaml
+++ b/apps/60-services/openclaw/overlays/prod/dataangel.yaml
@@ -13,7 +13,7 @@ spec:
         dataangel.io/bucket: "vixens-prod-openclaw"
         dataangel.io/sqlite-paths: ""
         dataangel.io/fs-paths: "/data"
-        dataangel.io/s3-endpoint: "http://synelia.internal.truxonline.com:9000"
+        dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
         dataangel.io/deployment-name: "openclaw"
         dataangel.io/rclone-interval: "15s"
         dataangel.io/metrics-enabled: "true"


### PR DESCRIPTION
## Summary
- **scanopy→netvisor rename:** files, kustomization refs, credentials, DB definition, cluster config, prod overlay
- **openclaw S3 endpoint:** `synelia.internal.truxonline.com` → `192.168.111.69` (consistent with all other apps)
- **MinIO:** deleted orphan bucket `backups-vixens-birdnet-go`

## Risk assessment
- scanopy rename: **medium** — changes K8s resource names for the netvisor PostgreSQL database. ArgoCD will recreate with new name. If the database already exists as "scanopy" in CloudNativePG, a manual rename/migration may be needed.
- openclaw endpoint: **low** — same server, different name
- bucket cleanup: **none** — unused bucket

## Test plan
- [x] kustomize build postgresql-shared/prod passes
- [x] kustomize build openclaw/prod shows IP endpoint

Part of #2286

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL database configuration across shared infrastructure resources
  * Modified S3-compatible storage endpoint address for internal services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->