### PR TITLE
fix(keda): increase interceptor waitTimeout to 120s for Java cold-start

### DIFF
--- a/apps/00-infra/keda-http-addon/values/common.yaml
+++ b/apps/00-infra/keda-http-addon/values/common.yaml
@@ -4,6 +4,8 @@ interceptor:
   replicas:
     min: 1
     max: 1
+  # Stirling-PDF (Java) needs ~60s to start; set generous cold-start timeout
+  waitTimeout: "120s"
   resources:
     requests:
       cpu: 10m


### PR DESCRIPTION
## Summary
- Increases `interceptor.waitTimeout` from 20s (default) to 120s
- Stirling-PDF is a Java application that takes ~60s to start on cold boot
- Without this, the KEDA interceptor times out with 502 before the pod is ready

## Test plan
- [ ] Merge → ArgoCD syncs dev → verify `KEDA_CONDITION_WAIT_TIMEOUT=120s` in interceptor deployment
- [ ] Promote prod-stable → curl https://pdf.truxonline.com triggers scale-up from 0 → page loads within 120s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated interceptor configuration to increase wait timeout to 120 seconds, improving handling of delayed responses during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->