### PR TITLE
feat: Groupe B — DataAngel + local-path-retain (11 apps)

### DIFF
--- a/apps/10-home/mosquitto/overlays/prod/dataangel.yaml
+++ b/apps/10-home/mosquitto/overlays/prod/dataangel.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mosquitto
+spec:
+  template:
+    metadata:
+      labels:
+        vixens.io/sizing.dataangel: V-small
+        vixens.io/sizing.restore-data: null
+        vixens.io/sizing.config-syncer: null
+      annotations:
+        dataangel.io/bucket: "vixens-prod-mosquitto"
+        dataangel.io/fs-paths: "/mosquitto/data"
+        dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
+        dataangel.io/deployment-name: "mosquitto"
+        dataangel.io/rclone-interval: "60s"
+        dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
+    spec:
+      initContainers:
+        - name: restore-data
+          $patch: delete
+        - name: dataangel
+          securityContext:
+            runAsUser: 1883
+            runAsGroup: 1883
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: mosquitto-password-file
+                  key: LITESTREAM_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mosquitto-password-file
+                  key: LITESTREAM_SECRET_ACCESS_KEY
+          volumeMounts:
+            - mountPath: /data
+              $patch: delete
+            - name: data
+              mountPath: /mosquitto/data
+      containers:
+        - name: config-syncer
+          $patch: delete

--- a/apps/10-home/mosquitto/overlays/prod/kustomization.yaml
+++ b/apps/10-home/mosquitto/overlays/prod/kustomization.yaml
@@ -10,5 +10,21 @@ resources:
 components:
   - ../../../../_shared/components/sync-wave/wave-6
   - ../../../../_shared/components/goldilocks/enabled
+  - ../../../../_shared/components/dataangel
 
 patches:
+  - path: dataangel.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: mosquitto-data
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: mosquitto-config

--- a/apps/20-media/amule/overlays/prod/dataangel.yaml
+++ b/apps/20-media/amule/overlays/prod/dataangel.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: amule
+spec:
+  template:
+    metadata:
+      labels:
+        vixens.io/sizing.dataangel: V-small
+      annotations:
+        dataangel.io/bucket: "vixens-prod-amule"
+        dataangel.io/fs-paths: "/home/amule/.aMule"
+        dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
+        dataangel.io/deployment-name: "amule"
+        dataangel.io/rclone-interval: "60s"
+        dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
+    spec:
+      initContainers:
+        - name: dataangel
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: amule-secrets
+                  key: LITESTREAM_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: amule-secrets
+                  key: LITESTREAM_SECRET_ACCESS_KEY
+          volumeMounts:
+            - mountPath: /data
+              $patch: delete
+            - name: config
+              mountPath: /home/amule/.aMule

--- a/apps/20-media/amule/overlays/prod/kustomization.yaml
+++ b/apps/20-media/amule/overlays/prod/kustomization.yaml
@@ -12,6 +12,15 @@ labels:
 components:
   - ../../../../_shared/components/sync-wave/wave-15
   - ../../../../_shared/components/goldilocks/enabled
+  - ../../../../_shared/components/dataangel
 
 patches:
   - path: patch-infisical-env.yaml
+  - path: dataangel.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: amule-config-pvc

--- a/apps/20-media/jellyfin/overlays/prod/dataangel.yaml
+++ b/apps/20-media/jellyfin/overlays/prod/dataangel.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jellyfin
+spec:
+  template:
+    metadata:
+      labels:
+        vixens.io/sizing.dataangel: V-small
+      annotations:
+        dataangel.io/bucket: "vixens-prod-jellyfin"
+        dataangel.io/fs-paths: "/config"
+        dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
+        dataangel.io/deployment-name: "jellyfin"
+        dataangel.io/rclone-interval: "60s"
+        dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
+    spec:
+      initContainers:
+        - name: dataangel
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: jellyfin-secrets
+                  key: LITESTREAM_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: jellyfin-secrets
+                  key: LITESTREAM_SECRET_ACCESS_KEY
+          volumeMounts:
+            - mountPath: /data
+              $patch: delete
+            - name: config
+              mountPath: /config

