### PR TITLE
fix(traefik): enable allowExternalNameServices for KEDA interceptor routing

### DIFF
--- a/apps/00-infra/traefik/values/common.yaml
+++ b/apps/00-infra/traefik/values/common.yaml
@@ -12,6 +12,7 @@ providers:
     allowCrossNamespace: true
   kubernetesIngress:
     enabled: true
+    allowExternalNameServices: true
     publishedService:
       enabled: true
 # ============================================================================


### PR DESCRIPTION
## Summary
- KEDA HTTP Add-on interceptor is exposed as `keda-interceptor-proxy` ExternalName service in the `tools` namespace
- Traefik v2.6+ requires `allowExternalNameServices: true` to route Ingress traffic to ExternalName backends
- Without this flag, HTTPS requests to `pdf.truxonline.com` returned 404 (Traefik silently rejected the backend)

## Root Cause
`--providers.kubernetesingress.allowExternalNameServices` defaults to `false` since Traefik v2.6 (security hardening). The interceptor ExternalName service was correctly configured in the stirling-pdf overlay, but Traefik would not resolve it.

## Test Plan
- [ ] ArgoCD syncs Traefik deployment with new `allowExternalNameServices: true` arg
- [ ] `curl -sI https://pdf.truxonline.com` returns `503` (scale-to-zero, interceptor holding) then `200` after cold-start
- [ ] KEDA scale-to-zero flow: interceptor triggers scale-up, stirling-pdf starts, response served

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Traefik infrastructure configuration to enable support for external name services in Kubernetes environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->