### PR TITLE
feat(keda): scale-to-zero netvisor (scanopy) via KEDA HTTP Add-on

### DIFF
--- a/apps/40-network/netvisor/base/networkpolicy.yaml
+++ b/apps/40-network/netvisor/base/networkpolicy.yaml
@@ -11,11 +11,14 @@ spec:
     - Ingress
     - Egress
   ingress:
-    # Allow ingress from Traefik (HTTP)
+    # Allow ingress from Traefik (HTTP) and KEDA HTTP interceptor
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: traefik
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: keda
       ports:
         - protocol: TCP
           port: 60072

--- a/apps/40-network/netvisor/overlays/prod/httpscaledobject.yaml
+++ b/apps/40-network/netvisor/overlays/prod/httpscaledobject.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: http.keda.sh/v1alpha1
+kind: HTTPScaledObject
+metadata:
+  name: netvisor
+  namespace: networking
+spec:
+  hosts:
+    - netvisor.truxonline.com
+  pathPrefixes:
+    - /
+  scaleTargetRef:
+    name: netvisor-server
+    kind: Deployment
+    service: netvisor-server
+    port: 60072
+  replicas:
+    min: 0
+    max: 1
+  scaledownPeriod: 300

--- a/apps/40-network/netvisor/overlays/prod/ingress.yaml
+++ b/apps/40-network/netvisor/overlays/prod/ingress.yaml
@@ -23,7 +23,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: netvisor-server
+                name: keda-interceptor-proxy
                 port:
                   number: 60072
   tls:

--- a/apps/40-network/netvisor/overlays/prod/keda-interceptor-svc.yaml
+++ b/apps/40-network/netvisor/overlays/prod/keda-interceptor-svc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keda-interceptor-proxy
+  namespace: networking
+spec:
+  type: ExternalName
+  externalName: keda-add-ons-http-interceptor-proxy.keda.svc.cluster.local
+  ports:
+    - port: 60072
+      protocol: TCP

--- a/apps/40-network/netvisor/overlays/prod/kustomization.yaml
+++ b/apps/40-network/netvisor/overlays/prod/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+  - httpscaledobject.yaml
+  - keda-interceptor-svc.yaml
 components:
   - ../../../../_shared/components/sync-wave/wave-15
   - ../../../../_shared/components/goldilocks/enabled


### PR DESCRIPTION
## Summary
- Add `HTTPScaledObject` for netvisor-server: `minReplicas=0`, `maxReplicas=1`, `scaledownPeriod=300s`
- Create `keda-interceptor-proxy` ExternalName service in `networking` namespace (new namespace, owned by this app)
- Rewire `netvisor-ingress` backend to `keda-interceptor-proxy` (port 60072)
- Fix `NetworkPolicy`: allow ingress from `keda` namespace alongside `traefik`

## Notes
- Port 60072 (non-standard) — ExternalName service port matches
- No probes defined → container considered ready immediately after start → fast cold-start
- Same pattern as stirling-pdf/netbox, third KEDA-enabled app

🤖 Generated with [Claude Code](https://claude.com/claude-code)