### PR TITLE
fix(ops): iscsi zombie force-clean, booklore probe, pyload V-micro, argocd-dev dex

### DIFF
--- a/apps/00-infra/argocd/overlays/dev/kustomization.yaml
+++ b/apps/00-infra/argocd/overlays/dev/kustomization.yaml
@@ -11,3 +11,9 @@ components:
 patches:
   - path: patches/repo-server-resources.yaml
   - path: patches/argocd-params.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: argocd-dex-server
+    path: patches/dex-run-as-user-json.yaml

--- a/apps/00-infra/argocd/overlays/dev/patches/dex-run-as-user-json.yaml
+++ b/apps/00-infra/argocd/overlays/dev/patches/dex-run-as-user-json.yaml
@@ -1,0 +1,7 @@
+---
+# Fix: dex v2.45.1 uses non-numeric username "dex" which breaks runAsNonRoot validation.
+# Kubernetes requires a numeric UID when runAsNonRoot: true is set.
+# dex user has UID 1001 in ghcr.io/dexidp/dex images.
+- op: add
+  path: /spec/template/spec/containers/0/securityContext/runAsUser
+  value: 1001

--- a/apps/01-storage/synology-csi/base/iscsi-lock-cleanup-daemonset.yaml
+++ b/apps/01-storage/synology-csi/base/iscsi-lock-cleanup-daemonset.yaml
@@ -34,10 +34,15 @@ spec:
               LOCK_DIR="/host-lock"
               LOCK_FILE="${LOCK_DIR}/lock.write"
               AGE_THRESHOLD=120
+              # FORCE_THRESHOLD: bypass open-fd check for zombie processes.
+              # A live iscsiadm holds the advisory flock (Gate 2 blocks).
+              # A zombie holds only the fd without the flock → Gate 2 passes, Gate 3 blocks.
+              # After FORCE_THRESHOLD seconds we know the flock owner is a zombie.
+              FORCE_THRESHOLD=3600
               CHECK_INTERVAL=60
 
               log() { echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') iscsi-lock-cleanup: $*"; }
-              log "Started (interval=${CHECK_INTERVAL}s, threshold=${AGE_THRESHOLD}s)"
+              log "Started (interval=${CHECK_INTERVAL}s, threshold=${AGE_THRESHOLD}s, force=${FORCE_THRESHOLD}s)"
 
               while true; do
                 if [ ! -f "${LOCK_FILE}" ]; then
@@ -55,7 +60,7 @@ spec:
                   continue
                 fi
 
-                # Gate 2: advisory lock check
+                # Gate 2: advisory lock check (a live iscsiadm holds this)
                 if ! flock -n "${LOCK_FILE}" true 2>/dev/null; then
                   log "SKIP age=${FILE_AGE}s advisory lock held"
                   sleep "${CHECK_INTERVAL}"
@@ -63,16 +68,20 @@ spec:
                 fi
 
                 # Gate 3: open file descriptor check
+                # Skip normally, but override for very old locks (zombie process holding fd only).
                 if fuser "${LOCK_FILE}" >/dev/null 2>&1; then
-                  log "SKIP age=${FILE_AGE}s file open by process"
-                  sleep "${CHECK_INTERVAL}"
-                  continue
+                  if [ "${FILE_AGE}" -lt "${FORCE_THRESHOLD}" ]; then
+                    log "SKIP age=${FILE_AGE}s file open by process"
+                    sleep "${CHECK_INTERVAL}"
+                    continue
+                  fi
+                  log "FORCE age=${FILE_AGE}s > ${FORCE_THRESHOLD}s zombie fd detected, forcing cleanup"
                 fi
 
-                # Atomic removal: hold flock, re-check fuser, then rm
+                # Atomic removal: hold flock, then rm (force path skips inner fuser check)
                 (
                   if flock -n 9; then
-                    if fuser "${LOCK_FILE}" >/dev/null 2>&1; then
+                    if fuser "${LOCK_FILE}" >/dev/null 2>&1 && [ "${FILE_AGE}" -lt "${FORCE_THRESHOLD}" ]; then
                       log "SKIP age=${FILE_AGE}s process opened during lock"
                     else
                       rm -f "${LOCK_FILE}"

--- a/apps/20-media/booklore/overlays/prod/dataangel.yaml
+++ b/apps/20-media/booklore/overlays/prod/dataangel.yaml
@@ -88,7 +88,7 @@ spec:
               path: /ready
               port: 9090
             periodSeconds: 2
-            failureThreshold: 150
+            failureThreshold: 600
           readinessProbe:
             httpGet:
               path: /ready

--- a/apps/20-media/pyload/base/deployment.yaml
+++ b/apps/20-media/pyload/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: pyload
-        vixens.io/sizing.pyload: V-small
+        vixens.io/sizing.pyload: V-micro
         vixens.io/backup-profile: "relaxed"
       annotations:
         vixens.io/service-binding: "false"
@@ -34,11 +34,11 @@ spec:
         - name: pyload
           resources:
             requests:
-              cpu: 25m
-              memory: 256Mi
+              cpu: 10m
+              memory: 128Mi
             limits:
-              cpu: 100m
-              memory: 1Gi
+              cpu: 40m
+              memory: 512Mi
           image: lscr.io/linuxserver/pyload-ng:0.5.0
           ports:
             - containerPort: 8000


### PR DESCRIPTION
## Summary

- **synology-csi**: `iscsi-lock-cleanup` — ajout `FORCE_THRESHOLD=3600s` pour bypasser Gate 3 quand un iscsiadm zombie tient le fd sans le flock advisory (incident phoebe : verrou bloqué 12000+s, loki + g4f stuck ContainerCreating)
- **booklore**: `dataangel` startupProbe `failureThreshold` 150→600 (5min→20min) pour accommoder un restore rclone S3 volumieux
- **pyload**: label `V-small`→`V-micro` + fallback resources alignés (128Mi req / 512Mi lim) — pearl à 99% memory requests, pod Pending 160min+
- **argocd dev**: patch `dex runAsUser:1001` (identique prod) — `CreateContainerConfigError` avec username non-numérique `dex` et `runAsNonRoot: true`

## Non-inclus (nécessite action manuelle)

- **external-dns-gandi** CrashLoop : PAT Gandi probablement expiré (pod tourne 40s = leader election + premier appel API Gandi → 401). Regenerer dans Gandi admin → mettre à jour dans Infisical `/apps/40-network/external-dns/gandi` clé `GANDI_API_KEY`.

## Tests

- `just lint` ✅
- `kustomize build` sur les 4 apps ✅ (kinds stables)
- `runAsUser: 1001` présent dans build argocd/overlays/dev ✅

Closes #2537

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure & Reliability**
  * Enhanced storage cleanup mechanism with configurable timeout thresholds to improve data consistency during container operations
  * Updated security configurations for authentication services to strengthen security
  * Increased startup probe failure tolerance for media services, allowing more time for reliable service initialization
  * Optimized resource allocation for streaming application, reducing CPU and memory requirements to improve system efficiency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->