### PR TITLE
fix(vaultwarden): chmod sqlite files 660 in fix-permissions initContainer

### DIFF
--- a/apps/60-services/vaultwarden/base/deployment.yaml
+++ b/apps/60-services/vaultwarden/base/deployment.yaml
@@ -39,7 +39,7 @@ spec:
       initContainers:
         - name: fix-permissions
           image: busybox:1.37.0
-          command: ["sh", "-c", "chown -R 1000:1000 /data && rm -rf /data/*.db-litestream /data/.*-litestream"]
+          command: ["sh", "-c", "chown -R 1000:1000 /data && find /data -name '*.sqlite3*' -exec chmod 660 {} \\; && rm -rf /data/*.db-litestream /data/.*-litestream"]
           volumeMounts:
             - name: data
               mountPath: /data


### PR DESCRIPTION
## Summary

- Fixes vaultwarden CrashLoopBackOff on first boot from an empty volume (e.g., after local-path PVC migration)
- Root cause: vaultwarden container runs as root with `capabilities: drop: ALL`, losing `CAP_DAC_OVERRIDE` and `CAP_FOWNER`, so it cannot access `db.sqlite3` with permissions `600` owned by uid 1000 (restored by litestream)
- Fix: add `find /data -name '*.sqlite3*' -exec chmod 660 {} \;` in the `fix-permissions` initContainer so group (gid=1000 via fsGroup) can read/write the files

## Root cause chain

1. New empty local-path PVC mounted
2. `fix-permissions` initContainer chowns `/data` to 1000:1000 (directory was empty)
3. Litestream restore (if triggered manually) or previous runs created `db.sqlite3` with mode `600`
4. Vaultwarden container starts as root but `drop: ALL` capabilities → no `CAP_DAC_OVERRIDE` → can't access `600` files owned by 1000
5. SQLite: "Unable to open the database file" → CrashLoopBackOff

## Test plan

- [ ] Merge → deploy → vaultwarden pod healthy on next restart
- [ ] Verify vaultwarden accessible at https://vaultwarden.truxonline.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database file permission handling during service initialization to ensure reliable data access and prevent potential access-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->