### PR TITLE
feat(keda): scale-to-zero headlamp, radar + fix netvisor interceptor port

### DIFF
--- a/apps/40-network/netvisor/overlays/prod/ingress.yaml
+++ b/apps/40-network/netvisor/overlays/prod/ingress.yaml
@@ -25,7 +25,7 @@ spec:
               service:
                 name: keda-interceptor-proxy
                 port:
-                  number: 60072
+                  number: 8080
   tls:
     - hosts:
         - netvisor.truxonline.com

--- a/apps/40-network/netvisor/overlays/prod/keda-interceptor-svc.yaml
+++ b/apps/40-network/netvisor/overlays/prod/keda-interceptor-svc.yaml
@@ -8,5 +8,5 @@ spec:
   type: ExternalName
   externalName: keda-add-ons-http-interceptor-proxy.keda.svc.cluster.local
   ports:
-    - port: 60072
+    - port: 8080
       protocol: TCP

--- a/apps/70-tools/headlamp/base/networkpolicy.yaml
+++ b/apps/70-tools/headlamp/base/networkpolicy.yaml
@@ -11,11 +11,14 @@ spec:
     - Ingress
     - Egress
   ingress:
-    # Allow ingress from Traefik (HTTP)
+    # Allow ingress from Traefik (HTTP) and KEDA HTTP interceptor
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: traefik
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: keda
       ports:
         - protocol: TCP
           port: 4466

--- a/apps/70-tools/headlamp/overlays/prod/httpscaledobject.yaml
+++ b/apps/70-tools/headlamp/overlays/prod/httpscaledobject.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: http.keda.sh/v1alpha1
+kind: HTTPScaledObject
+metadata:
+  name: headlamp
+  namespace: tools
+spec:
+  hosts:
+    - headlamp.truxonline.com
+  pathPrefixes:
+    - /
+  scaleTargetRef:
+    name: headlamp
+    kind: Deployment
+    service: headlamp
+    port: 80
+  replicas:
+    min: 0
+    max: 1
+  scaledownPeriod: 300

--- a/apps/70-tools/headlamp/overlays/prod/ingress.yaml
+++ b/apps/70-tools/headlamp/overlays/prod/ingress.yaml
@@ -24,9 +24,9 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: headlamp
+                name: keda-interceptor-proxy
                 port:
-                  number: 80
+                  number: 8080
   tls:
     - hosts:
         - headlamp.truxonline.com

--- a/apps/70-tools/headlamp/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/headlamp/overlays/prod/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+  - httpscaledobject.yaml
 
 components:
   - ../../../../_shared/components/sync-wave/wave-11

--- a/apps/70-tools/radar/overlays/prod/httpscaledobject.yaml
+++ b/apps/70-tools/radar/overlays/prod/httpscaledobject.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: http.keda.sh/v1alpha1
+kind: HTTPScaledObject
+metadata:
+  name: radar
+  namespace: tools
+spec:
+  hosts:
+    - radar.truxonline.com
+  pathPrefixes:
+    - /
+  scaleTargetRef:
+    name: radar
+    kind: Deployment
+    service: radar
+    port: 9280
+  replicas:
+    min: 0
+    max: 1
+  scaledownPeriod: 300

--- a/apps/70-tools/radar/overlays/prod/ingress.yaml
+++ b/apps/70-tools/radar/overlays/prod/ingress.yaml
@@ -24,9 +24,9 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: radar
+                name: keda-interceptor-proxy
                 port:
-                  number: 9280
+                  number: 8080
   tls:
     - hosts:
         - radar.truxonline.com

--- a/apps/70-tools/radar/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/radar/overlays/prod/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: tools
 resources:
   - ../../base
   - ingress.yaml
+  - httpscaledobject.yaml
 
 components:
   - ../../../../_shared/components/sync-wave/wave-11


### PR DESCRIPTION
headlamp+radar: HTTPScaledObject min=0/max=1, ingress→keda-interceptor-proxy:8080. headlamp NetworkPolicy +keda. netvisor fix: port 60072→8080.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled HTTP-based auto-scaling for applications, with scaling configured between 0-1 replicas and a 5-minute scale-down period.

* **Chores**
  * Updated network routing configuration to optimize request handling through an intermediary proxy service.
  * Expanded network access policies to allow cross-namespace traffic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->