### PR TITLE
feat(storage): migrate 9 apps to local-path-retain (Groupe A)

### DIFF
--- a/apps/20-media/lazylibrarian/overlays/prod/kustomization.yaml
+++ b/apps/20-media/lazylibrarian/overlays/prod/kustomization.yaml
@@ -13,3 +13,10 @@ components:
 
 patches:
   - path: dataangel.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: lazylibrarian-config-pvc

--- a/apps/20-media/lidarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/lidarr/overlays/prod/kustomization.yaml
@@ -22,3 +22,10 @@ components:
 patches:
   - path: resources-patch.yaml
   - path: dataangel.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: lidarr-config-pvc

--- a/apps/20-media/mylar/overlays/prod/kustomization.yaml
+++ b/apps/20-media/mylar/overlays/prod/kustomization.yaml
@@ -21,3 +21,10 @@ components:
 
 patches:
   - path: dataangel.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: mylar-config-pvc

--- a/apps/20-media/prowlarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/prowlarr/overlays/prod/kustomization.yaml
@@ -22,3 +22,10 @@ components:
 patches:
   - path: resources-patch.yaml
   - path: dataangel.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: prowlarr-config-pvc

--- a/apps/20-media/radarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/radarr/overlays/prod/kustomization.yaml
@@ -21,3 +21,10 @@ components:
 
 patches:
   - path: dataangel.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: radarr-config-pvc

--- a/apps/20-media/sabnzbd/overlays/prod/kustomization.yaml
+++ b/apps/20-media/sabnzbd/overlays/prod/kustomization.yaml
@@ -13,3 +13,10 @@ components:
 
 patches:
   - path: dataangel.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: sabnzbd-config-pvc

--- a/apps/20-media/sonarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/sonarr/overlays/prod/kustomization.yaml
@@ -25,3 +25,10 @@ patches:
       name: sonarr
     path: resources-patch.yaml
   - path: dataangel.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: sonarr-config-pvc

--- a/apps/20-media/whisparr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/whisparr/overlays/prod/kustomization.yaml
@@ -22,3 +22,10 @@ components:
 patches:
   - path: resources-patch.yaml
   - path: dataangel.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: whisparr-config-pvc

--- a/apps/70-tools/renovate/overlays/prod/pvc.yaml
+++ b/apps/70-tools/renovate/overlays/prod/pvc.yaml
@@ -10,4 +10,4 @@ spec:
   resources:
     requests:
       storage: 2Gi
-  storageClassName: synelia-iscsi-retain
+  storageClassName: local-path-retain


### PR DESCRIPTION
## Summary

Migrates 9 apps from `synelia-iscsi-retain` to `local-path-retain` for config PVCs.

All *arr apps already have DataAngel enabled (SQLite backup/restore via init container), so migration is safe: on next boot, DataAngel restores data from S3 before the main container starts.

### Apps migrated (storageClass patch in prod overlay)

| App | Real data size | DataAngel |
|-----|---------------|-----------|
| prowlarr | ~71M | ✅ already active |
| sonarr | ~344M | ✅ already active |
| radarr | ~840M | ✅ already active |
| sabnzbd | ~212M | ✅ already active |
| lidarr | ~15M | ✅ already active |
| whisparr | ~10M | ✅ already active |
| mylar | ~15M | ✅ already active |
| lazylibrarian | ~8M | ✅ already active |
| renovate | cache only | ❌ not needed (pure cache) |

## Migration procedure (after merge + prod-stable tag)

For each app:
1. Scale down deployment to 0
2. Delete the PVC
3. ArgoCD sync → recreates PVC avec `local-path-retain`
4. Scale up → DataAngel restores from S3 on boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated storage class configuration for multiple media applications (lazylibrarian, lidarr, mylar, prowlarr, radarr, sabnzbd, sonarr, and whisparr) and Renovate service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->