### PR TITLE
feat(keda): scale-to-zero it-tools, linkwarden, jellyseerr, docspell

### DIFF
--- a/apps/20-media/jellyseerr/base/networkpolicy.yaml
+++ b/apps/20-media/jellyseerr/base/networkpolicy.yaml
@@ -11,11 +11,14 @@ spec:
     - Ingress
     - Egress
   ingress:
-    # Allow ingress from Traefik (HTTP)
+    # Allow ingress from Traefik (HTTP) and KEDA HTTP interceptor
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: traefik
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: keda
       ports:
         - protocol: TCP
           port: 5055

--- a/apps/20-media/jellyseerr/overlays/prod/httpscaledobject.yaml
+++ b/apps/20-media/jellyseerr/overlays/prod/httpscaledobject.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: http.keda.sh/v1alpha1
+kind: HTTPScaledObject
+metadata:
+  name: jellyseerr
+  namespace: media
+spec:
+  hosts:
+    - jellyseerr.truxonline.com
+  pathPrefixes:
+    - /
+  scaleTargetRef:
+    name: jellyseerr
+    kind: Deployment
+    service: jellyseerr
+    port: 5055
+  replicas:
+    min: 0
+    max: 1
+  scaledownPeriod: 300

--- a/apps/20-media/jellyseerr/overlays/prod/ingress.yaml
+++ b/apps/20-media/jellyseerr/overlays/prod/ingress.yaml
@@ -23,9 +23,9 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: jellyseerr
+                name: keda-interceptor-proxy
                 port:
-                  number: 5055
+                  number: 8080
   tls:
     - hosts:
         - jellyseerr.truxonline.com

--- a/apps/20-media/jellyseerr/overlays/prod/keda-interceptor-svc.yaml
+++ b/apps/20-media/jellyseerr/overlays/prod/keda-interceptor-svc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keda-interceptor-proxy
+  namespace: media
+spec:
+  type: ExternalName
+  externalName: keda-add-ons-http-interceptor-proxy.keda.svc.cluster.local
+  ports:
+    - port: 8080
+      protocol: TCP

--- a/apps/20-media/jellyseerr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/jellyseerr/overlays/prod/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+  - keda-interceptor-svc.yaml
+  - httpscaledobject.yaml
 
 components:
   - ../../../../_shared/components/sync-wave/wave-15

--- a/apps/60-services/docspell/base/networkpolicy.yaml
+++ b/apps/60-services/docspell/base/networkpolicy.yaml
@@ -11,11 +11,14 @@ spec:
     - Ingress
     - Egress
   ingress:
-    # Allow ingress from Traefik (HTTP)
+    # Allow ingress from Traefik (HTTP) and KEDA HTTP interceptor
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: traefik
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: keda
       ports:
         - protocol: TCP
           port: 7880

--- a/apps/60-services/docspell/overlays/prod/httpscaledobject-restserver.yaml
+++ b/apps/60-services/docspell/overlays/prod/httpscaledobject-restserver.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: http.keda.sh/v1alpha1
+kind: HTTPScaledObject
+metadata:
+  name: docspell-restserver
+  namespace: services
+spec:
+  hosts:
+    - docspell.truxonline.com
+  pathPrefixes:
+    - /
+  scaleTargetRef:
+    name: docspell-restserver
+    kind: StatefulSet
+    service: docspell-restserver
+    port: 7880
+  replicas:
+    min: 0
+    max: 1
+  scaledownPeriod: 300

--- a/apps/60-services/docspell/overlays/prod/ingress.yaml
+++ b/apps/60-services/docspell/overlays/prod/ingress.yaml
@@ -30,6 +30,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: docspell-restserver
+                name: keda-interceptor-proxy
                 port:
-                  number: 7880
+                  number: 8080

--- a/apps/60-services/docspell/overlays/prod/keda-interceptor-svc.yaml
+++ b/apps/60-services/docspell/overlays/prod/keda-interceptor-svc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keda-interceptor-proxy
+  namespace: services
+spec:
+  type: ExternalName
+  externalName: keda-add-ons-http-interceptor-proxy.keda.svc.cluster.local
+  ports:
+    - port: 8080
+      protocol: TCP

--- a/apps/60-services/docspell/overlays/prod/kustomization.yaml
+++ b/apps/60-services/docspell/overlays/prod/kustomization.yaml
@@ -16,3 +16,7 @@ patchesStrategicMerge:
 resources:
   - ../../base
   - ingress.yaml
+  - keda-interceptor-svc.yaml
+  - httpscaledobject-restserver.yaml
+  - triggerauthentication-joex.yaml
+  - scaledobject-joex.yaml

--- a/apps/60-services/docspell/overlays/prod/scaledobject-joex.yaml
+++ b/apps/60-services/docspell/overlays/prod/scaledobject-joex.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: docspell-joex
+  namespace: services
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: docspell-joex
+  minReplicaCount: 0
+  maxReplicaCount: 1
+  cooldownPeriod: 120
+  triggers:
+    # Scale up when jobs are pending/running in the queue
+    - type: postgresql
+      metadata:
+        host: postgresql-shared-rw.databases.svc.cluster.local
+        port: "5432"
+        dbName: docspell
+        query: "SELECT COUNT(*) FROM job WHERE state IN ('waiting', 'running', 'stuck')"
+        targetQueryValue: "1"
+        activationTargetQueryValue: "1"
+        sslmode: disable
+      authenticationRef:
+        name: docspell-pg-auth
+    # Nightly fallback: scan watched folders even if n8n didn't trigger
+    - type: cron
+      metadata:
+        timezone: Europe/Paris
+        start: "0 2 * * *"
+        end: "0 6 * * *"
+        desiredReplicas: "1"

