### PR TITLE
fix(s6-overlay): add CHOWN+DAC_OVERRIDE to mylar and sabnzbd

### DIFF
--- a/apps/20-media/mylar/base/deployment.yaml
+++ b/apps/20-media/mylar/base/deployment.yaml
@@ -104,7 +104,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
-              add: ["SETGID", "SETUID"]
+              add: ["SETGID", "SETUID", "CHOWN", "DAC_OVERRIDE"]
           livenessProbe:
             httpGet:
               path: /

--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -87,7 +87,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
-              add: ["SETGID", "SETUID"]
+              add: ["SETGID", "SETUID", "CHOWN", "DAC_OVERRIDE"]
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
Same capability fix as PR #2521 for mylar and sabnzbd.

These apps handle `chown /config` failure as a warning (not fatal), so they eventually start, but `find: Permission denied` errors occur when accessing restored files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated security configurations for media processing services to enhance operational capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->