### PR TITLE
fix(dataangel): add initContainers: [] to trilium + linkwarden base

### DIFF
--- a/apps/70-tools/linkwarden/base/deployment.yaml
+++ b/apps/70-tools/linkwarden/base/deployment.yaml
@@ -26,6 +26,7 @@ spec:
           operator: Exists
           effect: NoSchedule
       priorityClassName: vixens-low
+      initContainers: []
       containers:
         - name: linkwarden
           resources:

--- a/apps/70-tools/trilium/base/deployment.yaml
+++ b/apps/70-tools/trilium/base/deployment.yaml
@@ -28,6 +28,7 @@ spec:
           operator: Exists
           effect: NoSchedule
       priorityClassName: vixens-low
+      initContainers: []
       containers:
         - name: trilium
           image: triliumnext/notes:v0.95.0


### PR DESCRIPTION
## Problem

ArgoCD kustomize build fails for trilium (and would fail for linkwarden) with:

```
add operation does not apply: doc is missing path: "/spec/template/spec/initContainers/-": missing value
```

The DataAngel shared component uses a JSON Patch `op: add, path: /-` to append its sidecar container. This requires the `initContainers` array to already exist in the Deployment spec.

## Fix

Add `initContainers: []` to the base Deployment for both trilium and linkwarden.

## Impact

- Unblocks trilium from syncing in ArgoCD (currently `ComparisonError`)
- Preemptively fixes linkwarden (same issue, not yet manifested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configurations for internal consistency and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->