### PR TITLE
feat(backup/storage): add DataAngel + local-path migration for trilium

### DIFF
--- a/apps/70-tools/trilium/overlays/prod/dataangel.yaml
+++ b/apps/70-tools/trilium/overlays/prod/dataangel.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trilium
+spec:
+  template:
+    metadata:
+      labels:
+        vixens.io/sizing.dataangel: V-small
+      annotations:
+        dataangel.io/bucket: "vixens-prod-trilium"
+        dataangel.io/sqlite-paths: "/home/node/trilium-data/document.db"
+        dataangel.io/fs-paths: "/home/node/trilium-data"
+        dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
+        dataangel.io/deployment-name: "trilium"
+        dataangel.io/rclone-interval: "60s"
+        dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
+    spec:
+      initContainers:
+        - name: dataangel
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: trilium-secrets
+                  key: S3_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: trilium-secrets
+                  key: S3_SECRET_ACCESS_KEY
+          volumeMounts:
+            - mountPath: /data
+              $patch: delete
+            - name: trilium-data
+              mountPath: /home/node/trilium-data

--- a/apps/70-tools/trilium/overlays/prod/infisical-secret.yaml
+++ b/apps/70-tools/trilium/overlays/prod/infisical-secret.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: trilium-secrets-sync
+  namespace: tools
+  labels:
+    app.kubernetes.io/name: trilium
+spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
+  authentication:
+    universalAuth:
+      credentialsRef:
+        secretName: infisical-universal-auth
+        secretNamespace: argocd
+      secretsScope:
+        projectSlug: vixens
+        envSlug: prod
+        secretsPath: /apps/70-tools/trilium
+  managedSecretReference:
+    secretName: trilium-secrets
+    creationPolicy: Owner
+    secretNamespace: tools

--- a/apps/70-tools/trilium/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/trilium/overlays/prod/kustomization.yaml
@@ -3,13 +3,23 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - infisical-secret.yaml
 components:
   - ../../../../_shared/components/sync-wave/wave-9
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics
   - ../../../../_shared/components/poddisruptionbudget/0
+  - ../../../../_shared/components/dataangel
 
 patches:
+  - path: dataangel.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: trilium-data-pvc
   - target:
       kind: Ingress
       name: trilium


### PR DESCRIPTION
## Summary

- Adds DataAngel sidecar with sqlite-mode (`document.db`) + fs-sync for `/home/node/trilium-data`
- Migrates PVC `trilium-data-pvc` from `synelia-iscsi-retain` → `local-path-retain`
- Adds `InfisicalSecret` to sync S3 credentials (`trilium-secrets`)

**Volume name note**: trilium uses `trilium-data` (not the component default `data`), so the DataAngel patch overrides the volumeMount accordingly.

## ⚠️ Out-of-band prerequisites (before merge)

1. Create MinIO bucket `vixens-prod-trilium`
2. Add to Infisical `/apps/70-tools/trilium` (prod env):
   - `S3_ACCESS_KEY_ID`
   - `S3_SECRET_ACCESS_KEY`

## Migration procedure (after merge + prod tag)

```bash
export KUBECONFIG=/home/charchess/vixens/.secrets/prod/kubeconfig-prod

# 1. Scale down — DataAngel completes initial backup (first run)
kubectl scale deployment trilium -n tools --replicas=0
# Wait ~90s

# 2. Delete old iSCSI PVC
kubectl delete pvc trilium-data-pvc -n tools

# 3. ArgoCD sync → new local-path PVC + DataAngel litestream restore
```

## Test plan
- [ ] Prerequisites: MinIO bucket + Infisical creds created
- [ ] Merge + promote to prod
- [ ] Verify DataAngel starts and `document.db` appears in MinIO bucket (`vixens-prod-trilium`)
- [ ] Follow migration runbook
- [ ] Verify trilium starts and notes are intact after restore
- [ ] Old iSCSI LUN on Synology can be removed after validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)