### PR TITLE
fix(velero): upgrade chart 11.3.2 → 12.0.0 — fix broken backups (#2287)

### DIFF
--- a/argocd/overlays/prod/apps/velero.yaml
+++ b/argocd/overlays/prod/apps/velero.yaml
@@ -16,7 +16,7 @@ spec:
   sources:
     - repoURL: https://vmware-tanzu.github.io/helm-charts
       chart: velero
-      targetRevision: 11.3.2
+      targetRevision: 12.0.0
       helm:
         valueFiles:
           - $values/apps/00-infra/velero/values/common.yaml


### PR DESCRIPTION
## Summary
Upgrade Velero Helm chart from 11.3.2 to 12.0.0. The old chart CRDs lacked the "Queued" phase enum, breaking all backups since ~March 10.

## Risk assessment
**Medium.** Major chart version bump (11→12). May include breaking changes in values schema. However, backups are currently completely broken, so the risk of NOT upgrading is higher.

## Test plan
- [ ] ArgoCD syncs velero
- [ ] CRD includes "Queued" phase
- [ ] Manual backup completes
- [ ] Scheduled backups resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)