### PR TITLE
perf: reduce goldilocks-dashboard + webhook-gandi to 1 replica

### DIFF
--- a/apps/00-infra/cert-manager-webhook-gandi/values/common.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/values/common.yaml
@@ -7,6 +7,7 @@
 # ============================================================================
 # Group name for the ACME DNS solver
 # Must match the group used in ClusterIssuer
+replicaCount: 1
 groupName: acme.truxonline.com
 # ============================================================================
 # Control Plane Tolerations

--- a/apps/02-monitoring/goldilocks/values/common.yaml
+++ b/apps/02-monitoring/goldilocks/values/common.yaml
@@ -30,6 +30,7 @@ controller:
   revisionHistoryLimit: 3
 
 dashboard:
+  replicaCount: 1
   tolerations:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists


### PR DESCRIPTION
## Summary
Set `replicaCount: 1` for goldilocks-dashboard and cert-manager-webhook-gandi. Both were at Helm default of 2 with no need for HA.

## Risk assessment
**Very low.** goldilocks-dashboard is a read-only UI. webhook-gandi handles DNS-01 challenges only during certificate renewal (minutes per month).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configurations for cert-manager webhook and monitoring dashboard services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->