### PR TITLE
fix(s6-overlay): add explicitly-allow-root to preserve CAP_CHOWN

### DIFF
--- a/apps/_shared/components/securitycontext/s6-overlay/kustomization.yaml
+++ b/apps/_shared/components/securitycontext/s6-overlay/kustomization.yaml
@@ -14,3 +14,6 @@ patches:
       - op: replace
         path: /spec/template/spec/securityContext/fsGroupChangePolicy
         value: OnRootMismatch
+      - op: add
+        path: /spec/template/metadata/annotations/vixens.io~1explicitly-allow-root
+        value: "true"


### PR DESCRIPTION
## Problem

s6-overlay containers (linuxserver.io apps) need to `chown /config` on startup.

After migrating from iSCSI to local-path:
1. Fresh volume → DataAngel restores files as UID 1000
2. s6-overlay init tries `chown /config` → fails: `Operation not permitted`
3. Container exits, CrashLoopBackOff

**Root cause:** Kyverno `sizing-v2-mutate` drops ALL capabilities by default. Without `CAP_CHOWN`, even root cannot change file ownership.

**Why it worked on iSCSI:** Persistent volumes retain ownership from previous boots. `fsGroupChangePolicy: OnRootMismatch` skips kubelet chown when root dir group already matches → s6-overlay chown of existing owned files works as a no-op (or rather, the files are already owned correctly from the previous run).

## Fix

Add `vixens.io/explicitly-allow-root: "true"` annotation to the `s6-overlay` component. This annotation signals Kyverno to preserve root capabilities (including `CAP_CHOWN`) for these containers.

Consistent with `lazylibrarian` which already has this annotation and works correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)