### PR TITLE
feat(keda): scale-to-zero netbox via KEDA HTTP Add-on

### DIFF
--- a/apps/70-tools/netbox/overlays/prod/httpscaledobject.yaml
+++ b/apps/70-tools/netbox/overlays/prod/httpscaledobject.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: http.keda.sh/v1alpha1
+kind: HTTPScaledObject
+metadata:
+  name: netbox
+  namespace: tools
+spec:
+  hosts:
+    - netbox.truxonline.com
+  pathPrefixes:
+    - /
+  scaleTargetRef:
+    name: netbox
+    kind: Deployment
+    service: netbox
+    port: 8080
+  replicas:
+    min: 0
+    max: 1
+  scaledownPeriod: 300

--- a/apps/70-tools/netbox/overlays/prod/ingress.yaml
+++ b/apps/70-tools/netbox/overlays/prod/ingress.yaml
@@ -23,7 +23,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: netbox
+                name: keda-interceptor-proxy
                 port:
                   number: 8080
   tls:

--- a/apps/70-tools/netbox/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/netbox/overlays/prod/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - ../../base
   - ingress.yaml
   - infisical-redis-secret.yaml
+  - httpscaledobject.yaml


### PR DESCRIPTION
## Summary
- Add `HTTPScaledObject` for netbox: `minReplicas=0`, `maxReplicas=1`, `scaledownPeriod=300s`
- Rewire `netbox-ingress` backend to `keda-interceptor-proxy` (shared ExternalName service in `tools` namespace, owned by stirling-pdf app)
- No probe changes needed: Django startup probe already at 300s tolerance (`failureThreshold=30×10s`)

## Note
`keda-interceptor-proxy` ExternalName service (tools → keda namespace) is managed by the stirling-pdf ArgoCD app. Netbox uses it without re-declaring it to avoid ArgoCD ownership conflicts. Future apps in tools follow the same pattern.

## Test Plan
- [ ] ArgoCD syncs netbox app cleanly (no ownership conflicts)
- [ ] `curl https://netbox.truxonline.com` triggers scale-up from 0 → HTTP 200
- [ ] Netbox scales back to 0 after 5min idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NetBox deployment now automatically scales based on incoming HTTP traffic, optimizing resource utilization. The service maintains between 0 and 1 active replicas with a 5-minute scale-down period to balance performance and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->