### PR TITLE
fix(penpot,grafana): KEDA replica drift + grafana-sc-dashboard OOMKill

### DIFF
--- a/apps/02-monitoring/grafana/base/values.yaml
+++ b/apps/02-monitoring/grafana/base/values.yaml
@@ -97,7 +97,7 @@ sidecar:
       memory: 64Mi
     limits:
       cpu: 100m
-      memory: 128Mi
+      memory: 512Mi
   livenessProbe:
     exec:
       command:

--- a/argocd/overlays/prod/apps/penpot.yaml
+++ b/argocd/overlays/prod/apps/penpot.yaml
@@ -18,6 +18,11 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: tools
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Summary

- **penpot ArgoCD**: Add `ignoreDifferences` for `/spec/replicas` on Deployments — prevents ArgoCD from reporting OutOfSync when KEDA scales backend/exporter/frontend to 0. Follows the identical pattern used by `stirling-pdf`, `it-tools`, and `headlamp`.
- **grafana sidecar**: Raise `grafana-sc-dashboard` memory limit from `128Mi` → `512Mi` to stop recurring OOMKills (396 restarts as of today). The live prod pod was already manually patched to 256Mi but still OOMKills; VPA recommends ~442Mi target / ~461Mi upper bound, so 512Mi gives the necessary headroom.

## Files changed

- `argocd/overlays/prod/apps/penpot.yaml` — added `ignoreDifferences` block
- `apps/02-monitoring/grafana/base/values.yaml` — raised sidecar memory limit

## Test plan

- [ ] ArgoCD: verify penpot app shows `Synced` after this merges to prod-stable
- [ ] Monitoring: verify `grafana-sc-dashboard` restartCount stops climbing after ArgoCD reconciles grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased memory allocation for Grafana dashboard sidecar components to enhance monitoring stability and performance.
  * Optimized production application replica synchronization configuration to improve automated deployment handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->