### PR TITLE
fix(penpot): revert runAsNonRoot on backend + add KEDA scale-to-zero

### DIFF
--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -92,8 +92,7 @@ spec:
           persistentVolumeClaim:
             claimName: penpot-data
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1001
+        # runAsNonRoot: true  # DISABLED: penpot/backend init sequence requires root — do not enable
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:

--- a/apps/70-tools/penpot/overlays/prod/keda-scaledobjects.yaml
+++ b/apps/70-tools/penpot/overlays/prod/keda-scaledobjects.yaml
@@ -1,0 +1,61 @@
+---
+# Frontend: HTTPScaledObject intercepts traffic on design.truxonline.com
+apiVersion: http.keda.sh/v1alpha1
+kind: HTTPScaledObject
+metadata:
+  name: penpot-frontend
+  namespace: tools
+spec:
+  hosts:
+    - design.truxonline.com
+  pathPrefixes:
+    - /
+  scaleTargetRef:
+    name: penpot-frontend
+    kind: Deployment
+    service: penpot-frontend
+    port: 80
+  replicas:
+    min: 0
+    max: 1
+  scaledownPeriod: 300
+---
+# Backend: scales in sync with frontend (external-push from same HTTPScaledObject)
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: penpot-backend
+  namespace: tools
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: penpot-backend
+  minReplicaCount: 0
+  maxReplicaCount: 1
+  cooldownPeriod: 300
+  triggers:
+    - type: external-push
+      metadata:
+        httpScaledObject: penpot-frontend
+        scalerAddress: keda-add-ons-http-external-scaler.keda:9090
+---
+# Exporter: scales in sync with frontend (external-push from same HTTPScaledObject)
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: penpot-exporter
+  namespace: tools
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: penpot-exporter
+  minReplicaCount: 0
+  maxReplicaCount: 1
+  cooldownPeriod: 300
+  triggers:
+    - type: external-push
+      metadata:
+        httpScaledObject: penpot-frontend
+        scalerAddress: keda-add-ons-http-external-scaler.keda:9090

--- a/apps/70-tools/penpot/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/penpot/overlays/prod/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - keda-scaledobjects.yaml
 components:
   - ../../../../_shared/components/infisical/env-prod
   - ../../../../_shared/components/sync-wave/wave-11


### PR DESCRIPTION
## Summary
- **Root cause**: PR #2443 enabled `runAsNonRoot: true` + `runAsUser: 1001` on penpot-backend despite an explicit comment "DISABLED: penpot/backend init sequence requires root". Backend has been in CrashLoopBackOff (551 restarts) for 2 days
- Reverts to root for backend only — frontend and exporter keep `runAsNonRoot: true`
- Adds KEDA scale-to-zero: HTTPScaledObject for frontend + external-push ScaledObjects for backend and exporter (all 3 wake/sleep together on traffic to `design.truxonline.com`)

## Test plan
- [ ] penpot-backend stops crashing after deploy
- [ ] https://design.truxonline.com accessible
- [ ] All 3 pods scale to 0 after 5min inactivity
- [ ] All 3 pods scale up on first request

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented HTTP-based autoscaling for Penpot services, enabling automatic scaling based on incoming request activity with configurable replica limits and cooldown periods.

* **Chores**
  * Modified backend deployment security configuration.
  * Integrated KEDA autoscaling framework into production environment for dynamic service scaling management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->