### PR TITLE
feat(keda): add KEDA + HTTP Add-on to dev overlay

### DIFF
--- a/argocd/overlays/dev/apps/keda-http-addon.yaml
+++ b/argocd/overlays/dev/apps/keda-http-addon.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: keda-http-addon
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: default
+  sources:
+    - repoURL: https://kedacore.github.io/charts
+      chart: keda-add-ons-http
+      targetRevision: 0.13.0
+      helm:
+        valueFiles:
+          - $values/apps/00-infra/keda-http-addon/values/common.yaml
+    - repoURL: https://github.com/charchess/vixens.git
+      targetRevision: main
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: keda
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: false
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/overlays/dev/apps/keda.yaml
+++ b/argocd/overlays/dev/apps/keda.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: keda
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  sources:
+    - repoURL: https://kedacore.github.io/charts
+      chart: keda
+      targetRevision: 2.17.1
+      helm:
+        valueFiles:
+          - $values/apps/00-infra/keda/values/common.yaml
+    - repoURL: https://github.com/charchess/vixens.git
+      targetRevision: main
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: keda
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: false
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/argocd/overlays/dev/kustomization.yaml
+++ b/argocd/overlays/dev/kustomization.yaml
@@ -11,6 +11,8 @@ resources:
   - apps/cilium-lb.yaml
   - apps/traefik.yaml
   - apps/traefik-middlewares.yaml
+  - apps/keda.yaml
+  - apps/keda-http-addon.yaml
   - apps/vpa.yaml
   - apps/reloader.yaml
   - apps/kyverno.yaml


### PR DESCRIPTION
## Summary

- Add `argocd/overlays/dev/apps/keda.yaml` (chart 2.17.1, wave 1)
- Add `argocd/overlays/dev/apps/keda-http-addon.yaml` (chart 0.13.0, wave 2)
- Register both in `argocd/overlays/dev/kustomization.yaml`

Mirrors the existing prod overlay. Uses `targetRevision: main` for the values ref (vs `prod-stable` in prod).

## Test plan

- [ ] ArgoCD deploys `keda` app in dev → namespace `keda` created, operator pods Running
- [ ] ArgoCD deploys `keda-http-addon` app → interceptor + scaler pods Running
- [ ] `kubectl get crd | grep keda` shows KEDA CRDs installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)