### PR TITLE
fix(keda): upgrade HTTP add-on 0.10.0 → 0.13.0 (fix ImagePullBackOff)

### DIFF
--- a/argocd/overlays/prod/apps/keda-http-addon.yaml
+++ b/argocd/overlays/prod/apps/keda-http-addon.yaml
@@ -13,7 +13,7 @@ spec:
   sources:
     - repoURL: https://kedacore.github.io/charts
       chart: keda-add-ons-http
-      targetRevision: 0.10.0
+      targetRevision: 0.13.0
       helm:
         valueFiles:
           - $values/apps/00-infra/keda-http-addon/values/common.yaml


### PR DESCRIPTION
Chart 0.10.0 hardcodes a GCR image that no longer exists. Upgrade to 0.13.0 fixes the controller-manager ImagePullBackOff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated KEDA HTTP Addon to version 0.13.0 for production environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->