### PR TITLE
fix(trilium): add RespectIgnoreDifferences to prevent PVC immutable field sync error

### DIFF
--- a/argocd/overlays/prod/apps/trilium.yaml
+++ b/argocd/overlays/prod/apps/trilium.yaml
@@ -23,9 +23,11 @@ spec:
       name: trilium-data-pvc
       jsonPointers:
         - /spec/storageClassName
+        - /spec/volumeName
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      - RespectIgnoreDifferences=true


### PR DESCRIPTION
ArgoCD was still trying to patch the PVC storageClassName/volumeName even with ignoreDifferences. Adding RespectIgnoreDifferences=true to syncOptions tells ArgoCD to skip applying the ignored fields during sync operations.