--- a/apps/60-services/docspell/overlays/prod/triggerauthentication-joex.yaml
+++ b/apps/60-services/docspell/overlays/prod/triggerauthentication-joex.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: docspell-pg-auth
+  namespace: services
+spec:
+  secretTargetRef:
+    - parameter: username
+      name: docspell-db-credentials
+      key: username
+    - parameter: password
+      name: docspell-db-credentials
+      key: password

--- a/apps/70-tools/it-tools/overlays/prod/httpscaledobject.yaml
+++ b/apps/70-tools/it-tools/overlays/prod/httpscaledobject.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: http.keda.sh/v1alpha1
+kind: HTTPScaledObject
+metadata:
+  name: it-tools
+  namespace: tools
+spec:
+  hosts:
+    - it-tools.truxonline.com
+  pathPrefixes:
+    - /
+  scaleTargetRef:
+    name: it-tools
+    kind: Deployment
+    service: it-tools
+    port: 8080
+  replicas:
+    min: 0
+    max: 1
+  scaledownPeriod: 300

--- a/apps/70-tools/it-tools/overlays/prod/ingress.yaml
+++ b/apps/70-tools/it-tools/overlays/prod/ingress.yaml
@@ -22,7 +22,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: it-tools
+                name: keda-interceptor-proxy
                 port:
                   number: 8080
   tls:

--- a/apps/70-tools/it-tools/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/it-tools/overlays/prod/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: tools
 resources:
   - ../../base
   - ingress.yaml
+  - httpscaledobject.yaml
 
 components:
 

--- a/apps/70-tools/linkwarden/base/networkpolicy.yaml
+++ b/apps/70-tools/linkwarden/base/networkpolicy.yaml
@@ -11,11 +11,14 @@ spec:
     - Ingress
     - Egress
   ingress:
-    # Allow ingress from Traefik (HTTP)
+    # Allow ingress from Traefik (HTTP) and KEDA HTTP interceptor
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: traefik
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: keda
       ports:
         - protocol: TCP
           port: 3000

--- a/apps/70-tools/linkwarden/overlays/prod/httpscaledobject.yaml
+++ b/apps/70-tools/linkwarden/overlays/prod/httpscaledobject.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: http.keda.sh/v1alpha1
+kind: HTTPScaledObject
+metadata:
+  name: linkwarden
+  namespace: tools
+spec:
+  hosts:
+    - linkwarden.truxonline.com
+  pathPrefixes:
+    - /
+  scaleTargetRef:
+    name: linkwarden
+    kind: Deployment
+    service: linkwarden
+    port: 3000
+  replicas:
+    min: 0
+    max: 1
+  scaledownPeriod: 300

--- a/apps/70-tools/linkwarden/overlays/prod/ingress.yaml
+++ b/apps/70-tools/linkwarden/overlays/prod/ingress.yaml
@@ -26,9 +26,9 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: linkwarden
+                name: keda-interceptor-proxy
                 port:
-                  number: 3000
+                  number: 8080
   tls:
     - hosts:
         - linkwarden.truxonline.com

--- a/apps/70-tools/linkwarden/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/linkwarden/overlays/prod/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   - ../../base
   - infisical-secret.yaml
   - ingress.yaml
+  - httpscaledobject.yaml


### PR DESCRIPTION
## Summary

- **it-tools** (`tools`): HTTPScaledObject — réutilise keda-interceptor-proxy de stirling-pdf
- **linkwarden** (`tools`): HTTPScaledObject + NetworkPolicy +keda — réutilise keda-interceptor-proxy
- **jellyseerr** (`media`): HTTPScaledObject + keda-interceptor-svc (nouveau namespace) + NetworkPolicy +keda
- **docspell-restserver** (`services`): HTTPScaledObject + keda-interceptor-svc (nouveau namespace) + NetworkPolicy +keda
- **docspell-joex** (`services`): ScaledObject hybride PostgreSQL + CronScaler
  - PostgreSQL: scale up quand `job.state IN ('waiting','running','stuck')`, scale down à 0 quand queue vide
  - Cron: 02h00–06h00 Paris (fallback nocturne)
  - TriggerAuthentication: réutilise `docspell-db-credentials`

## Test plan

- [ ] it-tools cold-start: `curl -L https://it-tools.truxonline.com`
- [ ] linkwarden cold-start: `curl -L https://linkwarden.truxonline.com`
- [ ] jellyseerr cold-start: `curl -L https://jellyseerr.truxonline.com`
- [ ] docspell cold-start: `curl -L https://docspell.truxonline.com`
- [ ] `kubectl get scaledobject -n services` → docspell-joex READY
- [ ] déposer un document → joex démarre automatiquement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled HTTP-based autoscaling for jellyseerr, docspell, it-tools, and linkwarden services
  * Services automatically scale down to zero replicas during idle periods and scale up when traffic is detected, reducing resource consumption
  * Database-driven autoscaling for background job processing (docspell)
  * Infrastructure updated to support autoscaling operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->