### PR TITLE
fix(kyverno): fix cleanup policies — duration parse error (#2288)

### DIFF
--- a/apps/00-infra/kyverno/base/policies/cleanup-policies.yaml
+++ b/apps/00-infra/kyverno/base/policies/cleanup-policies.yaml
@@ -14,8 +14,8 @@ spec:
       - key: "{{ target.status.phase }}"
         operator: Equals
         value: Failed
-      - key: "{{ target.status.startTime }}"
-        operator: DurationGreaterThan
+      - key: "{{ time_since('', '{{ target.status.startTime }}', '') }}"
+        operator: GreaterThan
         value: 24h
   schedule: "*/30 * * * *"
 ---
@@ -34,8 +34,8 @@ spec:
       - key: "{{ target.status.phase }}"
         operator: Equals
         value: Succeeded
-      - key: "{{ target.status.startTime }}"
-        operator: DurationGreaterThan
+      - key: "{{ time_since('', '{{ target.status.startTime }}', '') }}"
+        operator: GreaterThan
         value: 24h
   schedule: "*/30 * * * *"
 ---
@@ -54,7 +54,7 @@ spec:
       - key: "{{ target.spec.replicas }}"
         operator: Equals
         value: 0
-      - key: "{{ target.metadata.creationTimestamp }}"
-        operator: DurationGreaterThan
-        value: 7d
+      - key: "{{ time_since('', '{{ target.metadata.creationTimestamp }}', '') }}"
+        operator: GreaterThan
+        value: 168h
   schedule: "@daily"


### PR DESCRIPTION
## Summary
All 3 ClusterCleanupPolicies were silently failing because `DurationGreaterThan` received raw ISO timestamps instead of durations. No resources were cleaned up since deployment.

**Root cause:** `target.metadata.creationTimestamp` returns `2026-03-21T03:01:03Z` but Kyverno's duration parser expects `168h`. Error in logs: `Failed to parse time duration: unknown unit "-" in duration "2026-03-21T03:01:03Z"`.

**Fix:** Wrap timestamps with `time_since()` JMESPath function to compute elapsed duration.

## Risk assessment
**Low.** The policies were already supposed to delete these resources — they just weren't working. This fix makes them functional.

## Test plan
- [ ] ArgoCD syncs kyverno policies
- [ ] Cleanup controller logs show successful deletions (no more parse errors)
- [ ] Empty ReplicaSets auto-cleaned within 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cleanup policy condition logic to use an improved method for calculating elapsed time before resource cleanup, ensuring consistent behavior with existing thresholds for failed/succeeded pods and orphaned replica sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->