### PR TITLE
feat(linkwarden): migrate PVC to local-path-retain

### DIFF
--- a/apps/70-tools/linkwarden/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/linkwarden/overlays/prod/kustomization.yaml
@@ -13,6 +13,13 @@ components:
 patches:
   - path: patch-nextauth-url.yaml
   - path: dataangel.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: linkwarden-data
 resources:
   - ../../base
   - infisical-secret.yaml


### PR DESCRIPTION
## Summary

- Migrates `linkwarden-data` PVC from `synelia-iscsi-retain` to `local-path-retain`
- Safe migration: the PVC was empty (linkwarden stores all data in PostgreSQL; the PVC is only for file attachments — none uploaded)
- DataAngel fs-mode backup already in place

## Migration steps performed

1. Scaled linkwarden deployment to 0
2. Deleted old iSCSI PVC (empty, no data loss)
3. This PR patches storageClassName → ArgoCD will create a new `local-path-retain` PVC on sync

## Test plan

- [ ] Merge → prod-stable advanced → ArgoCD syncs → linkwarden-data PVC bound (local-path-retain)
- [ ] linkwarden pod 2/2 Running
- [ ] Verify https://linkwarden.truxonline.com accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized data persistence configuration in production environments for improved system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->