### PR TITLE
docs: update architecture docs — DataAngel, Velero, VPA, monitoring (#2250)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,21 +50,6 @@ Detailed technical documentation:
 - **[ArgoCD Sync Waves](reference/argocd-sync-waves.md)** - Sync wave patterns.
 - **[Resource Standards](reference/RESOURCE_STANDARDS.md)** - CPU/Memory allocation rules.
 - **[Naming Conventions](reference/naming-conventions.md)** - Files, resources, namespaces.
-Detailed technical documentation:
-- **[Workflow State Machine](reference/workflow-state-machine.md)** - Guide to Justfile Phases 0-6.
-- **[Quality Standards](reference/quality-standards.md)** - Application quality tiers (Elite V4.0).
-- **[Metrics Exemption](reference/metrics-exemption.md)** - How to exempt apps from metrics requirement (Gold tier).
-- **[Multi-Agent Orchestration](reference/multi-agent-orchestration.md)** - Agent task assignment logic.
-- **[ArgoCD Sync Waves](reference/argocd-sync-waves.md)** - Sync wave patterns.
-- **[Resource Standards](reference/RESOURCE_STANDARDS.md)** - CPU/Memory allocation rules.
-- **[Naming Conventions](reference/naming-conventions.md)** - Files, resources, namespaces.
-Detailed technical documentation:
-- **[Workflow State Machine](reference/workflow-state-machine.md)** - Guide to Justfile Phases 0-6.
-- **[Quality Standards](reference/quality-standards.md)** - Application quality tiers (Elite V4.0).
-- **[Multi-Agent Orchestration](reference/multi-agent-orchestration.md)** - Agent task assignment logic.
-- **[ArgoCD Sync Waves](reference/argocd-sync-waves.md)** - Sync wave patterns.
-- **[Resource Standards](reference/RESOURCE_STANDARDS.md)** - CPU/Memory allocation rules.
-- **[Naming Conventions](reference/naming-conventions.md)** - Files, resources, namespaces.
 
 ---
 
@@ -121,4 +106,4 @@ Detailed technical documentation:
 
 ---
 
-**Last Updated:** 2026-01-11
+**Last Updated:** 2026-03-26

--- a/docs/reports/validation/RECETTE-FONCTIONNELLE.md
+++ b/docs/reports/validation/RECETTE-FONCTIONNELLE.md
@@ -6,7 +6,8 @@ Validation des fonctionnalités utilisateur après déploiement.
 | :--- | :--- | :--- | :--- | :--- |
 | **hydrus-client** | Accès Web UI (noVNC) | ✅ OK | 2026-01-08 | Accessible via hydrus.truxonline.com |
 | **hydrus-client** | Redirection HTTPS | ✅ OK | 2026-01-08 | http -> https redirection verified |
-| **litestream** | Résilience (Chaos Test) | ✅ OK | 2026-01-08 | Successful full restore from S3 on 40Gi volume |
+| **DataAngel** | Backup/Restore (16 apps) | ✅ OK | 2026-03-26 | Unified SQLite+FS backup to S3/MinIO. Full restore validated (replaces litestream) |
+| **Velero** | Cluster Backup (4 schedules) | ✅ OK | 2026-03-26 | daily-critical, daily-home, daily-media, weekly-full. 100% namespace coverage |
 | **authentik** | Accès Web & OIDC | ✅ OK | 2026-01-13 | 302 Redirect verified, blueprint mounted. OIDC ready (Netbird). |
 | **Cluster Global** | **Disponibilité** | ✅ **100%** | 2026-01-13 | Authentik operational after DB/Redis credentials fix |
 | **grafana** | Dashboards métriques | ✅ OK | 2026-03-23 | Datasource VictoriaMetrics fonctionnel, dashboards existants compatibles (PromQL) |

--- a/docs/reports/validation/RECETTE-TECHNIQUE.md
+++ b/docs/reports/validation/RECETTE-TECHNIQUE.md
@@ -7,9 +7,9 @@ Validation des aspects techniques (infra, logs, perfs).
 | **hydrus-client** | Pod Status | ✅ Running | 2026-01-08 | 2/2 containers ready. Priority: vixens-medium |
 | **hydrus-client** | Gold Standard | ✅ Compliant | 2026-01-08 | Integrity check (sqlite3) + Conditional restore active |
 | **hydrus-client** | Storage (ISCSI) | ✅ Resized | 2026-01-08 | PVC increased to 40Gi to accommodate large WAL sets |
-| **litestream** | Restoration | ✅ Robust | 2026-01-08 | Automated cleanup of .tmp files + Cache bypass valid |
-| **litestream** | Secrets | ✅ Synced | 2026-01-04 | Path /shared/litestream utilisé |
-| **litestream** | Config | ✅ OK | 2026-01-04 | ConfigMap unifié pour multi-DB |
+| **DataAngel** | Backup (16 apps) | ✅ Running | 2026-03-26 | Unified SQLite+FS backup to S3/MinIO. Replaces litestream + config-syncer + rclone |
+| **DataAngel** | Sidecar Injection | ✅ OK | 2026-03-26 | Shared component `_shared/components/dataangel/` + per-app patches |
+| **DataAngel** | Secrets | ✅ Synced | 2026-03-26 | MinIO credentials via Infisical |
 | **traefik** | Routing | ✅ OK | 2026-01-04 | Middleware qualifié par namespace |
 | **postgresql-shared** | HA Scale-down | ✅ OK | 2026-01-07 | Retour à 1 instance stable après test HA |
 | **redis-shared** | Sécurité Auth | ✅ OK | 2026-01-07 | requirepass activé via Infisical |
@@ -34,3 +34,9 @@ Validation des aspects techniques (infra, logs, perfs).
 | **loki** | Sizing V-medium | ✅ Stabilisé | 2026-03-23 | Upgrade G-medium → V-medium après surcharge Fluent Bit. 0 restarts post-upgrade |
 | **loki** | NetworkPolicy | ✅ Corrigé | 2026-03-23 | Ajout namespace monitoring dans ingress (bloquait Fluent Bit) |
 | **grafana** | Datasource VictoriaMetrics | ✅ OK | 2026-03-23 | URL mise à jour vers vmsingle:8428. Dashboards fonctionnels |
+| **grafana** | Dashboards (8) | ✅ OK | 2026-03-26 | HA, PostgreSQL, Traefik, Trivy, DataAngel, ArgoCD, Velero, Cert-Manager |
+| **local-path-provisioner** | StorageClasses | ✅ Running | 2026-03-26 | v0.0.35 : local-path-delete + local-path-retain StorageClasses alongside Synology iSCSI |
+| **VPA** | Auto Mode | ✅ OK | 2026-03-26 | 52 containers on V-* profiles (VPA Auto mode). Kyverno auto-detects V-* prefix |
+| **Velero** | Schedules (4) | ✅ OK | 2026-03-26 | daily-critical, daily-home, daily-media, weekly-full. 100% namespace coverage |
+| **Security** | runAsNonRoot | ✅ OK | 2026-03-26 | Enforced on 11 apps |
+| **Security** | preStop hooks | ✅ OK | 2026-03-26 | Configured on 8 critical apps for graceful shutdown |


### PR DESCRIPTION
## Summary
Update RECETTE-TECHNIQUE, RECETTE-FONCTIONNELLE and README to reflect current cluster state.

Key updates: litestream → DataAngel (16 apps), Local Path Provisioner, VPA V-* (52 containers), 8 Grafana dashboards, Velero 4 schedules, runAsNonRoot 11 apps, preStop 8 apps.

Closes #2250

🤖 Generated with [Claude Code](https://claude.com/claude-code)