### PR TITLE
feat(homepage): dynamic widgets for 5 arr/download apps (#2243)

### DIFF
--- a/apps/20-media/lidarr/overlays/prod/ingress.yaml
+++ b/apps/20-media/lidarr/overlays/prod/ingress.yaml
@@ -10,6 +10,9 @@ metadata:
     gethomepage.dev/name: Lidarr
     gethomepage.dev/icon: lidarr.png
     gethomepage.dev/group: Media
+    gethomepage.dev/widget.type: "lidarr"
+    gethomepage.dev/widget.url: "http://lidarr.media.svc.cluster.local:8686"
+    gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_LIDARR_API_KEY}}"
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
 spec:
   ingressClassName: traefik

--- a/apps/20-media/radarr/overlays/prod/ingress.yaml
+++ b/apps/20-media/radarr/overlays/prod/ingress.yaml
@@ -10,6 +10,9 @@ metadata:
     gethomepage.dev/name: Radarr
     gethomepage.dev/icon: radarr.png
     gethomepage.dev/group: Media
+    gethomepage.dev/widget.type: "radarr"
+    gethomepage.dev/widget.url: "http://radarr.media.svc.cluster.local:7878"
+    gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_RADARR_API_KEY}}"
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
 spec:
   ingressClassName: traefik

--- a/apps/20-media/sabnzbd/overlays/prod/ingress.yaml
+++ b/apps/20-media/sabnzbd/overlays/prod/ingress.yaml
@@ -11,6 +11,9 @@ metadata:
     gethomepage.dev/name: SABnzbd
     gethomepage.dev/icon: sabnzbd.png
     gethomepage.dev/group: Media
+    gethomepage.dev/widget.type: "sabnzbd"
+    gethomepage.dev/widget.url: "http://sabnzbd.media.svc.cluster.local:8080"
+    gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_SABNZBD_API_KEY}}"
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
     vixens.io/nossoneeded: "true"
 spec:

--- a/apps/20-media/sonarr/overlays/prod/ingress.yaml
+++ b/apps/20-media/sonarr/overlays/prod/ingress.yaml
@@ -10,6 +10,9 @@ metadata:
     gethomepage.dev/name: Sonarr
     gethomepage.dev/icon: sonarr.png
     gethomepage.dev/group: Media
+    gethomepage.dev/widget.type: "sonarr"
+    gethomepage.dev/widget.url: "http://sonarr.media.svc.cluster.local:8989"
+    gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_SONARR_API_KEY}}"
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
 spec:
   ingressClassName: traefik

--- a/apps/20-media/whisparr/overlays/prod/ingress.yaml
+++ b/apps/20-media/whisparr/overlays/prod/ingress.yaml
@@ -10,6 +10,9 @@ metadata:
     gethomepage.dev/name: Whisparr
     gethomepage.dev/icon: whisparr.png
     gethomepage.dev/group: Media
+    gethomepage.dev/widget.type: "sonarr"
+    gethomepage.dev/widget.url: "http://whisparr.media.svc.cluster.local:6969"
+    gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_WHISPARR_API_KEY}}"
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
 spec:
   ingressClassName: traefik

--- a/apps/70-tools/homepage/base/deployment.yaml
+++ b/apps/70-tools/homepage/base/deployment.yaml
@@ -75,6 +75,31 @@ spec:
                 secretKeyRef:
                   name: homepage-secrets
                   key: HOMEASSISTANT_API_KEY
+            - name: HOMEPAGE_VAR_SONARR_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: homepage-secrets
+                  key: HOMEPAGE_VAR_SONARR_API_KEY
+            - name: HOMEPAGE_VAR_RADARR_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: homepage-secrets
+                  key: HOMEPAGE_VAR_RADARR_API_KEY
+            - name: HOMEPAGE_VAR_LIDARR_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: homepage-secrets
+                  key: HOMEPAGE_VAR_LIDARR_API_KEY
+            - name: HOMEPAGE_VAR_WHISPARR_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: homepage-secrets
+                  key: HOMEPAGE_VAR_WHISPARR_API_KEY
+            - name: HOMEPAGE_VAR_SABNZBD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: homepage-secrets
+                  key: HOMEPAGE_VAR_SABNZBD_API_KEY
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
## Summary
Add dynamic homepage widgets for Sonarr, Radarr, Lidarr, Whisparr, Sabnzbd using their API keys stored in Infisical.

## Changes
- 5 prod ingresses: widget.type, widget.url, widget.key annotations
- Homepage deployment: 5 HOMEPAGE_VAR_* env vars from homepage-secrets

## Risk assessment
**Very low.** Annotations + env vars only. Homepage will display stats widgets for these apps.

Closes #2243

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Homepage dashboard widgets for media management services: Lidarr, Radarr, SABnzbd, Sonarr, and Whisparr. Each widget is now configured with the necessary API credentials to display service status and information on the Homepage dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->