### PR TITLE
fix(stirling-pdf+keda): increase cold-start timeouts to 300s

### DIFF
--- a/apps/00-infra/keda-http-addon/values/common.yaml
+++ b/apps/00-infra/keda-http-addon/values/common.yaml
@@ -4,8 +4,8 @@ interceptor:
   replicas:
     min: 1
     max: 1
-    # Java apps (Stirling-PDF) need ~60s cold-start; 20s default causes 502 on scale-up
-    waitTimeout: 120s
+    # Stirling-PDF cold-start: ~40s JWT key gen + ~2min Spring Boot = ~3min total
+    waitTimeout: 300s
   resources:
     requests:
       cpu: 10m

--- a/apps/70-tools/stirling-pdf/base/values.yaml
+++ b/apps/70-tools/stirling-pdf/base/values.yaml
@@ -37,8 +37,8 @@ probes:
       port: 8080
     initialDelaySeconds: 0
     periodSeconds: 10
-    # 18 * 10s = 180s tolerance for cold-start from 0 replicas (Java startup ~60-90s)
-    failureThreshold: 18
+    # 30 * 10s = 300s tolerance for cold-start (JWT key gen alone takes ~40s)
+    failureThreshold: 30
   readiness:
     enabled: true
     httpGet:
@@ -46,7 +46,8 @@ probes:
       port: 8080
     initialDelaySeconds: 0
     periodSeconds: 10
-    failureThreshold: 3
+    # Must survive 300s cold-start; KEDA interceptor waitTimeout matches this
+    failureThreshold: 30
   startup:
     enabled: true
     httpGet:


### PR DESCRIPTION
## Summary
- Stirling-PDF cold-start analysis from pod logs:
  - JWT key generation (no persistent storage): ~40s
  - Spring Boot full initialization: ~3min total
- KEDA interceptor was timing out at 120s; readiness probe failing at 30s
- Matched all timeouts to 300s for consistent behavior

## Changes
- `interceptor.replicas.waitTimeout`: 120s → 300s
- `probes.liveness.failureThreshold`: 18 → 30 (300s tolerance)
- `probes.readiness.failureThreshold`: 3 → 30 (300s tolerance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)