### PR TITLE
fix(openclaw): remove control-plane toleration

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -34,10 +34,6 @@ spec:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
       priorityClassName: vixens-high
-      tolerations:
-        - key: node-role.kubernetes.io/control-plane
-          operator: Exists
-          effect: NoSchedule
       initContainers:
         # 1/3 — Install system tools (merged fix-perms + install-tools)
         #        Skips reinstall if TOOLS_VERSION matches. Always chowns /data/tools.


### PR DESCRIPTION
## Summary

- Removes `tolerations: node-role.kubernetes.io/control-plane` from openclaw deployment
- openclaw has no hardware dependency on control-plane nodes (no GPU, no camera, no local storage)
- PVC is `synelia-iscsi-retain` (iSCSI Synology — portable across all nodes)
- Forces scheduling onto worker nodes (peach/pearl), freeing ~1.1Gi RAM on `powder`
- Reduces kube-apiserver OOMKill pressure on `powder` (currently 86% RAM, 12 OOMKills)

## Test plan
- [ ] Verify openclaw pod reschedules onto peach or pearl
- [ ] Verify openclaw remains functional (Discord/Telegram connectivity)
- [ ] Monitor powder RAM usage after rescheduling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pod scheduling configuration to prevent placement on control-plane nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->