--- a/apps/20-media/jellyfin/overlays/prod/infisical-secret.yaml
+++ b/apps/20-media/jellyfin/overlays/prod/infisical-secret.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: jellyfin-secrets
+spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
+  authentication:
+    universalAuth:
+      credentialsRef:
+        secretName: infisical-universal-auth
+        secretNamespace: argocd
+      secretsScope:
+        projectSlug: vixens
+        envSlug: prod
+        secretsPath: /apps/20-media/jellyfin
+  managedSecretReference:
+    secretName: jellyfin-secrets
+    creationPolicy: Owner
+    secretNamespace: media

--- a/apps/20-media/jellyfin/overlays/prod/kustomization.yaml
+++ b/apps/20-media/jellyfin/overlays/prod/kustomization.yaml
@@ -4,10 +4,20 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+  - infisical-secret.yaml
 
 components:
   - ../../../../_shared/components/sync-wave/wave-15
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics
+  - ../../../../_shared/components/dataangel
 
 patches:
+  - path: dataangel.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: jellyfin-config-pvc

--- a/apps/20-media/jellyseerr/overlays/prod/dataangel.yaml
+++ b/apps/20-media/jellyseerr/overlays/prod/dataangel.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jellyseerr
+spec:
+  template:
+    metadata:
+      labels:
+        vixens.io/sizing.dataangel: V-small
+      annotations:
+        dataangel.io/bucket: "vixens-prod-jellyseerr"
+        dataangel.io/fs-paths: "/app/config"
+        dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
+        dataangel.io/deployment-name: "jellyseerr"
+        dataangel.io/rclone-interval: "60s"
+        dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
+    spec:
+      initContainers:
+        - name: dataangel
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: jellyseerr-secrets
+                  key: LITESTREAM_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: jellyseerr-secrets
+                  key: LITESTREAM_SECRET_ACCESS_KEY
+          volumeMounts:
+            - mountPath: /data
+              $patch: delete
+            - name: config
+              mountPath: /app/config

--- a/apps/20-media/jellyseerr/overlays/prod/infisical-secret.yaml
+++ b/apps/20-media/jellyseerr/overlays/prod/infisical-secret.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: jellyseerr-secrets
+spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
+  authentication:
+    universalAuth:
+      credentialsRef:
+        secretName: infisical-universal-auth
+        secretNamespace: argocd
+      secretsScope:
+        projectSlug: vixens
+        envSlug: prod
+        secretsPath: /apps/20-media/jellyseerr
+  managedSecretReference:
+    secretName: jellyseerr-secrets
+    creationPolicy: Owner
+    secretNamespace: media

--- a/apps/20-media/jellyseerr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/jellyseerr/overlays/prod/kustomization.yaml
@@ -6,10 +6,20 @@ resources:
   - ingress.yaml
   - keda-interceptor-svc.yaml
   - httpscaledobject.yaml
+  - infisical-secret.yaml
 
 components:
   - ../../../../_shared/components/sync-wave/wave-15
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics
+  - ../../../../_shared/components/dataangel
 
 patches:
+  - path: dataangel.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: jellyseerr-config-pvc

--- a/apps/20-media/music-assistant/overlays/prod/dataangel.yaml
+++ b/apps/20-media/music-assistant/overlays/prod/dataangel.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: music-assistant
+spec:
+  template:
+    metadata:
+      labels:
+        vixens.io/sizing.dataangel: V-small
+      annotations:
+        dataangel.io/bucket: "vixens-prod-music-assistant"
+        dataangel.io/fs-paths: "/data"
+        dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
+        dataangel.io/deployment-name: "music-assistant"
+        dataangel.io/rclone-interval: "60s"
+        dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
+    spec:
+      initContainers:
+        - name: dataangel
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: music-assistant-secrets
+                  key: LITESTREAM_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: music-assistant-secrets
+                  key: LITESTREAM_SECRET_ACCESS_KEY
+          volumeMounts:
+            - mountPath: /data
+              $patch: delete
+            - name: config
+              mountPath: /data

