### PR TITLE
fix(keda): fix waitTimeout key to interceptor.replicas.waitTimeout

### DIFF
--- a/apps/00-infra/keda-http-addon/values/common.yaml
+++ b/apps/00-infra/keda-http-addon/values/common.yaml
@@ -4,8 +4,8 @@ interceptor:
   replicas:
     min: 1
     max: 1
-  # Java apps (Stirling-PDF) need ~60s cold-start; 20s default causes 502 on scale-up
-  waitTimeout: 120s
+    # Java apps (Stirling-PDF) need ~60s cold-start; 20s default causes 502 on scale-up
+    waitTimeout: 120s
   resources:
     requests:
       cpu: 10m


### PR DESCRIPTION
## Summary
- Chart template uses `.Values.interceptor.replicas.waitTimeout` (not `.Values.interceptor.waitTimeout`)
- Moves the `waitTimeout: 120s` setting to the correct nested location

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Fixed YAML configuration indentation formatting for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->