### PR TITLE
fix(s6-overlay): add CHOWN+DAC_OVERRIDE caps to linuxserver.io apps

### DIFF
--- a/apps/20-media/lidarr/base/deployment.yaml
+++ b/apps/20-media/lidarr/base/deployment.yaml
@@ -104,7 +104,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
-              add: ["SETGID", "SETUID"]
+              add: ["SETGID", "SETUID", "CHOWN", "DAC_OVERRIDE"]
           livenessProbe:
             httpGet:
               path: /ping

--- a/apps/20-media/prowlarr/base/deployment.yaml
+++ b/apps/20-media/prowlarr/base/deployment.yaml
@@ -138,7 +138,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
-              add: ["SETGID", "SETUID"]
+              add: ["SETGID", "SETUID", "CHOWN", "DAC_OVERRIDE"]
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/20-media/radarr/base/deployment.yaml
+++ b/apps/20-media/radarr/base/deployment.yaml
@@ -122,7 +122,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
-              add: ["SETGID", "SETUID"]
+              add: ["SETGID", "SETUID", "CHOWN", "DAC_OVERRIDE"]
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/20-media/sonarr/base/deployment.yaml
+++ b/apps/20-media/sonarr/base/deployment.yaml
@@ -138,7 +138,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
-              add: ["SETGID", "SETUID"]
+              add: ["SETGID", "SETUID", "CHOWN", "DAC_OVERRIDE"]
           volumeMounts:
             - name: config
               mountPath: /config

--- a/apps/20-media/whisparr/base/deployment.yaml
+++ b/apps/20-media/whisparr/base/deployment.yaml
@@ -86,7 +86,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
-              add: ["SETGID", "SETUID"]
+              add: ["SETGID", "SETUID", "CHOWN", "DAC_OVERRIDE"]
           livenessProbe:
             httpGet:
               path: /ping


### PR DESCRIPTION
## Problem

After migrating from iSCSI to local-path, fresh volumes cause DataAngel to restore files as UID 1000. s6-overlay init tries `chown /config` to take ownership → fails with `Operation not permitted`.

**Root cause:** `capabilities: drop: [ALL]` in base deployment removes `CAP_CHOWN` and `CAP_DAC_OVERRIDE`, even for containers running as root. This causes:
- `chown /config` → fatal crash (prowlarr, sonarr, radarr, lidarr, whisparr)
- `find /config/admin: Permission denied` (access to 700 dirs without DAC_OVERRIDE)

## Fix

Add `CHOWN` and `DAC_OVERRIDE` to `capabilities.add` for 5 linuxserver.io apps that use s6-overlay init and run as root. This restores the minimum capabilities needed for the init script to function.

Note: `vixens.io/explicitly-allow-root: "true"` annotation was added to the s6-overlay component (PR #2520) but doesn't help here since the capability drop is already in the base deployment YAML, not injected by Kyverno.

🤖 Generated with [Claude Code](https://claude.com/claude-code)