--- a/apps/20-media/music-assistant/overlays/prod/infisical-secret.yaml
+++ b/apps/20-media/music-assistant/overlays/prod/infisical-secret.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: music-assistant-secrets
+spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
+  authentication:
+    universalAuth:
+      credentialsRef:
+        secretName: infisical-universal-auth
+        secretNamespace: argocd
+      secretsScope:
+        projectSlug: vixens
+        envSlug: prod
+        secretsPath: /apps/20-media/music-assistant
+  managedSecretReference:
+    secretName: music-assistant-secrets
+    creationPolicy: Owner
+    secretNamespace: media

--- a/apps/20-media/music-assistant/overlays/prod/kustomization.yaml
+++ b/apps/20-media/music-assistant/overlays/prod/kustomization.yaml
@@ -4,14 +4,24 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+  - infisical-secret.yaml
 
 components:
   - ../../../../_shared/components/sync-wave/wave-11
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics
+  - ../../../../_shared/components/dataangel
 
 patches:
   - target:
       kind: Deployment
       name: music-assistant
     path: resources-patch.yaml
+  - path: dataangel.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: music-assistant-config-pvc

--- a/apps/20-media/pyload/overlays/prod/dataangel.yaml
+++ b/apps/20-media/pyload/overlays/prod/dataangel.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pyload
+spec:
+  template:
+    metadata:
+      labels:
+        vixens.io/sizing.dataangel: V-small
+      annotations:
+        dataangel.io/bucket: "vixens-prod-pyload"
+        dataangel.io/fs-paths: "/config"
+        dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
+        dataangel.io/deployment-name: "pyload"
+        dataangel.io/rclone-interval: "60s"
+        dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
+    spec:
+      initContainers:
+        - name: dataangel
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: pyload-secrets
+                  key: LITESTREAM_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: pyload-secrets
+                  key: LITESTREAM_SECRET_ACCESS_KEY
+          volumeMounts:
+            - mountPath: /data
+              $patch: delete
+            - name: config
+              mountPath: /config

--- a/apps/20-media/pyload/overlays/prod/kustomization.yaml
+++ b/apps/20-media/pyload/overlays/prod/kustomization.yaml
@@ -13,6 +13,15 @@ components:
   - ../../../../_shared/components/sync-wave/wave-15
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics
+  - ../../../../_shared/components/dataangel
 
 patches:
   - path: patch-infisical-env.yaml
+  - path: dataangel.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: pyload-config-pvc

--- a/apps/20-media/qbittorrent/overlays/prod/dataangel.yaml
+++ b/apps/20-media/qbittorrent/overlays/prod/dataangel.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: qbittorrent
+spec:
+  template:
+    metadata:
+      labels:
+        vixens.io/sizing.dataangel: V-small
+      annotations:
+        dataangel.io/bucket: "vixens-prod-qbittorrent"
+        dataangel.io/fs-paths: "/config"
+        dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
+        dataangel.io/deployment-name: "qbittorrent"
+        dataangel.io/rclone-interval: "60s"
+        dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
+    spec:
+      initContainers:
+        - name: dataangel
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: qbittorrent-secrets
+                  key: LITESTREAM_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: qbittorrent-secrets
+                  key: LITESTREAM_SECRET_ACCESS_KEY
+          volumeMounts:
+            - mountPath: /data
+              $patch: delete
+            - name: config
+              mountPath: /config

--- a/apps/20-media/qbittorrent/overlays/prod/kustomization.yaml
+++ b/apps/20-media/qbittorrent/overlays/prod/kustomization.yaml
@@ -13,6 +13,15 @@ components:
   - ../../../../_shared/components/sync-wave/wave-10
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics
+  - ../../../../_shared/components/dataangel
 
 patches:
   - path: patch-infisical-env.yaml
