### PR TITLE
fix: gluetun health server binding, firefly probe timeouts and sizing

### DIFF
--- a/apps/60-services/firefly-iii-importer/base/deployment.yaml
+++ b/apps/60-services/firefly-iii-importer/base/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: firefly-iii-importer
 spec:
   replicas: 1
+  revisionHistoryLimit: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: firefly-iii-importer
@@ -79,5 +80,6 @@ spec:
             httpGet:
               path: /
               port: http
-            failureThreshold: 15
+            failureThreshold: 30
             periodSeconds: 10
+            timeoutSeconds: 5

--- a/apps/60-services/firefly-iii/base/deployment.yaml
+++ b/apps/60-services/firefly-iii/base/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         app.kubernetes.io/name: firefly-iii
         vixens.io/sizing.restore-config: B-nano
         vixens.io/sizing.firefly-iii: V-medium
-        vixens.io/sizing.config-syncer: V-nano
+        vixens.io/sizing.config-syncer: V-micro
         vixens.io/backup-profile: standard
       annotations:
         reloader.stakater.com/auto: "true"
@@ -195,6 +195,7 @@ spec:
                 - /upload
             initialDelaySeconds: 5
             periodSeconds: 10
+            timeoutSeconds: 5
           volumeMounts:
             - name: static
               mountPath: /upload
@@ -213,6 +214,7 @@ spec:
                 - "sh -c"
             initialDelaySeconds: 30
             periodSeconds: 60
+            timeoutSeconds: 5
             failureThreshold: 3
       volumes:
         - name: static

--- a/apps/60-services/gluetun/base/deployment.yaml
+++ b/apps/60-services/gluetun/base/deployment.yaml
@@ -70,6 +70,8 @@ spec:
               value: :8888
             - name: SOCKS5_PROXY_LISTENING_ADDRESS
               value: :1080
+            - name: HEALTH_SERVER_ADDRESS
+              value: ":9999"
             # Enable proxies
             - name: HTTPPROXY
               value: on


### PR DESCRIPTION
## Summary

- **gluetun**: Add `HEALTH_SERVER_ADDRESS=:9999` env var so the health HTTP server binds on all interfaces instead of loopback only (`127.0.0.1:9999`). Kubernetes probes connect from the host to the pod IP, so without this fix all probes are permanently refused.
- **firefly-iii-importer**: Relax `startupProbe` — `failureThreshold` 15→30 and `timeoutSeconds` 1→5 (300s total budget instead of 15s) to survive slow PHP-FPM startup. Also add `revisionHistoryLimit: 3`.
- **firefly-iii config-syncer**: Add `timeoutSeconds: 5` to both `livenessProbe` and `readinessProbe` to handle slow PVC I/O. Bump sizing label `V-nano`→`V-micro` to give rclone S3 sync adequate memory headroom (64Mi limit was too tight).

## Test plan

- [ ] Verify gluetun pod starts healthy and all three probes (startup/liveness/readiness) succeed in ArgoCD
- [ ] Verify firefly-iii-importer startupProbe no longer times out during initial PHP-FPM boot
- [ ] Verify firefly-iii config-syncer liveness/readiness probes pass; confirm Kyverno applies V-micro sizing (256Mi memory limit)
- [ ] ArgoCD shows all three apps as Synced + Healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure & Reliability**
  * Enhanced startup probe configuration with increased failure tolerance to improve container initialization reliability.
  * Extended health check timeout durations to prevent premature probe failures during normal operations.
  * Introduced dedicated health monitoring endpoint with comprehensive health check coverage for operational visibility.
  * Optimized pod resource sizing configuration for improved service performance efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->