### PR TITLE
fix(penpot): wire ingress to KEDA interceptor proxy

### DIFF
--- a/apps/70-tools/penpot/overlays/prod/ingress-keda-patch.yaml
+++ b/apps/70-tools/penpot/overlays/prod/ingress-keda-patch.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: penpot-ingress
+  namespace: tools
+spec:
+  rules:
+    - host: design.truxonline.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: keda-interceptor-proxy
+                port:
+                  number: 8080

--- a/apps/70-tools/penpot/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/penpot/overlays/prod/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 resources:
   - ../../base
   - keda-scaledobjects.yaml
+patches:
+  - path: ingress-keda-patch.yaml
 components:
   - ../../../../_shared/components/infisical/env-prod
   - ../../../../_shared/components/sync-wave/wave-11


### PR DESCRIPTION
## Summary
- Follow-up to #2527: ingress must route through `keda-interceptor-proxy:8080` for KEDA HTTP add-on to intercept requests and trigger scale-up (same pattern as headlamp, linkwarden, netbox, stirling-pdf)
- Without this, pods stay at 0 and never wake up on browser requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic scaling for Penpot services to dynamically allocate resources based on usage, improving availability and performance during peak demand.
  * Configured service routing infrastructure and updated backend security settings for optimized deployment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->