### PR TITLE
fix(keda): add dev values with reduced memory requests

### DIFF
--- a/apps/00-infra/keda-http-addon/values/dev.yaml
+++ b/apps/00-infra/keda-http-addon/values/dev.yaml
@@ -1,0 +1,19 @@
+---
+# KEDA HTTP Add-on - dev overrides (single-node, memory-constrained)
+interceptor:
+  resources:
+    requests:
+      cpu: 5m
+      memory: 8Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+
+scaler:
+  resources:
+    requests:
+      cpu: 5m
+      memory: 8Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi

--- a/apps/00-infra/keda/values/dev.yaml
+++ b/apps/00-infra/keda/values/dev.yaml
@@ -1,0 +1,24 @@
+---
+# KEDA Operator - dev overrides (single-node, memory-constrained)
+resources:
+  operator:
+    requests:
+      cpu: 20m
+      memory: 32Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+  metricsServer:
+    requests:
+      cpu: 10m
+      memory: 16Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  webhooks:
+    requests:
+      cpu: 10m
+      memory: 16Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi

--- a/argocd/overlays/dev/apps/keda-http-addon.yaml
+++ b/argocd/overlays/dev/apps/keda-http-addon.yaml
@@ -17,6 +17,7 @@ spec:
       helm:
         valueFiles:
           - $values/apps/00-infra/keda-http-addon/values/common.yaml
+          - $values/apps/00-infra/keda-http-addon/values/dev.yaml
     - repoURL: https://github.com/charchess/vixens.git
       targetRevision: main
       ref: values

--- a/argocd/overlays/dev/apps/keda.yaml
+++ b/argocd/overlays/dev/apps/keda.yaml
@@ -17,6 +17,7 @@ spec:
       helm:
         valueFiles:
           - $values/apps/00-infra/keda/values/common.yaml
+          - $values/apps/00-infra/keda/values/dev.yaml
     - repoURL: https://github.com/charchess/vixens.git
       targetRevision: main
       ref: values


### PR DESCRIPTION
## Summary

- Add `apps/00-infra/keda/values/dev.yaml`: halve memory requests (64→32Mi operator, 32→16Mi metricsServer/webhooks)
- Add `apps/00-infra/keda-http-addon/values/dev.yaml`: halve interceptor+scaler requests (16→8Mi each)
- Update dev ArgoCD app manifests to load `dev.yaml` after `common.yaml`

**Why:** dev cluster is a single node at 98% memory (7190/7468 Mi). KEDA pods were stuck `Pending` due to `Insufficient memory`.

## Test plan

- [ ] KEDA pods transition to Running
- [ ] `kubectl get pods -n keda` → all Ready
- [ ] `kubectl get crd | grep keda` → CRDs installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured Kubernetes resource requests and limits for KEDA operator and related components in the development environment.
  * Configured Kubernetes resource requests and limits for KEDA HTTP add-on components in the development environment.
  * Updated deployment manifests to apply these development-specific resource configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->