### PR TITLE
fix(trilium): align PVC volumeName with manually-rebound iSCSI PV

### DIFF
--- a/apps/70-tools/trilium/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/trilium/overlays/prod/kustomization.yaml
@@ -13,8 +13,15 @@ components:
 
 patches:
   - path: dataangel.yaml
-  # storageClass migration patch removed temporarily — will be re-added
-  # once DataAngel has completed its first S3 backup
+  # Temporary: bind to existing iSCSI PV so ArgoCD desired state matches live.
+  # Remove once DataAngel has backed up to S3 and local-path migration is done.
+  - patch: |-
+      - op: add
+        path: /spec/volumeName
+        value: pvc-2089fa07-ad0d-4a0a-a9cf-b3b28dc08b4b
+    target:
+      kind: PersistentVolumeClaim
+      name: trilium-data-pvc
   - target:
       kind: Ingress
       name: trilium


### PR DESCRIPTION
During data recovery, PVC was recreated with explicit volumeName. This patch aligns kustomize desired state with live state so ArgoCD can sync. Temporary — remove once DataAngel completes initial S3 backup and local-path migration is done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated persistent volume binding configuration for the storage system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->