### PR TITLE
fix(kyverno): exclude local-path helper-pod by name in sizing-v2-mutate

### DIFF
--- a/apps/00-infra/kyverno/base/policies/sizing-v2-mutate.yaml
+++ b/apps/00-infra/kyverno/base/policies/sizing-v2-mutate.yaml
@@ -52,7 +52,9 @@ spec:
                 - trivy-server
               namespaces:
                 - security
-                - local-path-storage
+          - resources:
+              names:
+                - helper-pod  # local-path provisioner ephemeral helper pods (any namespace)
       mutate:
         foreach:
           - list: "request.object.spec.containers || '[]'"
@@ -132,7 +134,9 @@ spec:
                 - trivy-server
               namespaces:
                 - security
-                - local-path-storage
+          - resources:
+              names:
+                - helper-pod  # local-path provisioner ephemeral helper pods (any namespace)
       mutate:
         foreach:
           - list: "request.object.spec.initContainers || '[]'"
@@ -214,7 +218,9 @@ spec:
                 - trivy-server
               namespaces:
                 - security
-                - local-path-storage
+          - resources:
+              names:
+                - helper-pod  # local-path provisioner ephemeral helper pods (any namespace)
       mutate:
         foreach:
           - list: "request.object.spec.containers || '[]'"


### PR DESCRIPTION
## Summary

- Fixes Kyverno `sizing-v2-mutate` blocking local-path provisioner helper pods
- PR #2513 incorrectly excluded the `local-path-storage` namespace, but helper pods are created in the PVC's **target namespace** (e.g. `mealie`, `services`, `tools`)
- Correct fix: exclude pods named `helper-pod` globally (no namespace restriction) across all 3 rules

## Root cause

The local-path provisioner creates ephemeral pods named `helper-pod` with **no labels**. The JMESPath expression in `sizing-v2-mutate` fails with `Invalid type for: <nil>` when labels are absent, causing the `mutate.kyverno.svc-fail` webhook to deny the request.

## Impact

Unblocks PVC provisioning for:
- `mealie-data` (namespace: mealie)
- `vaultwarden-data-pvc` (namespace: services)
- `trilium-data-pvc` (namespace: tools)

## Test plan

- [ ] Merge → ArgoCD syncs kyverno policy
- [ ] Verify `kubectl get pvc -n mealie mealie-data` transitions from Pending → Bound
- [ ] Verify `kubectl get pvc -n services vaultwarden-data-pvc` transitions from Pending → Bound
- [ ] Verify `kubectl get pvc -n tools trilium-data-pvc` transitions from Pending → Bound

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pod sizing policy configuration to properly exclude local-path provisioner helper pods from mutation enforcement.
  * Refined exclusion logic across pod mutation rules to prevent unintended pod resource modifications and ensure helper pods are correctly handled by cluster policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->