### PR TITLE
fix(jellyfin): replace root NFS mount with subPath mounts for media libraries

### DIFF
--- a/apps/20-media/jellyfin/base/deployment.yaml
+++ b/apps/20-media/jellyfin/base/deployment.yaml
@@ -49,23 +49,22 @@ spec:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 120
+            initialDelaySeconds: 1200
             periodSeconds: 30
             timeoutSeconds: 5
-            failureThreshold: 3
+            failureThreshold: 10
           readinessProbe:
-            httpGet:
-              path: /health
-              port: http
-            initialDelaySeconds: 60
-            periodSeconds: 15
-            timeoutSeconds: 3
+            exec:
+              command: ["/bin/sh", "-c", "exit 0"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
             failureThreshold: 3
           startupProbe:
             httpGet:
               path: /health
               port: http
-            failureThreshold: 30
+            failureThreshold: 120
             periodSeconds: 10
             timeoutSeconds: 5
           lifecycle:
@@ -77,15 +76,22 @@ spec:
               mountPath: /config
             - name: cache
               mountPath: /cache
-            - name: media
-              mountPath: /media
+            - name: content
+              mountPath: /media/movies
+              subPath: movies
+            - name: content
+              mountPath: /media/tv
+              subPath: TV Show
+            - name: content
+              mountPath: /media/music
+              subPath: music
       volumes:
         - name: config
           persistentVolumeClaim:
             claimName: jellyfin-config-pvc
         - name: cache
           emptyDir: {}
-        - name: media
+        - name: content
           nfs:
             server: 192.168.111.69
             path: /volume3/Content


### PR DESCRIPTION
## Summary
- `/volume3/Content` root has `0000` POSIX permissions (Synology Windows ACL mode) — UID 1000 (jellyfin) cannot traverse it
- All other apps (sonarr, radarr, lidarr...) mount specific subdirectories, not the root
- Replace the single `/media → /volume3/Content` mount with three subPath mounts:
  - `/media/movies` → `subPath: movies`
  - `/media/tv` → `subPath: TV Show`
  - `/media/music` → `subPath: music`
- Align probes with permissive values already running live (startup=120×10s, liveness delay=1200s, readiness always-pass) to survive setup wizard

## Test plan
- [ ] ArgoCD syncs jellyfin after merge → pod restarts
- [ ] `/media/movies`, `/media/tv`, `/media/music` accessible from jellyfin pod (UID 1000)
- [ ] User can add libraries in jellyfin UI pointing to these paths
- [ ] After wizard complete: restore normal probes in follow-up commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced container health monitoring with adjusted probe timings for improved reliability.
  * Reorganized storage configuration to separately manage movies, TV shows, and music content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->