### PR TITLE
fix(kyverno): exclude local-path-storage from sizing-v2-mutate policy

### DIFF
--- a/apps/00-infra/kyverno/base/policies/sizing-v2-mutate.yaml
+++ b/apps/00-infra/kyverno/base/policies/sizing-v2-mutate.yaml
@@ -52,6 +52,7 @@ spec:
                 - trivy-server
               namespaces:
                 - security
+                - local-path-storage
       mutate:
         foreach:
           - list: "request.object.spec.containers || '[]'"
@@ -131,6 +132,7 @@ spec:
                 - trivy-server
               namespaces:
                 - security
+                - local-path-storage
       mutate:
         foreach:
           - list: "request.object.spec.initContainers || '[]'"
@@ -212,6 +214,7 @@ spec:
                 - trivy-server
               namespaces:
                 - security
+                - local-path-storage
       mutate:
         foreach:
           - list: "request.object.spec.containers || '[]'"


### PR DESCRIPTION
local-path provisioner creates helper pods in local-path-storage namespace without app labels. The sizing mutation policy errored on these pods, blocking all local-path PVC provisioning. Adds local-path-storage to the namespace exclusion on all 3 rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resource management policies to exclude pods in the `local-path-storage` namespace from automatic sizing adjustments, maintaining consistency with existing exclusion rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->