### PR TITLE
feat(trilium): finalize local-path-retain migration

### DIFF
--- a/apps/70-tools/trilium/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/trilium/overlays/prod/kustomization.yaml
@@ -13,12 +13,10 @@ components:
 
 patches:
   - path: dataangel.yaml
-  # Temporary: bind to existing iSCSI PV so ArgoCD desired state matches live.
-  # Remove once DataAngel has backed up to S3 and local-path migration is done.
   - patch: |-
-      - op: add
-        path: /spec/volumeName
-        value: pvc-2089fa07-ad0d-4a0a-a9cf-b3b28dc08b4b
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
     target:
       kind: PersistentVolumeClaim
       name: trilium-data-pvc


### PR DESCRIPTION
DataAngel confirmed running with snapshot + WAL segments in vixens-prod-trilium. Removes recovery patches (volumeName binding, storageClass workarounds). ArgoCD will create new local-path PVC + DataAngel restores from S3.