### PR TITLE
chore: add timeZone Europe/Paris to all CronJobs (#2276)

### DIFF
--- a/apps/00-infra/maturity-controller/base/cronjob.yaml
+++ b/apps/00-infra/maturity-controller/base/cronjob.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: kyverno
 spec:
   schedule: "*/15 * * * *"
+  timeZone: Europe/Paris
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1

--- a/apps/02-monitoring/descheduler/base/descheduler-gen.yaml
+++ b/apps/02-monitoring/descheduler/base/descheduler-gen.yaml
@@ -197,6 +197,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   schedule: 0 */4 * * *
+  timeZone: Europe/Paris
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/apps/60-services/firefly-iii/base/cronjob.yaml
+++ b/apps/60-services/firefly-iii/base/cronjob.yaml
@@ -7,6 +7,7 @@ metadata:
     vixens.lab/managed-by: argocd
 spec:
   schedule: "0 3 * * *"
+  timeZone: Europe/Paris
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/apps/70-tools/renovate/base/cronjob.yaml
+++ b/apps/70-tools/renovate/base/cronjob.yaml
@@ -5,6 +5,7 @@ metadata:
   name: renovate
 spec:
   schedule: 0 */6 * * * # Every 6 hours
+  timeZone: Europe/Paris
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3


### PR DESCRIPTION
## Summary
Add `timeZone: Europe/Paris` to all 4 K8s CronJobs. Without it, schedules run in UTC (1-2h shift from local time).

## Risk assessment
**Very low.** Only affects scheduling time, not job logic. Most jobs run frequently enough that the shift is negligible. Biggest impact: firefly-iii-cron now runs at 3AM Paris instead of 3AM UTC (4-5AM Paris).

Closes #2276

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated timezone configuration for scheduled system tasks to Europe/Paris across infrastructure management, monitoring, financial services, and dependency management components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->