### PR TITLE
hotfix: revert runAsNonRoot for netbird-management + nocodb

### DIFF
--- a/apps/40-network/netbird/base/management.yaml
+++ b/apps/40-network/netbird/base/management.yaml
@@ -24,6 +24,7 @@ spec:
         vixens.io/backup-profile: "relaxed"
       annotations:
         vixens.io/fast-start: "true"
+        vixens.io/explicitly-allow-root: "true"
     spec:
       priorityClassName: vixens-low
       tolerations:
@@ -100,8 +101,8 @@ spec:
             - name: config-writable
               mountPath: /etc/netbird
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
+        # runAsNonRoot: true  # disabled — management writes to /etc/netbird/management.json (permission denied as non-root)
+        # runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/apps/70-tools/nocodb/base/deployment.yaml
+++ b/apps/70-tools/nocodb/base/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         reloader.stakater.com/auto: "true"
         vixens.io/service-binding: "false"
         vixens.io/no-long-connections: "true"
+        vixens.io/explicitly-allow-root: "true"
     spec:
       priorityClassName: vixens-low
       tolerations:
@@ -97,8 +98,8 @@ spec:
           persistentVolumeClaim:
             claimName: nocodb-data
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
+        # runAsNonRoot: true  # disabled — SQLITE_READONLY (PVC owned by root, nocodb needs root to write)
+        # runAsUser: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:


### PR DESCRIPTION
Fix CrashLoopBackOff caused by #2319 runAsNonRoot. Both apps need root to write config/DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated deployment configurations for improved workload execution flexibility and root access allowance through pod-level annotations.
  * Modified security context settings to adjust user execution constraints in network and database deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->