+  - path: dataangel.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: qbittorrent-config-pvc

--- a/apps/60-services/n8n/overlays/prod/dataangel.yaml
+++ b/apps/60-services/n8n/overlays/prod/dataangel.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: n8n
+spec:
+  template:
+    metadata:
+      labels:
+        vixens.io/sizing.dataangel: V-small
+      annotations:
+        dataangel.io/bucket: "vixens-prod-n8n"
+        dataangel.io/fs-paths: "/home/node/.n8n"
+        dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
+        dataangel.io/deployment-name: "n8n"
+        dataangel.io/rclone-interval: "60s"
+        dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
+    spec:
+      initContainers:
+        - name: dataangel
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: n8n-secrets
+                  key: LITESTREAM_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: n8n-secrets
+                  key: LITESTREAM_SECRET_ACCESS_KEY
+          volumeMounts:
+            - mountPath: /data
+              $patch: delete
+            - name: data
+              mountPath: /home/node/.n8n

--- a/apps/60-services/n8n/overlays/prod/kustomization.yaml
+++ b/apps/60-services/n8n/overlays/prod/kustomization.yaml
@@ -10,5 +10,14 @@ components:
   - ../../../../_shared/components/infisical/env-prod
   - ../../../../_shared/components/sync-wave/wave-11
   - ../../../../_shared/components/goldilocks/enabled
+  - ../../../../_shared/components/dataangel
 
 patches:
+  - path: dataangel.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: n8n-config-pvc

--- a/apps/70-tools/changedetection/overlays/prod/dataangel.yaml
+++ b/apps/70-tools/changedetection/overlays/prod/dataangel.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: changedetection
+spec:
+  template:
+    metadata:
+      labels:
+        vixens.io/sizing.dataangel: V-small
+        vixens.io/sizing.restore-config: null
+        vixens.io/sizing.config-syncer: null
+      annotations:
+        dataangel.io/bucket: "vixens-prod-changedetection"
+        dataangel.io/fs-paths: "/datastore"
+        dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
+        dataangel.io/deployment-name: "changedetection"
+        dataangel.io/rclone-interval: "60s"
+        dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
+    spec:
+      initContainers:
+        - name: restore-config
+          $patch: delete
+        - name: dataangel
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: changedetection-secrets
+                  key: LITESTREAM_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: changedetection-secrets
+                  key: LITESTREAM_SECRET_ACCESS_KEY
+          volumeMounts:
+            - mountPath: /data
+              $patch: delete
+            - name: datastore
+              mountPath: /datastore
+      containers:
+        - name: config-syncer
+          $patch: delete

--- a/apps/70-tools/changedetection/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/changedetection/overlays/prod/kustomization.yaml
@@ -6,6 +6,7 @@ components:
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics
   - ../../../../_shared/components/infisical/env-prod
+  - ../../../../_shared/components/dataangel
 
 patches:
   - patch: |-
@@ -15,6 +16,14 @@ patches:
     target:
       kind: Deployment
       name: changedetection
+  - path: dataangel.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: changedetection-datastore-pvc
 resources:
   - ../../base
   - ingress.yaml

--- a/apps/70-tools/homepage/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/homepage/overlays/prod/kustomization.yaml
@@ -16,6 +16,13 @@ patches:
     target:
       kind: Deployment
       name: homepage
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: homepage-config
 resources:
   - ../../base
   - ingress.yaml

