### PR TITLE
fix(keda): rewire stirling-pdf Ingress to interceptor for scale-to-zero

### DIFF
--- a/apps/70-tools/stirling-pdf/overlays/prod/ingress.yaml
+++ b/apps/70-tools/stirling-pdf/overlays/prod/ingress.yaml
@@ -22,7 +22,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: stirling-pdf-stirling-pdf-chart
+                name: keda-interceptor-proxy
                 port:
                   number: 8080
   tls:

--- a/apps/70-tools/stirling-pdf/overlays/prod/keda-interceptor-svc.yaml
+++ b/apps/70-tools/stirling-pdf/overlays/prod/keda-interceptor-svc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keda-interceptor-proxy
+  namespace: tools
+spec:
+  type: ExternalName
+  externalName: keda-add-ons-http-interceptor-proxy.keda.svc.cluster.local
+  ports:
+    - port: 8080
+      protocol: TCP

--- a/apps/70-tools/stirling-pdf/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/stirling-pdf/overlays/prod/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../base
   - ingress.yaml
   - httpscaledobject.yaml
+  - keda-interceptor-svc.yaml
 
 # NOTE: ArgoCD multi-source limitation — kustomize patches cannot target Helm-rendered resources.
 # The following are active (target Deployment metadata, not pod template):


### PR DESCRIPTION
Ingress must point to KEDA interceptor proxy for wake-on-request to work. ExternalName svc bridges namespaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production infrastructure configuration for improved traffic routing and request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->