### PR TITLE
feat(birdnet-go): migrate to DataAngel — last legacy litestream app (#2279)

### DIFF
--- a/apps/20-media/birdnet-go/overlays/prod/dataangel.yaml
+++ b/apps/20-media/birdnet-go/overlays/prod/dataangel.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: birdnet-go
+spec:
+  template:
+    metadata:
+      labels:
+        vixens.io/sizing.dataangel: V-small
+        vixens.io/sizing.litestream: null
+        vixens.io/sizing.data-syncer: null
+        vixens.io/sizing.fix-permissions: null
+      annotations:
+        dataangel.io/bucket: "vixens-prod-birdnet-go"
+        dataangel.io/sqlite-paths: "/data/birdnet.db"
+        dataangel.io/fs-paths: "/data"
+        dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
+        dataangel.io/deployment-name: "birdnet-go"
+        dataangel.io/rclone-interval: "60s"
+        dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
+    spec:
+      initContainers:
+        - name: fix-permissions
+          $patch: delete
+        - name: generate-litestream-config
+          $patch: delete
+        - name: litestream-restore
+          $patch: delete
+        - name: dataangel
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 9090
+            periodSeconds: 2
+            failureThreshold: 3600
+          env:
+            - name: DATA_GUARD_EXCLUDE_PATTERNS
+              value: "clips/**,lost+found/**"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: birdnet-go-secrets
+                  key: LITESTREAM_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: birdnet-go-secrets
+                  key: LITESTREAM_SECRET_ACCESS_KEY
+          volumeMounts:
+            - mountPath: /data
+              $patch: delete
+            - name: data
+              mountPath: /data
+      containers:
+        - name: litestream
+          $patch: delete
+        - name: data-syncer
+          $patch: delete

--- a/apps/20-media/birdnet-go/overlays/prod/kustomization.yaml
+++ b/apps/20-media/birdnet-go/overlays/prod/kustomization.yaml
@@ -11,6 +11,8 @@ components:
   - ../../../../_shared/components/sync-wave/wave-8
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/poddisruptionbudget/1
+  - ../../../../_shared/components/dataangel
 
 patches:
   - path: resources-patch.yaml
+  - path: dataangel.yaml


### PR DESCRIPTION
## Summary
Migrate birdnet-go from legacy litestream+rclone (5 containers) to DataAngel (1 container). This is the **last app** using the legacy backup pattern.

## Changes
- Delete: fix-permissions, generate-litestream-config, litestream-restore, litestream, data-syncer
- Add: DataAngel shared component + overlay
- Exclude patterns: `clips/**,lost+found/**` (NFS clips not backed up to S3)

## Risk assessment
**Low.** Same pattern as 15 other apps already migrated. Bucket exists. Secrets exist. strategy: Recreate.

## Test plan
- [x] kustomize build — 1 init (dataangel) + 1 container (birdnet-go)
- [ ] ArgoCD syncs, pod starts with DataAngel
- [ ] DataAngel restores DB + FS from S3

Closes #2279

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production deployment configuration for birdnet-go service with enhanced storage integration and monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->