### PR TITLE
fix(keda): add Kyverno sizing labels to bypass 128Mi default in dev

### DIFF
--- a/apps/00-infra/keda-http-addon/values/dev.yaml
+++ b/apps/00-infra/keda-http-addon/values/dev.yaml
@@ -1,19 +1,27 @@
 ---
 # KEDA HTTP Add-on - dev overrides (single-node, memory-constrained)
+# additionalLabels applies to pod templates via keda-http-add-on.labels helper.
+# Setting all three container sizing labels on all pods so Kyverno finds the
+# right label for each container (instead of falling back to 128Mi default).
+additionalLabels:
+  vixens.io/sizing.keda-add-ons-http-operator: B-nano
+  vixens.io/sizing.keda-add-ons-http-external-scaler: B-nano
+  vixens.io/sizing.keda-add-ons-http-interceptor: B-nano
+
 interceptor:
   resources:
     requests:
-      cpu: 5m
-      memory: 8Mi
+      cpu: 10m
+      memory: 64Mi
     limits:
       cpu: 100m
-      memory: 64Mi
+      memory: 128Mi
 
 scaler:
   resources:
     requests:
-      cpu: 5m
-      memory: 8Mi
+      cpu: 10m
+      memory: 64Mi
     limits:
       cpu: 100m
-      memory: 64Mi
+      memory: 128Mi

--- a/apps/00-infra/keda/values/dev.yaml
+++ b/apps/00-infra/keda/values/dev.yaml
@@ -1,24 +1,34 @@
 ---
 # KEDA Operator - dev overrides (single-node, memory-constrained)
+# Sizing labels bypass the Kyverno sizing-v2-mutate default (128Mi).
+# B-nano = 64Mi request / 128Mi limit per container.
+podLabels:
+  keda:
+    vixens.io/sizing.keda-operator: B-nano
+  metricsAdapter:
+    vixens.io/sizing.keda-operator-metrics-apiserver: B-nano
+  webhooks:
+    vixens.io/sizing.keda-admission-webhooks: B-nano
+
 resources:
   operator:
     requests:
       cpu: 20m
-      memory: 32Mi
+      memory: 64Mi
     limits:
       cpu: 500m
       memory: 256Mi
-  metricsServer:
+  metricServer:
     requests:
       cpu: 10m
-      memory: 16Mi
+      memory: 64Mi
     limits:
       cpu: 200m
-      memory: 128Mi
+      memory: 256Mi
   webhooks:
     requests:
       cpu: 10m
-      memory: 16Mi
+      memory: 64Mi
     limits:
       cpu: 100m
-      memory: 64Mi
+      memory: 128Mi


### PR DESCRIPTION
## Summary

- Add `vixens.io/sizing.*: B-nano` labels via `podLabels` (keda chart) and `additionalLabels` (http-addon chart)
- Fix `metricsServer` → `metricServer` key typo in keda values
- Align explicit resource requests to match B-nano (64Mi)

**Root cause:** The `sizing-v2-mutate` Kyverno policy sets 128Mi for unlabeled containers. 6 KEDA pods × 128Mi > 278Mi free on single-node dev → all pods stuck Pending.

**Fix:** B-nano labels tell Kyverno to use 64Mi instead. 6 × 64Mi = 384Mi, which fits comfortably within the ~1046Mi actually free from running workloads.

## Test plan

- [ ] All KEDA pods transition from Pending → Running
- [ ] `kubectl get pods -n keda` → 6/6 Ready (after old pending pods are replaced)
- [ ] `kubectl get HTTPScaledObject -A` → CRD exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)