### PR TITLE
fix(trilium): temporarily remove local-path PVC patch to unblock ArgoCD sync

### DIFF
--- a/apps/70-tools/trilium/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/trilium/overlays/prod/kustomization.yaml
@@ -13,13 +13,8 @@ components:
 
 patches:
   - path: dataangel.yaml
-  - patch: |-
-      - op: replace
-        path: /spec/storageClassName
-        value: local-path-retain
-    target:
-      kind: PersistentVolumeClaim
-      name: trilium-data-pvc
+  # storageClass migration patch removed temporarily — will be re-added
+  # once DataAngel has completed its first S3 backup
   - target:
       kind: Ingress
       name: trilium

--- a/argocd/overlays/prod/apps/trilium.yaml
+++ b/argocd/overlays/prod/apps/trilium.yaml
@@ -17,17 +17,9 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: tools
-  ignoreDifferences:
-    - group: ""
-      kind: PersistentVolumeClaim
-      name: trilium-data-pvc
-      jsonPointers:
-        - /spec/storageClassName
-        - /spec/volumeName
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - RespectIgnoreDifferences=true


### PR DESCRIPTION
RespectIgnoreDifferences does not prevent ArgoCD from applying immutable PVC fields. Removing the storageClass patch until DataAngel has completed its first S3 backup. The migration patch will be re-added in a follow-up PR once backup is confirmed.