### PR TITLE
fix(keda): add endpoints RBAC for external-scaler (0.13.0 chart bug)

### DIFF
--- a/apps/00-infra/keda-http-addon/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/keda-http-addon/overlays/dev/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: keda
+resources:
+  - rbac-endpoints-fix.yaml

--- a/apps/00-infra/keda-http-addon/overlays/dev/rbac-endpoints-fix.yaml
+++ b/apps/00-infra/keda-http-addon/overlays/dev/rbac-endpoints-fix.yaml
@@ -1,0 +1,30 @@
+---
+# Workaround for keda-add-ons-http 0.13.0 bug:
+# The chart ClusterRole was updated to use endpointslices (discovery.k8s.io)
+# but the scaler binary still calls the legacy endpoints API (core "").
+# Without this, the external-scaler crashloops with:
+#   endpoints "keda-add-ons-http-interceptor-admin" is forbidden
+# Ref: https://github.com/kedacore/http-add-on/issues/...
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: keda-add-ons-http-external-scaler-endpoints
+  namespace: keda
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: keda-add-ons-http-external-scaler-endpoints
+  namespace: keda
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: keda-add-ons-http-external-scaler-endpoints
+subjects:
+  - kind: ServiceAccount
+    name: keda-add-ons-http-external-scaler
+    namespace: keda

--- a/apps/00-infra/keda-http-addon/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/keda-http-addon/overlays/prod/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: keda
+resources:
+  - rbac-endpoints-fix.yaml

--- a/apps/00-infra/keda-http-addon/overlays/prod/rbac-endpoints-fix.yaml
+++ b/apps/00-infra/keda-http-addon/overlays/prod/rbac-endpoints-fix.yaml
@@ -1,0 +1,30 @@
+---
+# Workaround for keda-add-ons-http 0.13.0 bug:
+# The chart ClusterRole was updated to use endpointslices (discovery.k8s.io)
+# but the scaler binary still calls the legacy endpoints API (core "").
+# Without this, the external-scaler crashloops with:
+#   endpoints "keda-add-ons-http-interceptor-admin" is forbidden
+# Ref: https://github.com/kedacore/http-add-on/issues/...
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: keda-add-ons-http-external-scaler-endpoints
+  namespace: keda
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: keda-add-ons-http-external-scaler-endpoints
+  namespace: keda
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: keda-add-ons-http-external-scaler-endpoints
+subjects:
+  - kind: ServiceAccount
+    name: keda-add-ons-http-external-scaler
+    namespace: keda

--- a/argocd/overlays/dev/apps/keda-http-addon.yaml
+++ b/argocd/overlays/dev/apps/keda-http-addon.yaml
@@ -21,6 +21,9 @@ spec:
     - repoURL: https://github.com/charchess/vixens.git
       targetRevision: main
       ref: values
+    - repoURL: https://github.com/charchess/vixens.git
+      targetRevision: main
+      path: apps/00-infra/keda-http-addon/overlays/dev
   destination:
     server: https://kubernetes.default.svc
     namespace: keda

--- a/argocd/overlays/prod/apps/keda-http-addon.yaml
+++ b/argocd/overlays/prod/apps/keda-http-addon.yaml
@@ -20,6 +20,9 @@ spec:
     - repoURL: https://github.com/charchess/vixens.git
       targetRevision: prod-stable
       ref: values
+    - repoURL: https://github.com/charchess/vixens.git
+      targetRevision: prod-stable
+      path: apps/00-infra/keda-http-addon/overlays/prod
   destination:
     server: https://kubernetes.default.svc
     namespace: keda


### PR DESCRIPTION
## Summary

- Add `apps/00-infra/keda-http-addon/overlays/{prod,dev}/rbac-endpoints-fix.yaml`: Role + RoleBinding for endpoints access
- Add kustomize overlay as 3rd source in `keda-http-addon` ArgoCD app (prod + dev)

**Root cause:** keda-add-ons-http 0.13.0 chart updated the ClusterRole to use `endpointslices` (discovery.k8s.io) but the scaler binary still calls the legacy `endpoints` core API. External-scaler crashloops (168 restarts) with:
```
endpoints "keda-add-ons-http-interceptor-admin" is forbidden: User "system:serviceaccount:keda:keda-add-ons-http-external-scaler" cannot get resource "endpoints" in API group ""
```

**Fix:** Add a namespaced Role granting `get/list/watch` on `endpoints` in the `keda` namespace to the external-scaler SA. This is a workaround pending an upstream fix.

## Test plan

- [ ] `keda-add-ons-http-external-scaler` pod stops crashlooping
- [ ] `curl https://pdf.truxonline.com` → 200 (scale-to-zero triggers scale-up)
- [ ] After 5min idle → stirling-pdf scales back to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added KEDA HTTP addon infrastructure for dev and prod and registered those overlays with Argo CD for automated deployment.

* **Chores**
  * Added namespace-scoped RBAC to allow the KEDA HTTP external scaler to query cluster endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->