### PR TITLE
chore: yamllint 80→120 chars + ignore CRDs (#2260)

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,12 +1,17 @@
 ---
-# Ne pas utiliser "extends" si vous personnalisez tout
 extends: default
 
-# Ignore patterns
+# Ignore auto-generated CRDs/manifests (reformatted on each upgrade)
 ignore: |
   backups/
   .git/
   .terraform/
+  apps/00-infra/argocd/base/argocd-crds.yaml
+  apps/00-infra/prometheus-operator-crds/
+  apps/00-infra/vpa/base/manifests.yaml
+  apps/00-infra/snapshot-controller/base/crds/
+  apps/03-security/trivy/base/manifests.yaml
+  apps/02-monitoring/descheduler/base/descheduler-gen.yaml
 
 yaml-files:
   - '*.yaml'
@@ -26,8 +31,9 @@ rules:
 
   # ============ WARNINGS ============
   line-length:
-    max: 80
+    max: 120
     allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
     level: warning
 
   trailing-spaces:
@@ -38,7 +44,6 @@ rules:
     level: warning
 
   # ============ DÉSACTIVÉES ============
-  # Syntaxe CORRECTE pour désactiver :
   comments: disable
   comments-indentation: disable
   brackets: disable


### PR DESCRIPTION
## Summary
- Line-length limit: 80 → 120 chars
- Ignore auto-generated CRDs/manifests (argocd-crds, prometheus, VPA, snapshot-controller, trivy, descheduler)
- Add `allow-non-breakable-inline-mappings: true`

**Before:** 3854 warnings in 278 files
**After:** ~150 warnings in 56 files (80% reduction)

## Risk assessment
**None.** yamllint is advisory (warnings only). No functional change.

Closes #2260

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to exclude additional auto-generated files and relaxed line-length constraints to accommodate longer code patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->