### PR TITLE
feat(velero): expand daily backup coverage to all app namespaces (#2287)

### DIFF
--- a/apps/00-infra/velero/values/common.yaml
+++ b/apps/00-infra/velero/values/common.yaml
@@ -47,16 +47,23 @@ schedules:
     schedule: "0 2 * * *"
     template:
       ttl: "720h"
-      includedNamespaces: ["databases", "tools", "security"]
+      includedNamespaces: ["databases", "tools", "security", "services", "finance", "auth", "networking"]
       snapshotVolumes: true
   daily-home:
     disabled: false
     schedule: "0 4 * * *"
     template:
       ttl: "168h"
-      includedNamespaces: ["home", "homeassistant"]
+      includedNamespaces: ["homeassistant", "mealie", "mosquitto"]
       snapshotVolumes: true
       defaultVolumesToFsBackup: true
+  daily-media:
+    disabled: false
+    schedule: "0 5 * * *"
+    template:
+      ttl: "168h"
+      includedNamespaces: ["media", "birdnet-go", "downloads"]
+      snapshotVolumes: true
   weekly-full:
     disabled: false
     schedule: "0 3 * * 0"


### PR DESCRIPTION
## Summary
Expand Velero scheduled backups to cover all application namespaces with user data.

| Schedule | Before | After |
|---|---|---|
| daily-critical (2AM) | databases, tools, security | + services, finance, auth, networking |
| daily-home (4AM) | home (nonexistent!), homeassistant | homeassistant, mealie, mosquitto |
| daily-media (5AM) | N/A | **NEW** — media, birdnet-go, downloads |
| weekly-full (Sun 3AM) | * (unchanged) | * (unchanged) |

## Risk assessment
**Low.** Only adds namespaces to existing schedules + creates one new schedule. No changes to existing backup behavior. May increase MinIO storage usage (~30-50% more daily backups).

## Test plan
- [ ] ArgoCD syncs velero schedules
- [ ] New schedules appear in `kubectl -n velero get schedules`
- [ ] First daily-media backup runs at 5AM tomorrow

Closes #2287

🤖 Generated with [Claude Code](https://claude.com/claude-code)