### PR TITLE
fix(trilium): ignore PVC storageClassName diff during DataAngel backup phase

### DIFF
--- a/argocd/overlays/prod/apps/trilium.yaml
+++ b/argocd/overlays/prod/apps/trilium.yaml
@@ -17,6 +17,12 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: tools
+  ignoreDifferences:
+    - group: ""
+      kind: PersistentVolumeClaim
+      name: trilium-data-pvc
+      jsonPointers:
+        - /spec/storageClassName
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Context

During the local-path migration for trilium, the PVC was deleted before DataAngel had run its first backup. The data was recovered by rebinding the old Synology iSCSI PV to a new PVC with `synelia-iscsi-retain`.

ArgoCD now sees a diff between the live PVC (`synelia-iscsi-retain`) and what Git declares (`local-path-retain`), blocking the sync and preventing the new deployment (with DataAngel) from being applied.

## Fix

Add `ignoreDifferences` for the PVC `storageClassName` so ArgoCD can sync the Deployment (with DataAngel) while leaving the PVC alone.

## Next steps (after DataAngel confirmed working in S3)

1. Remove this `ignoreDifferences`
2. Scale down trilium, delete the iSCSI PVC
3. ArgoCD creates new `local-path-retain` PVC + DataAngel restores

🤖 Generated with [Claude Code](https://claude.com/claude-code)