### PR TITLE
fix(velero): enable CRD upgrades — backups broken for 2 weeks (#2287)

### DIFF
--- a/apps/00-infra/velero/values/common.yaml
+++ b/apps/00-infra/velero/values/common.yaml
@@ -69,7 +69,7 @@ schedules:
 # CLEANUP SETTINGS
 maintenanceCronJob:
   enabled: false
-upgradeCRDs: false
+upgradeCRDs: true
 cleanUpCRDs: false
 
 kubectl:


### PR DESCRIPTION
## Summary
Velero backups have been broken since ~March 10. Root cause: CRD validation rejects the "Queued" phase used by v1.18.0's backup-queue controller.

**Fix:** `upgradeCRDs: false` → `true` in Helm values.

## Root cause
Helm doesn't upgrade CRDs by default. Velero was upgraded to v1.18.0 (which adds "Queued" phase) but the CRD still had the old schema. Every backup attempt fails with:
```
status.phase: Unsupported value: "Queued": supported values: "New", "FailedValidation", ...
```

## Risk assessment
**Low.** CRD upgrade only adds new fields/enum values. Existing backups in MinIO are not affected. Once the CRD is updated, scheduled backups should resume automatically.

## Test plan
- [ ] ArgoCD syncs velero, CRD updated
- [ ] Manual backup completes successfully
- [ ] Scheduled backups resume on next cron trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)