### PR TITLE
hotfix(mosquitto): fix CreateContainerConfigError (runAsNonRoot)

### DIFF
--- a/apps/10-home/mosquitto/base/statefulset.yaml
+++ b/apps/10-home/mosquitto/base/statefulset.yaml
@@ -106,6 +106,9 @@ spec:
       containers:
         - name: mosquitto
           image: eclipse-mosquitto:2.0.22
+          securityContext:
+            runAsUser: 1883
+            runAsGroup: 1883
           ports:
             - name: mqtt
               containerPort: 1883
@@ -144,6 +147,9 @@ spec:
             failureThreshold: 3
         - name: config-syncer
           image: rclone/rclone:1.73
+          securityContext:
+            runAsUser: 1883
+            runAsGroup: 1883
           command:
             - sh
             - -c


### PR DESCRIPTION
Fix mosquitto crash after #2319 runAsNonRoot. Add explicit runAsUser: 1883 to mosquitto + config-syncer containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)