### PR TITLE
feat(storage/backup): adguard-home local-path + linkwarden DataAngel

### DIFF
--- a/apps/40-network/adguard-home/overlays/prod/kustomization.yaml
+++ b/apps/40-network/adguard-home/overlays/prod/kustomization.yaml
@@ -25,6 +25,12 @@ patches:
       - op: add
         path: /spec/template/metadata/annotations/autoscaling.k8s.io~1vpa
         value: "auto"
+      - op: replace
+        path: /spec/volumeClaimTemplates/0/spec/storageClassName
+        value: local-path-retain
+      - op: replace
+        path: /spec/volumeClaimTemplates/1/spec/storageClassName
+        value: local-path-retain
     target:
       kind: StatefulSet
       name: adguard-home

--- a/apps/70-tools/linkwarden/overlays/prod/dataangel.yaml
+++ b/apps/70-tools/linkwarden/overlays/prod/dataangel.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: linkwarden
+spec:
+  template:
+    metadata:
+      labels:
+        vixens.io/sizing.dataangel: V-small
+      annotations:
+        dataangel.io/bucket: "vixens-prod-linkwarden"
+        dataangel.io/fs-paths: "/data"
+        dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
+        dataangel.io/deployment-name: "linkwarden"
+        dataangel.io/rclone-interval: "60s"
+        dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
+    spec:
+      initContainers:
+        - name: dataangel
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: linkwarden-secrets
+                  key: S3_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: linkwarden-secrets
+                  key: S3_SECRET_ACCESS_KEY

--- a/apps/70-tools/linkwarden/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/linkwarden/overlays/prod/kustomization.yaml
@@ -8,9 +8,11 @@ components:
   - ../../../../_shared/components/sync-wave/wave-9
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics
+  - ../../../../_shared/components/dataangel
 
 patches:
   - path: patch-nextauth-url.yaml
+  - path: dataangel.yaml
 resources:
   - ../../base
   - infisical-secret.yaml


### PR DESCRIPTION
## Summary

### adguard-home — migrate volumeClaimTemplates to `local-path-retain`
- Patches both `config` (1Gi) and `data` (5Gi) volumeClaimTemplates from `synelia-iscsi` → `local-path-retain`
- DataAngel already active and backing up to S3 (`vixens-prod-adguard-home`)
- StatefulSet migration procedure is more complex than a Deployment (see below)

### linkwarden — add DataAngel fs-mode backup
- Adds DataAngel sidecar to back up `/data/data` (file uploads, screenshots, web archives)
- fs-only mode — PostgreSQL database is managed externally via CloudNativePG
- Currently **zero backup** for this data — critical gap

## ⚠️ Out-of-band prerequisites (linkwarden, before merge)

1. Create MinIO bucket `vixens-prod-linkwarden`
2. Add to Infisical `/apps/70-tools/linkwarden` (prod env):
   - `S3_ACCESS_KEY_ID`
   - `S3_SECRET_ACCESS_KEY`

## Migration procedure — adguard-home (after merge + prod tag)

StatefulSet `volumeClaimTemplates` are immutable — requires delete+recreate:

```bash
export KUBECONFIG=/home/charchess/vixens/.secrets/prod/kubeconfig-prod

# 1. Scale to 0 — DataAngel completes final backup
kubectl scale statefulset adguard-home -n networking --replicas=0
# Wait ~90s

# 2. Delete SS but keep PVCs (orphan)
kubectl delete statefulset adguard-home -n networking --cascade=orphan

# 3. Delete old iSCSI PVCs
kubectl delete pvc config-adguard-home-0 data-adguard-home-0 -n networking

# 4. ArgoCD sync → creates new SS with local-path PVCs + DataAngel restores
# argocd app sync adguard-home
```

## Test plan
- [ ] Prerequisites: MinIO bucket + Infisical creds for linkwarden
- [ ] Merge + promote to prod
- [ ] **linkwarden**: verify DataAngel sidecar starts and `/data` appears in MinIO bucket
- [ ] **adguard-home**: follow migration runbook, verify DNS keeps working after restore
- [ ] Old iSCSI LUNs on Synology can be removed after validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AdGuard Home storage configuration to enhance data persistence reliability
  * Integrated DataAngel component for Linkwarden to enable automated data backup and synchronization capabilities with cloud storage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->