### PR TITLE
fix(sizing): remove V-scout, revert penpot to B-large

### DIFF
--- a/apps/20-media/booklore/base/deployment.yaml
+++ b/apps/20-media/booklore/base/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         vixens.io/explicitly-allow-root: "true"
       labels:
         app: booklore
-        vixens.io/sizing.booklore: V-scout
+        vixens.io/sizing.booklore: V-micro
         vixens.io/sizing.config-syncer: V-nano
         vixens.io/sizing.restore-config: B-nano
         vixens.io/backup-profile: "standard"

--- a/apps/20-media/lazylibrarian/base/deployment.yaml
+++ b/apps/20-media/lazylibrarian/base/deployment.yaml
@@ -16,9 +16,9 @@ spec:
     metadata:
       labels:
         app: lazylibrarian
-        vixens.io/sizing.lazylibrarian: V-scout
-        vixens.io/sizing.litestream: V-scout
-        vixens.io/sizing.config-syncer: V-scout
+        vixens.io/sizing.lazylibrarian: V-micro
+        vixens.io/sizing.litestream: V-micro
+        vixens.io/sizing.config-syncer: V-micro
         vixens.io/sizing.fix-permissions: G-nano
         vixens.io/sizing.restore-config: B-nano
         vixens.io/sizing.restore-db: B-nano

--- a/apps/70-tools/penpot/base/deployment-backend.yaml
+++ b/apps/70-tools/penpot/base/deployment-backend.yaml
@@ -20,11 +20,10 @@ spec:
       annotations:
         vixens.io/fast-start: "true"
         vixens.io/no-long-connections: "true"
-        vixens.io/vpa.min-cpu: "1000m"
       labels:
         app: penpot-backend
         component: backend
-        vixens.io/sizing.backend: V-large
+        vixens.io/sizing.backend: B-large
         vixens.io/backup-profile: standard
     spec:
       priorityClassName: vixens-medium


### PR DESCRIPTION
## Summary

- `booklore`, `lazylibrarian`: replace non-existent `V-scout` tier with `V-micro` (smallest defined V-* tier)
- `penpot-backend`: remove `vixens.io/vpa.min-cpu` annotation (per-app exception, non-compliant with t-shirt sizing standards) + revert to `B-large`

## Why B-large for penpot

VPA admission does not apply recommendations for defined sizing tiers in the current cluster (all V-* apps run with Kyverno-injected values). With `V-large` → 400m CPU, the JVM startup exceeds the 400s startupProbe limit. `B-large` (1000m) is required until VPA admission is investigated and fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated resource tier configurations for booklore, lazylibrarian, and penpot services to adjust deployment resource allocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->