### PR TITLE
fix(stirling-pdf): increase liveness failureThreshold to 18 for cold-start

### DIFF
--- a/apps/70-tools/stirling-pdf/base/values.yaml
+++ b/apps/70-tools/stirling-pdf/base/values.yaml
@@ -37,7 +37,8 @@ probes:
       port: 8080
     initialDelaySeconds: 0
     periodSeconds: 10
-    failureThreshold: 3
+    # 18 * 10s = 180s tolerance for cold-start from 0 replicas (Java startup ~60-90s)
+    failureThreshold: 18
   readiness:
     enabled: true
     httpGet:


### PR DESCRIPTION
## Summary
- Stirling-PDF (Java) takes ~60-90s to start from cold (0 replicas via KEDA)
- Default `failureThreshold: 3` with `periodSeconds: 10` = 30s before liveness kills the pod
- Increased to 18 (180s tolerance) to allow cold-start to complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved application startup stability by adjusting health monitoring tolerance settings to better handle cold-start scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->