### PR TITLE
fix(velero): enable ServerSideApply for CRD updates (#2287)

### DIFF
--- a/argocd/overlays/prod/apps/velero.yaml
+++ b/argocd/overlays/prod/apps/velero.yaml
@@ -34,6 +34,7 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true
   ignoreDifferences:
     - group: apps
       kind: Deployment


### PR DESCRIPTION
## Summary
Add `ServerSideApply=true` syncOption to the Velero ArgoCD Application. This allows ArgoCD to apply CRDs from the Helm chart, fixing the "Queued" phase validation error that broke all backups for ~2 weeks.

## Risk assessment
**Low-medium.** SSA changes how ArgoCD applies resources (field ownership). May trigger a one-time re-sync of all Velero resources. Existing data unaffected.

## Test plan
- [ ] ArgoCD syncs velero
- [ ] CRD includes "Queued" in status.phase enum
- [ ] Manual backup completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)