### PR TITLE
fix(kyverno): replace JMESPath arithmetic + with split conditions

### DIFF
--- a/apps/00-infra/kyverno/base/policies/check-config-syncer-relevance.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-config-syncer-relevance.yaml
@@ -28,6 +28,9 @@ spec:
         deny:
           conditions:
             all:
-              - key: "{{ (request.object.spec.containers[?contains(image, 'rclone')] | length(@)) + ((request.object.spec.initContainers || `[]`)[?contains(image, 'dataangel')] | length(@)) }}"
+              - key: "{{ request.object.spec.containers[?contains(image, 'rclone')] | length(@) }}"
+                operator: Equals
+                value: 0
+              - key: "{{ (request.object.spec.initContainers || `[]`)[?contains(image, 'dataangel')] | length(@) }}"
                 operator: Equals
                 value: 0

--- a/apps/00-infra/kyverno/base/policies/check-sidecar-relevance.yaml
+++ b/apps/00-infra/kyverno/base/policies/check-sidecar-relevance.yaml
@@ -33,7 +33,10 @@ spec:
                   - key: "{{ request.object.spec.volumes[?contains(name, 'config')] }}" # Has config volume
                     operator: NotEquals
                     value: ""
-                  - key: "{{ (request.object.spec.containers[?contains(image, 'litestream')] | length(@)) + ((request.object.spec.initContainers || `[]`)[?contains(image, 'dataangel')] | length(@)) }}"
+                  - key: "{{ request.object.spec.containers[?contains(image, 'litestream')] | length(@) }}"
+                    operator: Equals
+                    value: 0
+                  - key: "{{ (request.object.spec.initContainers || `[]`)[?contains(image, 'dataangel')] | length(@) }}"
                     operator: Equals
                     value: 0
                   - key: "{{ request.object.metadata.labels.app }}" # Filter out known non-sqlite apps


### PR DESCRIPTION
## Summary

- Fixes Kyverno ArgoCD app sync failure caused by unsupported JMESPath `+` operator
- Affects two Emerald-level audit policies: `check-config-syncer-relevance` and `check-sidecar-relevance`
- Split `(countA) + (countB) == 0` into two separate `== 0` conditions under `all:` — semantically equivalent for non-negative integers

## Root cause

ArgoCD was failing to sync the `kyverno` app with:
```
SyntaxError: Unknown char: '+'
```

Kyverno's JMESPath engine does not support arithmetic operators. The `+` was used to check if the sum of two container counts was zero (i.e., neither container type was present).

## Impact

Unblocks the `kyverno` ArgoCD application sync, which in turn allows the `sizing-v2-mutate` policy fix (#2514) to take effect and unblock local-path PVC provisioning.

## Test plan

- [ ] Merge → ArgoCD syncs kyverno app → status Synced+Healthy
- [ ] Verify `kubectl get clusterpolicy check-config-syncer-relevance` and `check-sidecar-relevance` show `READY: True`
- [ ] Verify PVCs bind: mealie-data, vaultwarden-data-pvc, trilium-data-pvc

🤖 Generated with [Claude Code](https://claude.com/claude-code)