### PR TITLE
feat(kyverno): per-app VPA min/max overrides + penpot V-large restore

### DIFF
--- a/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
+++ b/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
@@ -53,6 +53,11 @@ metadata:
       follow-up task for VPA upgrade.
       VPA uses RequestsAndLimits to maintain the 4x cpu/memory ratio as it tunes
       V-* containers. minAllowed and maxAllowed (safety defaults) are always set.
+      Per-app overrides via pod template annotations:
+        vixens.io/vpa.min-cpu    (default: 5m)
+        vixens.io/vpa.min-memory (default: 64Mi)
+        vixens.io/vpa.max-cpu    (default: 8000m)
+        vixens.io/vpa.max-memory (default: 16Gi)
 spec:
   validationFailureAction: Audit
   background: true
@@ -98,8 +103,8 @@ spec:
                 - containerName: "*"
                   controlledValues: RequestsAndLimits
                   minAllowed:
-                    cpu: "5m"
-                    memory: "64Mi"
+                    cpu: "{{ request.object.spec.template.metadata.annotations.\"vixens.io/vpa.min-cpu\" || '5m' }}"
+                    memory: "{{ request.object.spec.template.metadata.annotations.\"vixens.io/vpa.min-memory\" || '64Mi' }}"
                   maxAllowed:
-                    cpu: "8000m"
-                    memory: "16Gi"
+                    cpu: "{{ request.object.spec.template.metadata.annotations.\"vixens.io/vpa.max-cpu\" || '8000m' }}"
+                    memory: "{{ request.object.spec.template.metadata.annotations.\"vixens.io/vpa.max-memory\" || '16Gi' }}"

--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -20,10 +20,11 @@ spec:
       annotations:
         vixens.io/fast-start: "true"
         vixens.io/no-long-connections: "true"
+        vixens.io/vpa.min-cpu: "1000m"
       labels:
         app: penpot-backend
         component: backend
-        vixens.io/sizing.backend: B-large
+        vixens.io/sizing.backend: V-large
         vixens.io/backup-profile: standard
     spec:
       priorityClassName: vixens-medium


### PR DESCRIPTION
## Summary

- Adds optional pod template annotations to override hardcoded `minAllowed`/`maxAllowed` in Kyverno-generated VPAs:
  - `vixens.io/vpa.min-cpu` (default: `5m`)
  - `vixens.io/vpa.min-memory` (default: `64Mi`)
  - `vixens.io/vpa.max-cpu` (default: `8000m`)
  - `vixens.io/vpa.max-memory` (default: `16Gi`)
- Applies to penpot-backend: `vixens.io/vpa.min-cpu: "1000m"` + restores `V-large` sizing (VPA Auto mode)

## Why

PR #2529 switched penpot-backend to `B-large` (VPA Off) to get 1000m CPU limit for JVM startup. But this drops VPA auto-management.

Root cause: VPA with `minAllowed.cpu: 5m` can recommend 476m (steady-state), which is insufficient for JVM startup. By setting `minAllowed.cpu: 1000m`, VPA will never recommend below 1000m, ensuring startup always has enough CPU — while VPA still auto-manages resources.

## Test plan
- [ ] Kyverno policy update is picked up by ArgoCD
- [ ] VPA `vixens-penpot-backend` regenerated with `minAllowed.cpu: 1000m`
- [ ] penpot-backend pod gets `limits.cpu: 1000m` (or higher per VPA recommendation)
- [ ] penpot-backend starts successfully (1/1 Running, 0 restarts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pod template annotation support for per-workload resource sizing overrides, enabling custom CPU and memory bounds configuration per deployment.

* **Chores**
  * Updated backend sizing labels and added minimum CPU resource policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->