### PR TITLE
fix(infisical): standardize envSlug to dev in 10 base files (#2286)

### DIFF
--- a/apps/04-databases/postgresql-shared/base/credentials/n8n-secret.yaml
+++ b/apps/04-databases/postgresql-shared/base/credentials/n8n-secret.yaml
@@ -16,7 +16,7 @@ spec:
         secretNamespace: argocd
       secretsScope:
         projectSlug: vixens
-        envSlug: prod
+        envSlug: dev
         secretsPath: /apps/60-services/n8n
   managedSecretReference:
     secretName: n8n-db-credentials

--- a/apps/04-databases/postgresql-shared/overlays/prod/patch-credentials-env.yaml
+++ b/apps/04-databases/postgresql-shared/overlays/prod/patch-credentials-env.yaml
@@ -158,6 +158,19 @@ spec:
 apiVersion: secrets.infisical.com/v1alpha1
 kind: InfisicalSecret
 metadata:
+  name: n8n-db-credentials
+  namespace: databases
+spec:
+  authentication:
+    universalAuth:
+      secretsScope:
+        envSlug: prod
+  managedSecretReference:
+    secretNamespace: databases
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
   name: vikunja-db-secrets-sync
   namespace: databases
 spec:

--- a/apps/20-media/birdnet-go/base/infisical-secret.yaml
+++ b/apps/20-media/birdnet-go/base/infisical-secret.yaml
@@ -13,7 +13,7 @@ spec:
         secretNamespace: argocd
       secretsScope:
         projectSlug: vixens
-        envSlug: prod
+        envSlug: dev
         secretsPath: /apps/20-media/birdnet-go
   managedSecretReference:
     secretName: birdnet-go-secrets

--- a/apps/20-media/birdnet-go/overlays/prod/kustomization.yaml
+++ b/apps/20-media/birdnet-go/overlays/prod/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ingress.yaml
 
 components:
+  - ../../../../_shared/components/infisical/env-prod
   - ../../../../_shared/components/sync-wave/wave-8
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/poddisruptionbudget/1

--- a/apps/20-media/litestream-shared-secrets.yaml
+++ b/apps/20-media/litestream-shared-secrets.yaml
@@ -14,7 +14,7 @@ spec:
         secretNamespace: argocd
       secretsScope:
         projectSlug: vixens
-        envSlug: prod
+        envSlug: dev
         secretsPath: /shared/litestream
   managedSecretReference:
     creationPolicy: Owner

--- a/apps/40-network/external-dns-gandi/base/infisical-secret.yaml
+++ b/apps/40-network/external-dns-gandi/base/infisical-secret.yaml
@@ -13,7 +13,9 @@ spec:
         secretNamespace: argocd
       secretsScope:
         projectSlug: vixens
-        envSlug: prod
+        envSlug: dev
+        # TODO(#2286): secretsPath should be /apps/40-network/external-dns-gandi
+        # to match filesystem layout. Requires moving secrets in Infisical first.
         secretsPath: /apps/40-network/external-dns/gandi
   managedSecretReference:
     secretName: external-dns-gandi-secret

--- a/apps/40-network/external-dns-gandi/overlays/prod/kustomization.yaml
+++ b/apps/40-network/external-dns-gandi/overlays/prod/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 namespace: networking
 resources:
   - ../../base
+components:
+  - ../../../../_shared/components/infisical/env-prod
 labels:
   - pairs:
       environment: prod

--- a/apps/40-network/external-dns-unifi/base/infisical-secret.yaml
+++ b/apps/40-network/external-dns-unifi/base/infisical-secret.yaml
@@ -13,7 +13,9 @@ spec:
         secretNamespace: argocd
       secretsScope:
         projectSlug: vixens
-        envSlug: prod
+        envSlug: dev
+        # TODO(#2286): secretsPath should be /apps/40-network/external-dns-unifi
+        # to match filesystem layout. Requires moving secrets in Infisical first.
         secretsPath: /apps/40-network/external-dns/unifi
   managedSecretReference:
     secretName: external-dns-unifi-secret

--- a/apps/40-network/external-dns-unifi/overlays/prod/kustomization.yaml
+++ b/apps/40-network/external-dns-unifi/overlays/prod/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../../base
 
 components:
+  - ../../../../_shared/components/infisical/env-prod
   - ../../../../_shared/components/revision-history-limit
 
 patches:

--- a/apps/60-services/n8n/base/infisical-config.yaml
+++ b/apps/60-services/n8n/base/infisical-config.yaml
@@ -14,7 +14,7 @@ spec:
         secretNamespace: argocd
       secretsScope:
         projectSlug: vixens
-        envSlug: prod
+        envSlug: dev
         secretsPath: /apps/60-services/n8n
   managedSecretReference:
     secretName: n8n-db-credentials

--- a/apps/60-services/openclaw/base/infisical-config.yaml
+++ b/apps/60-services/openclaw/base/infisical-config.yaml
@@ -14,7 +14,7 @@ spec:
         secretNamespace: argocd
       secretsScope:
         projectSlug: vixens
-        envSlug: prod
+        envSlug: dev
         secretsPath: /apps/60-services/openclaw
   managedSecretReference:
     secretName: openclaw-config

--- a/apps/60-services/openclaw/base/infisical-secret.yaml
+++ b/apps/60-services/openclaw/base/infisical-secret.yaml
@@ -14,7 +14,7 @@ spec:
         secretNamespace: argocd
       secretsScope:
         projectSlug: vixens
-        envSlug: prod
+        envSlug: dev
         secretsPath: /apps/60-services/openclaw
   managedSecretReference:
     secretName: openclaw-secrets

--- a/apps/70-tools/penpot/base/infisical-secret.yaml
+++ b/apps/70-tools/penpot/base/infisical-secret.yaml
@@ -14,7 +14,7 @@ spec:
         secretNamespace: argocd
       secretsScope:
         projectSlug: vixens
-        envSlug: prod
+        envSlug: dev
         secretsPath: /apps/70-tools/penpot
   managedSecretReference:
     secretName: penpot-secrets

--- a/apps/70-tools/penpot/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/penpot/overlays/prod/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ../../base
 components:
+  - ../../../../_shared/components/infisical/env-prod
   - ../../../../_shared/components/sync-wave/wave-11
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics

--- a/apps/70-tools/vikunja/base/infisical-secret.yaml
+++ b/apps/70-tools/vikunja/base/infisical-secret.yaml
@@ -13,7 +13,7 @@ spec:
         secretNamespace: argocd
       secretsScope:
         projectSlug: vixens
-        envSlug: prod
+        envSlug: dev
         secretsPath: /apps/70-tools/vikunja
   managedSecretReference:
     secretName: vikunja-secrets


### PR DESCRIPTION
## Summary
Fix 10 base InfisicalSecret files that hardcoded `envSlug: prod` instead of `dev`. Convention: base = dev, prod overlay patches to prod.

Added `infisical/env-prod` component to prod overlays where missing (birdnet-go, penpot, external-dns-gandi, external-dns-unifi). Added n8n-db-credentials to postgresql-shared prod credentials patch.

Also added TODO comments for external-dns path mismatch (#5 from audit).

## Risk assessment
**Medium.** Changes Infisical envSlug for 10 secrets. Prod overlays are patched to maintain `prod` — verified with kustomize build. If any overlay is missing, the app would sync dev secrets in prod.

## Test plan
- [x] kustomize build verified for affected prod overlays

Part of #2286

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated secret management configurations across multiple applications to use development environment scopes for Infisical secret synchronization.
  * Enhanced production Kubernetes overlays with additional shared components for environment-specific configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->