### PR TITLE
fix(keda): set KEDA_CONDITION_WAIT_TIMEOUT=120s via kustomize patch

### DIFF
--- a/apps/00-infra/keda-http-addon/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/keda-http-addon/overlays/dev/kustomization.yaml
@@ -4,3 +4,8 @@ kind: Kustomization
 namespace: keda
 resources:
   - rbac-endpoints-fix.yaml
+patches:
+  - path: patch-interceptor-wait-timeout.yaml
+    target:
+      kind: Deployment
+      name: keda-add-ons-http-interceptor

--- a/apps/00-infra/keda-http-addon/overlays/dev/patch-interceptor-wait-timeout.yaml
+++ b/apps/00-infra/keda-http-addon/overlays/dev/patch-interceptor-wait-timeout.yaml
@@ -1,0 +1,17 @@
+---
+# Patch to increase KEDA interceptor cold-start timeout for Java apps (e.g. Stirling-PDF).
+# The chart default of 20s is too short; bumped to 120s.
+# chart v0.13.0 does not expose interceptor.waitTimeout in values, hence this patch.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keda-add-ons-http-interceptor
+  namespace: keda
+spec:
+  template:
+    spec:
+      containers:
+        - name: keda-add-ons-http-interceptor
+          env:
+            - name: KEDA_CONDITION_WAIT_TIMEOUT
+              value: "120s"

--- a/apps/00-infra/keda-http-addon/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/keda-http-addon/overlays/prod/kustomization.yaml
@@ -4,3 +4,8 @@ kind: Kustomization
 namespace: keda
 resources:
   - rbac-endpoints-fix.yaml
+patches:
+  - path: patch-interceptor-wait-timeout.yaml
+    target:
+      kind: Deployment
+      name: keda-add-ons-http-interceptor

--- a/apps/00-infra/keda-http-addon/overlays/prod/patch-interceptor-wait-timeout.yaml
+++ b/apps/00-infra/keda-http-addon/overlays/prod/patch-interceptor-wait-timeout.yaml
@@ -1,0 +1,17 @@
+---
+# Patch to increase KEDA interceptor cold-start timeout for Java apps (e.g. Stirling-PDF).
+# The chart default of 20s is too short; bumped to 120s.
+# chart v0.13.0 does not expose interceptor.waitTimeout in values, hence this patch.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keda-add-ons-http-interceptor
+  namespace: keda
+spec:
+  template:
+    spec:
+      containers:
+        - name: keda-add-ons-http-interceptor
+          env:
+            - name: KEDA_CONDITION_WAIT_TIMEOUT
+              value: "120s"

--- a/apps/00-infra/keda-http-addon/values/common.yaml
+++ b/apps/00-infra/keda-http-addon/values/common.yaml
@@ -4,8 +4,6 @@ interceptor:
   replicas:
     min: 1
     max: 1
-  # Stirling-PDF (Java) needs ~60s to start; set generous cold-start timeout
-  waitTimeout: "120s"
   resources:
     requests:
       cpu: 10m


### PR DESCRIPTION
## Summary
- `interceptor.waitTimeout` in Helm values doesn't actually set `KEDA_CONDITION_WAIT_TIMEOUT` in chart 0.13.0
- Using a Kustomize strategic merge patch instead to directly set the env var to 120s
- Removes the incorrect `waitTimeout` Helm value from common.yaml
- Applied to both dev and prod overlays

## Why 120s?
Stirling-PDF is a Java application with ~60s cold-start time. The default 20s timeout causes `502 Bad Gateway: context deadline exceeded` before the pod becomes ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)