### PR TITLE
fix(sabnzbd): allow arr apps ingress in NetworkPolicy (#2208)

### DIFF
--- a/apps/20-media/sabnzbd/base/networkpolicy.yaml
+++ b/apps/20-media/sabnzbd/base/networkpolicy.yaml
@@ -19,6 +19,12 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
+    # Allow ingress from media namespace (arr apps: whisparr, radarr, sonarr, etc.)
+    - from:
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: 8080
   egress:
     # Allow all egress (homelab: DNS, inter-app, external APIs)
     - {}


### PR DESCRIPTION
## Summary
Sabnzbd NetworkPolicy only allowed ingress from traefik. Arr apps (whisparr, radarr, sonarr) in the same namespace were blocked → download commands failed.

Fix: add `podSelector: {}` rule for same-namespace ingress on port 8080.

## Risk assessment
**Very low.** Only opens ingress from pods in the same namespace (media).

Closes #2208

🤖 Generated with [Claude Code](https://claude.com/claude-code)