### PR TITLE
fix(penpot): increase CPU limit to B-large for JVM startup

### DIFF
--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         app: penpot-backend
         component: backend
-        vixens.io/sizing.backend: V-large
+        vixens.io/sizing.backend: B-large
         vixens.io/backup-profile: standard
     spec:
       priorityClassName: vixens-medium
@@ -77,7 +77,7 @@ spec:
             httpGet:
               path: /readyz
               port: http
-            failureThreshold: 20
+            failureThreshold: 40
             periodSeconds: 10
             timeoutSeconds: 5
           securityContext:


### PR DESCRIPTION
## Summary

- Changes `vixens.io/sizing.backend` from `V-large` → `B-large` to restore 1000m CPU limit (V-large → 400m via Kyverno policy, which throttles JVM startup beyond the 200s probe limit)
- Increases `startupProbe.failureThreshold` from 20 → 40 (gives 400s instead of 200s)

## Root Cause

The Kyverno `sizing-v2-mutate` policy maps `V-large` to `cpuLim: 400m`. The JVM startup for penpot-backend needs ~1000m to start within 200s. At 400m, it is throttled and exceeds the startup probe timeout, entering a restart loop.

PR #1020 had previously set CPU limit to 1000m explicitly for this exact reason. The sizing label change overwrote that implicitly.

## Test plan
- [ ] Merge → ArgoCD syncs → penpot-backend pod starts → verify 1/1 Running
- [ ] Visit https://design.truxonline.com and confirm login page loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)