--- a/apps/70-tools/vikunja/overlays/prod/dataangel.yaml
+++ b/apps/70-tools/vikunja/overlays/prod/dataangel.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vikunja
+spec:
+  template:
+    metadata:
+      labels:
+        vixens.io/sizing.dataangel: V-small
+      annotations:
+        dataangel.io/bucket: "vixens-prod-vikunja"
+        dataangel.io/fs-paths: "/app/vikunja/files"
+        dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
+        dataangel.io/deployment-name: "vikunja"
+        dataangel.io/rclone-interval: "60s"
+        dataangel.io/metrics-enabled: "true"
+        dataangel.io/lock-enabled: "false"
+    spec:
+      initContainers:
+        - name: dataangel
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: vikunja-secrets
+                  key: LITESTREAM_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: vikunja-secrets
+                  key: LITESTREAM_SECRET_ACCESS_KEY
+          volumeMounts:
+            - mountPath: /data
+              $patch: delete
+            - name: vikunja-files
+              mountPath: /app/vikunja/files

--- a/apps/70-tools/vikunja/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/vikunja/overlays/prod/kustomization.yaml
@@ -9,8 +9,17 @@ components:
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics
   - ../../../../_shared/components/poddisruptionbudget/0
+  - ../../../../_shared/components/dataangel
 
 patches:
+  - path: dataangel.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: local-path-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: vikunja-files-pvc
   - target:
       kind: Ingress
       name: vikunja


### PR DESCRIPTION
## Summary

Migration vers `local-path-retain` + DataAngel (backup S3 via rclone) pour les 11 apps du Groupe B (volumes de config légers, démarrage rapide sur nœud local).

### Apps migrées

| App | Namespace | Volume | Bucket | Notes |
|-----|-----------|--------|--------|-------|
| qbittorrent | media | /config | vixens-prod-qbittorrent | linuxserver.io, creds existantes |
| music-assistant | media | /data | vixens-prod-music-assistant | **nouvelle infisical-secret.yaml** |
| jellyfin | media | /config | vixens-prod-jellyfin | **nouvelle infisical-secret.yaml** |
| jellyseerr | media | /app/config | vixens-prod-jellyseerr | **nouvelle infisical-secret.yaml** |
| changedetection | tools | /datastore | vixens-prod-changedetection | remplace restore-config + config-syncer |
| n8n | services | /home/node/.n8n | vixens-prod-n8n | PostgreSQL pour données, fs-only |
| vikunja | tools | /app/vikunja/files | vixens-prod-vikunja | PostgreSQL pour données, fs-only |
| pyload | downloads | /config | vixens-prod-pyload | linuxserver.io |
| amule | downloads | /home/amule/.aMule | vixens-prod-amule | configure-proxy init préservé |
| mosquitto | mosquitto | /mosquitto/data + config | vixens-prod-mosquitto | StatefulSet, UID 1883, 2 PVCs |
| homepage | tools | homepage-config | — | **PVC seulement**, config régénérée depuis ConfigMap |

### Actions requises avant merge/déploiement

**Buckets MinIO à créer :**
vixens-prod-qbittorrent, vixens-prod-music-assistant, vixens-prod-jellyfin, vixens-prod-jellyseerr, vixens-prod-changedetection, vixens-prod-n8n, vixens-prod-vikunja, vixens-prod-pyload, vixens-prod-amule, vixens-prod-mosquitto

**Infisical — ajouter LITESTREAM_ACCESS_KEY_ID + LITESTREAM_SECRET_ACCESS_KEY :**
- Paths existants (prod) : qbittorrent, n8n, vikunja, pyload, amule, mosquitto (dans mosquitto-password-file path)
- Nouveaux paths prod à créer : /apps/20-media/{music-assistant,jellyfin,jellyseerr}

### Notes techniques

- **homepage** : init container efface le PVC à chaque boot → backup inutile, storageClass uniquement
- **changedetection/mosquitto** : anciens restore-config/config-syncer supprimés (remplacés par DataAngel)
- **mosquitto** : StatefulSet, DataAngel runAsUser 1883
- **amule** : configure-proxy préservé (tourne après le restore DataAngel)

## Test plan

- [ ] Créer buckets MinIO + renseigner Infisical
- [ ] Merger → ArgoCD sync → valider démarrage de chaque app
- [ ] Vérifier backup DataAngel (metrics port 9090)
- [ ] Supprimer iSCSI LUNs concernés sur NAS après migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)