### PR TITLE
fix(docspell): NetworkPolicy port 7878→7880 — fixes 504 (#2238)

### DIFF
--- a/apps/60-services/docspell/base/networkpolicy.yaml
+++ b/apps/60-services/docspell/base/networkpolicy.yaml
@@ -18,7 +18,7 @@ spec:
               kubernetes.io/metadata.name: traefik
       ports:
         - protocol: TCP
-          port: 7878
+          port: 7880
   egress:
     # Allow all egress (homelab: DNS, inter-app, external APIs)
     - {}


### PR DESCRIPTION
## Summary
Fix docspell ingress 504 Gateway Timeout. NetworkPolicy allowed traefik on port 7878 (joex) instead of 7880 (restserver).

## Root cause
Port 7878 is the joex internal processing port. The restserver (which serves the web UI) listens on 7880.

## Test plan
- [ ] `curl -sk https://docspell.truxonline.com/` returns 200

Closes #2238

🤖 Generated with [Claude Code](https://claude.com/claude-code)