### PR TITLE
feat(monitoring): 4 new Grafana dashboards — DataAngel, ArgoCD, Velero, Cert-Manager (#2242)

### DIFF
--- a/apps/02-monitoring/grafana/base/dashboards/argocd.yaml
+++ b/apps/02-monitoring/grafana/base/dashboards/argocd.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-argocd
+  labels:
+    grafana_dashboard: "1"
+immutable: true
+data:
+  argocd.json: |
+    {
+      "annotations": {"list": []},
+      "editable": true,
+      "panels": [
+        {
+          "title": "App Sync Status",
+          "type": "piechart",
+          "gridPos": {"h": 8, "w": 8, "x": 0, "y": 0},
+          "targets": [{"expr": "count(argocd_app_info{sync_status=~\".+\"}) by (sync_status)", "legendFormat": "{{sync_status}}"}]
+        },
+        {
+          "title": "App Health Status",
+          "type": "piechart",
+          "gridPos": {"h": 8, "w": 8, "x": 8, "y": 0},
+          "targets": [{"expr": "count(argocd_app_info{health_status=~\".+\"}) by (health_status)", "legendFormat": "{{health_status}}"}]
+        },
+        {
+          "title": "Sync Operations Rate",
+          "type": "timeseries",
+          "gridPos": {"h": 8, "w": 8, "x": 16, "y": 0},
+          "targets": [{"expr": "sum(rate(argocd_app_sync_total[5m])) by (phase)", "legendFormat": "{{phase}}"}]
+        },
+        {
+          "title": "Apps Not Synced/Healthy",
+          "type": "table",
+          "gridPos": {"h": 10, "w": 24, "x": 0, "y": 8},
+          "targets": [{"expr": "argocd_app_info{sync_status!=\"Synced\"} or argocd_app_info{health_status!=\"Healthy\"}", "format": "table", "instant": true}],
+          "transformations": [{"id": "organize", "options": {"excludeByName": {"Time": true, "__name__": true, "instance": true, "job": true}, "renameByName": {"name": "App", "sync_status": "Sync", "health_status": "Health", "namespace": "Namespace"}}}]
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": ["argocd", "gitops"],
+      "time": {"from": "now-6h", "to": "now"},
+      "title": "ArgoCD Overview",
+      "uid": "argocd-overview"
+    }

--- a/apps/02-monitoring/grafana/base/dashboards/cert-manager.yaml
+++ b/apps/02-monitoring/grafana/base/dashboards/cert-manager.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-cert-manager
+  labels:
+    grafana_dashboard: "1"
+immutable: true
+data:
+  cert-manager.json: |
+    {
+      "annotations": {"list": []},
+      "editable": true,
+      "panels": [
+        {
+          "title": "Certificate Expiry (days)",
+          "type": "bargauge",
+          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 0},
+          "targets": [{"expr": "(certmanager_certificate_expiration_timestamp_seconds - time()) / 86400", "legendFormat": "{{namespace}}/{{name}}"}],
+          "fieldConfig": {"defaults": {"unit": "d", "thresholds": {"steps": [{"color": "red", "value": 0}, {"color": "yellow", "value": 14}, {"color": "green", "value": 30}]}}}
+        },
+        {
+          "title": "Certificate Ready Status",
+          "type": "stat",
+          "gridPos": {"h": 4, "w": 12, "x": 0, "y": 8},
+          "targets": [{"expr": "certmanager_certificate_ready_status{condition=\"True\"}", "legendFormat": "{{namespace}}/{{name}}"}],
+          "fieldConfig": {"defaults": {"thresholds": {"steps": [{"color": "red", "value": 0}, {"color": "green", "value": 1}]}, "mappings": [{"type": "value", "options": {"0": {"text": "NOT READY"}, "1": {"text": "READY"}}}]}}
+        },
+        {
+          "title": "ACME Challenges",
+          "type": "timeseries",
+          "gridPos": {"h": 4, "w": 12, "x": 12, "y": 8},
+          "targets": [{"expr": "rate(certmanager_http_acme_client_request_count[5m])", "legendFormat": "{{method}} {{status}}"}]
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": ["cert-manager", "tls"],
+      "time": {"from": "now-7d", "to": "now"},
+      "title": "Cert-Manager Overview",
+      "uid": "cert-manager-overview"
+    }

--- a/apps/02-monitoring/grafana/base/dashboards/dataangel.yaml
+++ b/apps/02-monitoring/grafana/base/dashboards/dataangel.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-dataangel
+  labels:
+    grafana_dashboard: "1"
+immutable: true
+data:
+  dataangel.json: |
+    {
+      "annotations": {"list": []},
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "links": [],
+      "panels": [
+        {
+          "title": "Backup Status (rclone up)",
+          "type": "stat",
+          "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+          "targets": [{"expr": "dataangel_rclone_up", "legendFormat": "{{namespace}}/{{pod}}"}],
+          "fieldConfig": {"defaults": {"thresholds": {"steps": [{"color": "red", "value": 0}, {"color": "green", "value": 1}]}, "mappings": [{"type": "value", "options": {"0": {"text": "DOWN"}, "1": {"text": "UP"}}}]}}
+        },
+        {
+          "title": "Litestream Status",
+          "type": "stat",
+          "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+          "targets": [{"expr": "dataangel_litestream_up", "legendFormat": "{{namespace}}/{{pod}}"}],
+          "fieldConfig": {"defaults": {"thresholds": {"steps": [{"color": "red", "value": 0}, {"color": "green", "value": 1}]}, "mappings": [{"type": "value", "options": {"0": {"text": "DOWN"}, "1": {"text": "UP"}}}]}}
+        },
+        {
+          "title": "Sidecar Uptime",
+          "type": "stat",
+          "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+          "targets": [{"expr": "dataangel_sidecar_uptime_seconds / 3600", "legendFormat": "{{namespace}}/{{pod}}"}],
+          "fieldConfig": {"defaults": {"unit": "h"}}
+        },
+        {
+          "title": "Last Successful Sync Age",
+          "type": "stat",
+          "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+          "targets": [{"expr": "time() - dataangel_last_successful_rclone_sync_timestamp", "legendFormat": "{{namespace}}/{{pod}}"}],
+          "fieldConfig": {"defaults": {"unit": "s", "thresholds": {"steps": [{"color": "green", "value": 0}, {"color": "yellow", "value": 120}, {"color": "red", "value": 300}]}}}
+        },
+        {
+          "title": "Rclone Sync Duration (p99)",
+          "type": "timeseries",
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+          "targets": [{"expr": "histogram_quantile(0.99, rate(dataangel_rclone_sync_duration_seconds_bucket[5m]))", "legendFormat": "{{namespace}}/{{pod}}"}],
+          "fieldConfig": {"defaults": {"unit": "s"}}
+        },
+        {
+          "title": "Rclone Syncs Rate (success vs failed)",
+          "type": "timeseries",
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+          "targets": [
+            {"expr": "rate(dataangel_rclone_syncs_total[5m])", "legendFormat": "{{namespace}}/{{pod}} success"},
+            {"expr": "rate(dataangel_rclone_syncs_failed_total[5m])", "legendFormat": "{{namespace}}/{{pod}} failed"}
+          ]
+        },
+        {
+          "title": "Restore Duration by App",
+          "type": "bargauge",
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+          "targets": [{"expr": "dataangel_restore_duration_seconds > 0", "legendFormat": "{{namespace}}/{{pod}}"}],
+          "fieldConfig": {"defaults": {"unit": "s"}}
+        },
+        {
+          "title": "Lock Renewal Failures",
+          "type": "stat",
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+          "targets": [{"expr": "dataangel_lock_renewal_failures_total", "legendFormat": "{{namespace}}/{{pod}}"}],
+          "fieldConfig": {"defaults": {"thresholds": {"steps": [{"color": "green", "value": 0}, {"color": "red", "value": 1}]}}}
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": ["dataangel", "backup"],
+      "templating": {"list": []},
+      "time": {"from": "now-6h", "to": "now"},
+      "title": "DataAngel Backup Overview",
+      "uid": "dataangel-overview"
+    }

--- a/apps/02-monitoring/grafana/base/dashboards/velero.yaml
+++ b/apps/02-monitoring/grafana/base/dashboards/velero.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-velero
+  labels:
+    grafana_dashboard: "1"
+immutable: true
+data:
+  velero.json: |
+    {
+      "annotations": {"list": []},
+      "editable": true,
+      "panels": [
+        {
+          "title": "Backup Success/Failure",
+          "type": "stat",
+          "gridPos": {"h": 4, "w": 8, "x": 0, "y": 0},
+          "targets": [{"expr": "count(velero_backup_last_status{schedule=~\".+\"} == 1)", "legendFormat": "Success"}],
+          "fieldConfig": {"defaults": {"thresholds": {"steps": [{"color": "green", "value": 0}]}}}
+        },
+        {
+          "title": "Last Backup Age",
+          "type": "stat",
+          "gridPos": {"h": 4, "w": 8, "x": 8, "y": 0},
+          "targets": [{"expr": "time() - velero_backup_last_successful_timestamp{schedule=~\".+\"}", "legendFormat": "{{schedule}}"}],
+          "fieldConfig": {"defaults": {"unit": "s", "thresholds": {"steps": [{"color": "green", "value": 0}, {"color": "yellow", "value": 86400}, {"color": "red", "value": 172800}]}}}
+        },
+        {
+          "title": "Backup Duration",
+          "type": "timeseries",
+          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 4},
+          "targets": [{"expr": "velero_backup_duration_seconds{schedule=~\".+\"}", "legendFormat": "{{schedule}}"}],
+          "fieldConfig": {"defaults": {"unit": "s"}}
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": ["velero", "backup"],
+      "time": {"from": "now-7d", "to": "now"},
+      "title": "Velero Backup Overview",
+      "uid": "velero-overview"
+    }

--- a/apps/02-monitoring/grafana/base/kustomization.yaml
+++ b/apps/02-monitoring/grafana/base/kustomization.yaml
@@ -8,4 +8,8 @@ resources:
   - dashboards/postgresql.yaml
   - dashboards/homeassistant.yaml
   - dashboards/trivy.yaml
+  - dashboards/dataangel.yaml
+  - dashboards/argocd.yaml
+  - dashboards/velero.yaml
+  - dashboards/cert-manager.yaml
 # Helm chart managed by ArgoCD


### PR DESCRIPTION
## Summary
Add 4 Grafana dashboards as ConfigMaps (auto-discovered via `grafana_dashboard: "1"` label):

| Dashboard | Key metrics |
|---|---|
| DataAngel | rclone sync status/duration, litestream up, restore duration, lock failures |
| ArgoCD | sync/health pie charts, non-synced apps table, sync operations rate |
| Velero | backup success/failure, last backup age, backup duration |
| Cert-Manager | certificate expiry days, ready status, ACME challenges |

## Risk assessment
**None.** ConfigMaps with `immutable: true`, Grafana sidecar auto-loads.

Closes #2242

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ArgoCD Overview dashboard with app sync status, health status, and synchronization operation metrics.
  * Added Cert-Manager Overview dashboard displaying certificate expiry, readiness status, and ACME challenge monitoring.
  * Added DataAngel dashboard providing backup/restore status, sync duration, and operational health metrics.
  * Added Velero Backup Overview dashboard with backup success rates, last backup age, and duration tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->