### PR TITLE
fix(victoria-metrics): ignore operator-managed webhook cert in ArgoCD

### DIFF
--- a/argocd/overlays/prod/apps/victoria-metrics.yaml
+++ b/argocd/overlays/prod/apps/victoria-metrics.yaml
@@ -29,6 +29,18 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: monitoring
+  ignoreDifferences:
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      name: victoria-metrics-victoria-metrics-operator-admission
+      jqPathExpressions:
+        - .webhooks[].clientConfig.caBundle
+    - group: ""
+      kind: Secret
+      name: victoria-metrics-victoria-metrics-operator-validation
+      namespace: monitoring
+      jqPathExpressions:
+        - .data
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Summary

VM operator auto-rotate ses certs TLS après chaque restart. ArgoCD tente de les réconcilier vers les valeurs git (anciennes), ce qui:
1. Crée un OutOfSync permanent sur victoria-metrics
2. Fait cascader app-of-apps en OutOfSync
3. La tentative de sync échoue avec \`x509: certificate signed by unknown authority\` (cert expiré dans git)

Fix: `ignoreDifferences` sur:
- `ValidatingWebhookConfiguration/victoria-metrics-victoria-metrics-operator-admission` → `.webhooks[].clientConfig.caBundle`
- `Secret/victoria-metrics-victoria-metrics-operator-validation` → `.data`

Closes #2539