### PR TITLE
fix(kyverno): adapt 3 maturity policies for DataAngel (#2240)

### DIFF
--- a/apps/00-infra/kyverno/base/policies/check-config-syncer-relevance.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-config-syncer-relevance.yaml
@@ -28,6 +28,6 @@ spec:
         deny:
           conditions:
             all:
-              - key: "{{ request.object.spec.containers[?contains(image, 'rclone')] | length(@) }}"
+              - key: "{{ (request.object.spec.containers[?contains(image, 'rclone')] | length(@)) + ((request.object.spec.initContainers || `[]`)[?contains(image, 'dataangel')] | length(@)) }}"
                 operator: Equals
                 value: 0

--- a/apps/00-infra/kyverno/base/policies/check-restore-init.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-restore-init.yaml
@@ -23,6 +23,6 @@ spec:
         deny:
           conditions:
             all:
-              - key: "{{ (request.object.spec.initContainers || `[]`)[?contains(name, 'restore') || contains(name, 'init')] | length(@) }}"
+              - key: "{{ (request.object.spec.initContainers || `[]`)[?contains(name, 'restore') || contains(name, 'init') || contains(name, 'dataangel')] | length(@) }}"
                 operator: Equals
                 value: 0

--- a/apps/00-infra/kyverno/base/policies/check-sidecar-relevance.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-sidecar-relevance.yaml
@@ -33,7 +33,7 @@ spec:
                   - key: "{{ request.object.spec.volumes[?contains(name, 'config')] }}" # Has config volume
                     operator: NotEquals
                     value: ""
-                  - key: "{{ request.object.spec.containers[?contains(image, 'litestream')] | length(@) }}" # No litestream
+                  - key: "{{ (request.object.spec.containers[?contains(image, 'litestream')] | length(@)) + ((request.object.spec.initContainers || `[]`)[?contains(image, 'dataangel')] | length(@)) }}"
                     operator: Equals
                     value: 0
                   - key: "{{ request.object.metadata.labels.app }}" # Filter out known non-sqlite apps


### PR DESCRIPTION
## Summary
Update 3 Kyverno maturity policies to recognize DataAngel as a valid replacement for litestream, config-syncer, and restore-* init containers.

## Changes
- `check-sidecar-relevance`: also check initContainers for image containing 'dataangel'
- `check-restore-init`: also match init container name 'dataangel'
- `check-config-syncer-relevance`: also check initContainers for image containing 'dataangel'

## Risk assessment
**Very low.** Audit-mode policies only. Removes false positives that were blocking maturity scoring for DataAngel-migrated apps.

Closes #2240

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster validation policies to recognize additional container configurations, including newly supported container images in both standard and initialization containers for enhanced deployment compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->