### PR TITLE
feat(monitoring): PVC Pending alert rules (#2282)

### DIFF
--- a/apps/02-monitoring/victoria-metrics/base/kustomization.yaml
+++ b/apps/02-monitoring/victoria-metrics/base/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 namespace: monitoring
 resources:
   - alertmanager-infisical-secret.yaml
+  - vmrule-pvc-pending.yaml

--- a/apps/02-monitoring/victoria-metrics/base/vmrule-pvc-pending.yaml
+++ b/apps/02-monitoring/victoria-metrics/base/vmrule-pvc-pending.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  name: pvc-pending-alert
+  namespace: monitoring
+spec:
+  groups:
+    - name: pvc-health
+      rules:
+        - alert: PVCPendingTooLong
+          expr: |
+            kube_persistentvolumeclaim_status_phase{phase="Pending"} == 1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} stuck in Pending"
+            description: >-
+              PVC {{ $labels.persistentvolumeclaim }} in namespace
+              {{ $labels.namespace }} has been Pending for more than 10 minutes.
+              This may indicate a CSI provisioning failure or WaitForFirstConsumer
+              deadlock.
+        - alert: PVCPendingCritical
+          expr: |
+            kube_persistentvolumeclaim_status_phase{phase="Pending"} == 1
+          for: 30m
+          labels:
+            severity: critical
+          annotations:
+            summary: "PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} stuck in Pending for 30min+"
+            description: >-
+              PVC {{ $labels.persistentvolumeclaim }} in namespace
+              {{ $labels.namespace }} has been Pending for more than 30 minutes.
+              Immediate investigation required — storage provisioning is broken.


### PR DESCRIPTION
## Summary
Add VMRule with 2 alerts for PVCs stuck in Pending:
- **PVCPendingTooLong** (warning, >10min)
- **PVCPendingCritical** (critical, >30min)

## Risk assessment
**None.** Adds alerting rules only.

Closes #2282

🤖 Generated with [Claude Code](https://claude.com/claude-code)