### PR TITLE
fix(kyverno): guard against nil labels in v2-unlabeled-sidecar-defaults precondition

### DIFF
--- a/apps/00-infra/kyverno/base/policies/sizing-v2-mutate.yaml
+++ b/apps/00-infra/kyverno/base/policies/sizing-v2-mutate.yaml
@@ -227,8 +227,8 @@ spec:
             preconditions:
               all:
                 # Only act on containers that have NO v2 sizing label.
-                # Use keys() to avoid 'Unknown key' JMESPath error on absent labels.
-                - key: "{{ request.object.metadata.labels | keys(@) | [?@ == 'vixens.io/sizing.{{element.name}}'] | length(@) }}"
+                # Use (labels || `{}`) to handle pods with no labels at all (e.g. local-path helper-pod).
+                - key: "{{ (request.object.metadata.labels || `{}`) | keys(@) | [?@ == 'vixens.io/sizing.{{element.name}}'] | length(@) }}"
                   operator: Equals
                   value: "0"
             patchStrategicMerge:


### PR DESCRIPTION
## Summary

- Fixes Kyverno mutation webhook blocking local-path `helper-pod` provisioner pods
- Root cause: `request.object.metadata.labels | keys(@)` fails with `Invalid type for: <nil>` when a pod has **no labels** (like the local-path `helper-pod`)
- Fix: wrap with `(request.object.metadata.labels || \`{}\`)` to return an empty object when labels is nil

## Why the previous fix (#2514) wasn't enough

PR #2514 added a pod-name `exclude` for `helper-pod` which correctly prevents the rule from matching by intent. However, it appears Kyverno is still evaluating the rule for the helper-pod (possibly a webhook routing or cache issue). This fix makes the precondition expression itself nil-safe so it cannot error regardless of which pod hits it.

## Test plan

- [ ] Merge → prod-stable tag advanced → ArgoCD syncs kyverno
- [ ] Verify `mealie-data`, `vaultwarden-data-pvc`, `trilium-data-pvc` PVCs bind
- [ ] Verify mealie, vaultwarden, trilium pods start successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resource sizing policy to safely handle edge cases where label configurations are entirely absent, ensuring consistent and reliable policy evaluation across all workload scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->