### PR TITLE
fix: add initContainers: [] to base deployments for dataangel compat

### DIFF
--- a/apps/20-media/jellyfin/base/deployment.yaml
+++ b/apps/20-media/jellyfin/base/deployment.yaml
@@ -26,6 +26,7 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      initContainers: []
       containers:
         - name: jellyfin
           resources:

--- a/apps/20-media/jellyseerr/base/deployment.yaml
+++ b/apps/20-media/jellyseerr/base/deployment.yaml
@@ -26,6 +26,7 @@ spec:
           operator: Exists
           effect: NoSchedule
       priorityClassName: vixens-medium
+      initContainers: []
       containers:
         - name: jellyseerr
           resources:

--- a/apps/20-media/music-assistant/base/deployment.yaml
+++ b/apps/20-media/music-assistant/base/deployment.yaml
@@ -29,6 +29,7 @@ spec:
           operator: Exists
           effect: NoSchedule
       priorityClassName: vixens-medium
+      initContainers: []
       containers:
         - name: music-assistant
           resources:

--- a/apps/20-media/pyload/base/deployment.yaml
+++ b/apps/20-media/pyload/base/deployment.yaml
@@ -29,6 +29,7 @@ spec:
           operator: Exists
           effect: NoSchedule
       priorityClassName: vixens-low
+      initContainers: []
       containers:
         - name: pyload
           resources:

--- a/apps/60-services/n8n/base/deployment.yaml
+++ b/apps/60-services/n8n/base/deployment.yaml
@@ -30,6 +30,7 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      initContainers: []
       containers:
         - name: n8n
           resources:

--- a/apps/70-tools/vikunja/base/deployment.yaml
+++ b/apps/70-tools/vikunja/base/deployment.yaml
@@ -28,6 +28,7 @@ spec:
           operator: Exists
           effect: NoSchedule
       priorityClassName: vixens-low
+      initContainers: []
       containers:
         - name: vikunja
           image: vikunja/vikunja:2.2.2


### PR DESCRIPTION
## Summary
- Add `initContainers: []` to base deployments for 6 apps that had kustomize build failures
- The dataangel shared component uses `op: add /spec/template/spec/initContainers/-` which requires the array to exist
- Without this, ArgoCD shows `ComparisonError: doc is missing path: /spec/template/spec/initContainers/-`

Affected apps: jellyfin, music-assistant, jellyseerr, n8n, vikunja, pyload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configurations across multiple applications (jellyfin, jellyseerr, music-assistant, pyload, n8n, and vikunja) for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->