### PR TITLE
feat: homepage annotations for 20 apps + Kyverno gate (#2232)

### DIFF
--- a/apps/00-infra/kyverno/base/policies/check-homepage-annotations.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-homepage-annotations.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: check-homepage-annotations
+  annotations:
+    policies.kyverno.io/title: Check Homepage Dashboard Annotations
+    policies.kyverno.io/category: Maturity (Silver)
+    policies.kyverno.io/severity: low
+    policies.kyverno.io/description: >-
+      All user-facing Ingresses must have gethomepage.dev annotations
+      for automatic dashboard discovery (Silver maturity requirement).
+      HTTP redirect ingresses and infrastructure ingresses are excluded.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: require-homepage-annotations
+      match:
+        any:
+          - resources:
+              kinds:
+                - Ingress
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - argocd
+                - cert-manager
+                - kyverno
+                - velero
+                - vpa
+                - synology-csi
+                - local-path-storage
+                - policy-reporter
+          - resources:
+              names:
+                - "*-http-redirect"
+                - "*-redirect"
+      validate:
+        message: "Ingress must have gethomepage.dev/name annotation for dashboard integration (Silver maturity)."
+        pattern:
+          metadata:
+            annotations:
+              gethomepage.dev/name: "?*"

--- a/apps/00-infra/kyverno/base/policies/kustomization.yaml
+++ b/apps/00-infra/kyverno/base/policies/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - check-cp-toleration.yaml
   - check-explicit-resources.yaml
   - check-graceful-shutdown.yaml
+  - check-homepage-annotations.yaml
   - check-image-digest.yaml
   - check-image-tag.yaml
   - check-infisical-secrets.yaml

--- a/apps/02-monitoring/goldilocks/overlays/dev/ingress.yaml
+++ b/apps/02-monitoring/goldilocks/overlays/dev/ingress.yaml
@@ -8,6 +8,11 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-staging
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Monitoring
+    gethomepage.dev/name: Goldilocks
+    gethomepage.dev/icon: goldilocks.svg
+    gethomepage.dev/description: Resource recommendations
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/02-monitoring/goldilocks/overlays/prod/ingress.yaml
+++ b/apps/02-monitoring/goldilocks/overlays/prod/ingress.yaml
@@ -8,6 +8,11 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Monitoring
+    gethomepage.dev/name: Goldilocks
+    gethomepage.dev/icon: goldilocks.svg
+    gethomepage.dev/description: Resource recommendations
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/03-security/authentik/overlays/dev/ingress.yaml
+++ b/apps/03-security/authentik/overlays/dev/ingress.yaml
@@ -8,6 +8,11 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-staging
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd, auth-authentik-cors@kubernetescrd
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Security
+    gethomepage.dev/name: Authentik
+    gethomepage.dev/icon: authentik.svg
+    gethomepage.dev/description: Identity provider & SSO
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/03-security/authentik/overlays/prod/ingress.yaml
+++ b/apps/03-security/authentik/overlays/prod/ingress.yaml
@@ -10,6 +10,11 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd, auth-authentik-cors@kubernetescrd
     vixens.io/nossoneeded: "true"
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Security
+    gethomepage.dev/name: Authentik
+    gethomepage.dev/icon: authentik.svg
+    gethomepage.dev/description: Identity provider & SSO
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/10-home/mealie/overlays/dev/ingress.yaml
+++ b/apps/10-home/mealie/overlays/dev/ingress.yaml
@@ -8,6 +8,11 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-staging
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Home
+    gethomepage.dev/name: Mealie
+    gethomepage.dev/icon: mealie.svg
+    gethomepage.dev/description: Recipe manager
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/10-home/mealie/overlays/prod/ingress.yaml
+++ b/apps/10-home/mealie/overlays/prod/ingress.yaml
@@ -11,6 +11,11 @@ metadata:
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
     vixens.io/nossoneeded: "true"
     # external-dns.alpha.kubernetes.io/target: truxonline.com
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Home
+    gethomepage.dev/name: Mealie
+    gethomepage.dev/icon: mealie.svg
+    gethomepage.dev/description: Recipe manager
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/20-media/amule/overlays/dev/ingress.yaml
+++ b/apps/20-media/amule/overlays/dev/ingress.yaml
@@ -8,6 +8,11 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-staging
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Downloads
+    gethomepage.dev/name: aMule
+    gethomepage.dev/icon: amule.svg
+    gethomepage.dev/description: eDonkey/Kad file sharing client
 spec:
   rules:
     - host: amule.dev.truxonline.com

--- a/apps/20-media/amule/overlays/prod/ingress.yaml
+++ b/apps/20-media/amule/overlays/prod/ingress.yaml
@@ -8,6 +8,11 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Downloads
+    gethomepage.dev/name: aMule
+    gethomepage.dev/icon: amule.svg
+    gethomepage.dev/description: eDonkey/Kad file sharing client
 spec:
   rules:
     - host: amule.truxonline.com

--- a/apps/20-media/hydrus-client/overlays/prod/ingress-api.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/ingress-api.yaml
@@ -7,6 +7,11 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Media
+    gethomepage.dev/name: Hydrus
+    gethomepage.dev/icon: hydrus.svg
+    gethomepage.dev/description: Hydrus API endpoint
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/20-media/pyload/overlays/dev/ingress.yaml
+++ b/apps/20-media/pyload/overlays/dev/ingress.yaml
@@ -8,6 +8,11 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-staging
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Downloads
+    gethomepage.dev/name: pyLoad
+    gethomepage.dev/icon: pyload.svg
+    gethomepage.dev/description: Download manager
 spec:
   rules:
     - host: pyload.dev.truxonline.com

--- a/apps/20-media/pyload/overlays/prod/ingress.yaml
+++ b/apps/20-media/pyload/overlays/prod/ingress.yaml
@@ -8,6 +8,11 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Downloads
+    gethomepage.dev/name: pyLoad
+    gethomepage.dev/icon: pyload.svg
+    gethomepage.dev/description: Download manager
 spec:
   rules:
     - host: pyload.truxonline.com

--- a/apps/20-media/qbittorrent/overlays/dev/ingress.yaml
+++ b/apps/20-media/qbittorrent/overlays/dev/ingress.yaml
@@ -8,6 +8,11 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-staging
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Downloads
+    gethomepage.dev/name: qBittorrent
+    gethomepage.dev/icon: qbittorrent.svg
+    gethomepage.dev/description: BitTorrent client
 spec:
   rules:
     - host: qbittorrent.dev.truxonline.com

--- a/apps/20-media/qbittorrent/overlays/prod/ingress.yaml
+++ b/apps/20-media/qbittorrent/overlays/prod/ingress.yaml
@@ -8,6 +8,11 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Downloads
+    gethomepage.dev/name: qBittorrent
+    gethomepage.dev/icon: qbittorrent.svg
+    gethomepage.dev/description: BitTorrent client
 spec:
   rules:
     - host: qbittorrent.truxonline.com

--- a/apps/40-network/adguard-home/overlays/dev/ingress.yaml
+++ b/apps/40-network/adguard-home/overlays/dev/ingress.yaml
@@ -8,6 +8,11 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-staging
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Network
+    gethomepage.dev/name: AdGuard Home
+    gethomepage.dev/icon: adguard-home.svg
+    gethomepage.dev/description: DNS ad blocker
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/40-network/adguard-home/overlays/prod/ingress.yaml
+++ b/apps/40-network/adguard-home/overlays/prod/ingress.yaml
@@ -5,7 +5,11 @@ metadata:
   name: adguard-home
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
-
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Network
+    gethomepage.dev/name: AdGuard Home
+    gethomepage.dev/icon: adguard-home.svg
+    gethomepage.dev/description: DNS ad blocker
 spec:
   rules:
     - host: adguard.truxonline.com

--- a/apps/40-network/netbird/overlays/dev/ingress.yaml
+++ b/apps/40-network/netbird/overlays/dev/ingress.yaml
@@ -7,6 +7,11 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Network
+    gethomepage.dev/name: NetBird
+    gethomepage.dev/icon: netbird.svg
+    gethomepage.dev/description: VPN management dashboard
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/40-network/netbird/overlays/prod/ingress.yaml
+++ b/apps/40-network/netbird/overlays/prod/ingress.yaml
@@ -9,6 +9,11 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     vixens.io/nossoneeded: "true"
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Network
+    gethomepage.dev/name: NetBird
+    gethomepage.dev/icon: netbird.svg
+    gethomepage.dev/description: VPN management dashboard
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/60-services/docspell/overlays/prod/ingress.yaml
+++ b/apps/60-services/docspell/overlays/prod/ingress.yaml
@@ -11,6 +11,11 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
     vixens.io/nossoneeded: "true"
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Services
+    gethomepage.dev/name: Docspell
+    gethomepage.dev/icon: docspell.svg
+    gethomepage.dev/description: Document management system
 spec:
   ingressClassName: traefik
   tls:

--- a/apps/60-services/firefly-iii-importer/base/ingress.yaml
+++ b/apps/60-services/firefly-iii-importer/base/ingress.yaml
@@ -7,6 +7,11 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Finance
+    gethomepage.dev/name: Firefly III Importer
+    gethomepage.dev/icon: firefly-iii.svg
+    gethomepage.dev/description: Transaction importer for Firefly III
 spec:
   rules:
     - host: importer.truxonline.com

--- a/apps/60-services/firefly-iii/base/ingress.yaml
+++ b/apps/60-services/firefly-iii/base/ingress.yaml
@@ -9,6 +9,11 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Finance
+    gethomepage.dev/name: Firefly III
+    gethomepage.dev/icon: firefly-iii.svg
+    gethomepage.dev/description: Personal finance manager
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/60-services/g4f/base/ingress.yaml
+++ b/apps/60-services/g4f/base/ingress.yaml
@@ -8,6 +8,11 @@ metadata:
     traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: AI
+    gethomepage.dev/name: G4F
+    gethomepage.dev/icon: gpt-4.svg
+    gethomepage.dev/description: GPT4Free API provider
 spec:
   rules:
     - host: g4f.truxonline.com

--- a/apps/70-tools/headlamp/overlays/dev/ingress.yaml
+++ b/apps/70-tools/headlamp/overlays/dev/ingress.yaml
@@ -7,6 +7,11 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-staging
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Tools
+    gethomepage.dev/name: Headlamp
+    gethomepage.dev/icon: headlamp.svg
+    gethomepage.dev/description: Kubernetes dashboard
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/70-tools/headlamp/overlays/prod/ingress.yaml
+++ b/apps/70-tools/headlamp/overlays/prod/ingress.yaml
@@ -9,6 +9,11 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
     vixens.io/nossoneeded: "true"
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Tools
+    gethomepage.dev/name: Headlamp
+    gethomepage.dev/icon: headlamp.svg
+    gethomepage.dev/description: Kubernetes dashboard
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/70-tools/linkwarden/overlays/dev/ingress.yaml
+++ b/apps/70-tools/linkwarden/overlays/dev/ingress.yaml
@@ -10,6 +10,11 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-staging
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Tools
+    gethomepage.dev/name: Linkwarden
+    gethomepage.dev/icon: linkwarden.svg
+    gethomepage.dev/description: Bookmark manager
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/70-tools/linkwarden/overlays/prod/ingress.yaml
+++ b/apps/70-tools/linkwarden/overlays/prod/ingress.yaml
@@ -11,6 +11,11 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
     vixens.io/nossoneeded: "true"
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Tools
+    gethomepage.dev/name: Linkwarden
+    gethomepage.dev/icon: linkwarden.svg
+    gethomepage.dev/description: Bookmark manager
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/70-tools/nocodb/base/ingress.yaml
+++ b/apps/70-tools/nocodb/base/ingress.yaml
@@ -8,6 +8,11 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-staging
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Tools
+    gethomepage.dev/name: NocoDB
+    gethomepage.dev/icon: nocodb.svg
+    gethomepage.dev/description: Open source Airtable alternative
 spec:
   ingressClassName: traefik
   tls:

--- a/apps/70-tools/penpot/base/service-ingress.yaml
+++ b/apps/70-tools/penpot/base/service-ingress.yaml
@@ -58,6 +58,11 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Tools
+    gethomepage.dev/name: Penpot
+    gethomepage.dev/icon: penpot.svg
+    gethomepage.dev/description: Open source design platform
 spec:
   ingressClassName: traefik
   tls:

--- a/apps/70-tools/radar/overlays/dev/ingress.yaml
+++ b/apps/70-tools/radar/overlays/dev/ingress.yaml
@@ -9,6 +9,11 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Tools
+    gethomepage.dev/name: Radar
+    gethomepage.dev/icon: radar.svg
+    gethomepage.dev/description: Technology radar
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/70-tools/radar/overlays/prod/ingress.yaml
+++ b/apps/70-tools/radar/overlays/prod/ingress.yaml
@@ -9,6 +9,11 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Tools
+    gethomepage.dev/name: Radar
+    gethomepage.dev/icon: radar.svg
+    gethomepage.dev/description: Technology radar
 spec:
   ingressClassName: traefik
   rules:

--- a/apps/70-tools/trilium/base/ingress.yaml
+++ b/apps/70-tools/trilium/base/ingress.yaml
@@ -6,6 +6,11 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-staging
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Tools
+    gethomepage.dev/name: Trilium
+    gethomepage.dev/icon: trilium.svg
+    gethomepage.dev/description: Personal knowledge base
 spec:
   ingressClassName: traefik
   tls:

--- a/apps/70-tools/vikunja/base/ingress.yaml
+++ b/apps/70-tools/vikunja/base/ingress.yaml
@@ -6,6 +6,11 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-staging
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Tools
+    gethomepage.dev/name: Vikunja
+    gethomepage.dev/icon: vikunja.svg
+    gethomepage.dev/description: Task management
 spec:
   ingressClassName: traefik
   tls:


### PR DESCRIPTION
## Summary
- Add `gethomepage.dev` annotations to 31 ingress files across 20 apps
- New Kyverno `check-homepage-annotations` policy (Silver maturity, Audit)

## Apps annotated
Authentik, Firefly III (+importer), Mealie, Hydrus, qBittorrent, Docspell, G4F, Headlamp, Linkwarden, NocoDB, Penpot, Radar, Trilium, Vikunja, NetBird, AdGuard Home, Goldilocks, aMule, pyLoad

## Risk assessment
**Very low.** Annotations only — no functional change. Kyverno policy in Audit mode.

Closes #2232

🤖 Generated with [Claude Code](https://claude.com/claude-code)