### PR TITLE
fix(monitoring): reduce vmsingle sizing to B-micro on dev cluster

### DIFF
--- a/apps/02-monitoring/victoria-metrics/overlays/dev/kustomization.yaml
+++ b/apps/02-monitoring/victoria-metrics/overlays/dev/kustomization.yaml
@@ -8,5 +8,6 @@ labels:
       environment: dev
 resources:
   - ../../base
+  - patch-vmsingle-dev.yaml
 components:
   - ../../../../_shared/components/dev-hibernate

--- a/apps/02-monitoring/victoria-metrics/overlays/dev/patch-vmsingle-dev.yaml
+++ b/apps/02-monitoring/victoria-metrics/overlays/dev/patch-vmsingle-dev.yaml
@@ -1,0 +1,11 @@
+---
+# Dev override: reduce VMSingle sizing from G-large (1Gi req) to B-micro (128Mi req)
+# so the single-node dev cluster has enough headroom for KEDA and other components.
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMSingle
+metadata:
+  name: vm-stack
+spec:
+  podMetadata:
+    labels:
+      vixens.io/sizing.vmsingle: B-micro


### PR DESCRIPTION
## Summary

- Add `apps/02-monitoring/victoria-metrics/overlays/dev/patch-vmsingle-dev.yaml`
- Patch VMSingle `vm-stack` sizing label from `G-large` → `B-micro`
- Register patch in dev kustomization

**Why:** VMSingle uses `G-large` sizing (1Gi memory request), leaving only ~214Mi free on the single-node dev cluster. KEDA + HTTP Add-on need ~320Mi (5 pods × 64Mi B-nano). Reducing to `B-micro` (128Mi) frees ~896Mi of scheduler headroom.

**Impact:** VMSingle limits remain unchanged (only request changes via Kyverno). VictoriaMetrics will still function in dev — it only scrapes a handful of pods vs prod's larger fleet.

## Test plan

- [ ] VMSingle pod restarts with lower memory request (~128Mi)
- [ ] KEDA pods transition to Running after vmsingle redeploys
- [ ] Victoria Metrics UI still accessible at `vmetrics.dev.truxonline.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated monitoring infrastructure configuration for the development environment with resource specification updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->