### PR TITLE
hotfix(mosquitto): fix duplicate securityContext

### DIFF
--- a/apps/10-home/mosquitto/base/statefulset.yaml
+++ b/apps/10-home/mosquitto/base/statefulset.yaml
@@ -106,9 +106,6 @@ spec:
       containers:
         - name: mosquitto
           image: eclipse-mosquitto:2.0.22
-          securityContext:
-            runAsUser: 1883
-            runAsGroup: 1883
           ports:
             - name: mqtt
               containerPort: 1883


### PR DESCRIPTION
Fix kustomize build error: duplicate securityContext key on mosquitto container. Remove the one added by the previous hotfix — the existing block already has runAsUser: 1883.

🤖 Generated with [Claude Code](https://claude.com/claude-code)