### PR TITLE
fix(openclaw): prefer worker nodes via nodeAffinity

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -34,6 +34,18 @@ spec:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
       priorityClassName: vixens-high
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
       initContainers:
         # 1/3 — Install system tools (merged fix-perms + install-tools)
         #        Skips reinstall if TOOLS_VERSION matches. Always chowns /data/tools.


### PR DESCRIPTION
## Summary

Replaces the hard control-plane toleration removal (PR #2534, too restrictive) with a soft preference:

- Toleration restored — openclaw can still run on CP nodes as fallback
- `preferredDuringSchedulingIgnoredDuringExecution` (weight 100) toward non-CP nodes
- Kubernetes will schedule on peach/pearl when capacity allows, freeing ~1.1Gi RAM on `powder`
- If both workers are unavailable, openclaw can still land on a CP node

## Test plan
- [ ] Verify openclaw reschedules onto peach or pearl
- [ ] Verify openclaw remains functional
- [ ] Monitor powder RAM after rescheduling

🤖 Generated with [Claude Code](https://claude.com/claude-code)