### PR TITLE
fix(maturity): vixens-low priority-class sur tous les déploiements manquants

### DIFF
--- a/apps/00-infra/keda-http-addon/values/common.yaml
+++ b/apps/00-infra/keda-http-addon/values/common.yaml
@@ -1,5 +1,8 @@
 ---
 # KEDA HTTP Add-on
+podLabels:
+  vixens.io/priority-class: vixens-low
+
 interceptor:
   replicas:
     min: 1

--- a/apps/00-infra/keda/values/common.yaml
+++ b/apps/00-infra/keda/values/common.yaml
@@ -42,6 +42,9 @@ resources:
       cpu: 100m
       memory: 64Mi
 
+podLabels:
+  vixens.io/priority-class: vixens-low
+
 podAnnotations:
   vixens.io/fast-start: "true"
   vixens.io/nometrics: "true"

--- a/apps/01-storage/local-path-provisioner/base/deployment.yaml
+++ b/apps/01-storage/local-path-provisioner/base/deployment.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       labels:
         app: local-path-provisioner
+        vixens.io/priority-class: vixens-low
     spec:
       serviceAccountName: local-path-provisioner-service-account
       tolerations:

--- a/apps/02-monitoring/victoria-metrics/base/values.yaml
+++ b/apps/02-monitoring/victoria-metrics/base/values.yaml
@@ -9,6 +9,8 @@ fullnameOverride: vm-stack
 # --- VM Operator ---
 victoria-metrics-operator:
   enabled: true
+  podLabels:
+    vixens.io/priority-class: vixens-low
   tolerations:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists

--- a/apps/04-databases/redis-shared/base/deployment.yaml
+++ b/apps/04-databases/redis-shared/base/deployment.yaml
@@ -15,6 +15,7 @@ spec:
         app: redis-shared
         vixens.io/sizing.redis: V-micro
         vixens.io/backup-profile: "relaxed"
+        vixens.io/priority-class: vixens-low
       annotations:
         vixens.io/fast-start: "true"
         vixens.io/no-long-connections: "true"

--- a/argocd/overlays/prod/apps/kyverno.yaml
+++ b/argocd/overlays/prod/apps/kyverno.yaml
@@ -34,6 +34,8 @@ spec:
               limits:
                 cpu: "1"
                 memory: 1Gi
+            podLabels:
+              vixens.io/priority-class: vixens-low
             podAnnotations:
               prometheus.io/scrape: "true"
               prometheus.io/port: "8000"
@@ -61,6 +63,8 @@ spec:
               limits:
                 cpu: 200m
                 memory: 256Mi
+            podLabels:
+              vixens.io/priority-class: vixens-low
             podAnnotations:
               prometheus.io/scrape: "true"
               prometheus.io/port: "8000"
@@ -88,6 +92,8 @@ spec:
               limits:
                 cpu: 200m
                 memory: 256Mi
+            podLabels:
+              vixens.io/priority-class: vixens-low
             podAnnotations:
               prometheus.io/scrape: "true"
               prometheus.io/port: "8000"
@@ -106,6 +112,8 @@ spec:
               limits:
                 cpu: 200m
                 memory: 256Mi
+            podLabels:
+              vixens.io/priority-class: vixens-low
             podAnnotations:
               prometheus.io/scrape: "true"
               prometheus.io/port: "8000"

--- a/argocd/overlays/prod/apps/policy-reporter.yaml
+++ b/argocd/overlays/prod/apps/policy-reporter.yaml
@@ -46,6 +46,7 @@ spec:
           podLabels:
             vixens.io/sizing.policy-reporter: small
             vixens.io/sizing: small
+            vixens.io/priority-class: vixens-low
           kyvernoPlugin:
             enabled: true
             tolerations:
@@ -65,6 +66,8 @@ spec:
               prometheus.io/scrape: "true"
               prometheus.io/port: "8080"
               prometheus.io/path: "/metrics"
+             podLabels:
+              vixens.io/priority-class: vixens-low
             annotations:  # Deployment metadata (Gold maturity)
               argocd.argoproj.io/sync-wave: "10"
               goldilocks.fairwinds.com/enabled: "true"
@@ -85,10 +88,12 @@ spec:
               limits:
                 cpu: 100m
                 memory: 128Mi
+            podLabels:
+              vixens.io/priority-class: vixens-low
             podAnnotations:
               vixens.io/fast-start: "true"
               vixens.io/service-binding: "false"
-              vixens.io/nometrics: "true"  # policy-reporter-ui is a web UI with no /metrics endpoint
+              vixens.io/nometrics: "true"
             annotations:  # Deployment metadata (Gold maturity)
               argocd.argoproj.io/sync-wave: "10"
               goldilocks.fairwinds.com/enabled: "true"


### PR DESCRIPTION
## Summary

21 déploiements sans `priorityClassName` → priority=0 implicite → comportement de preemption non-déterministe.

Le mécanisme Kyverno (`mutate-priority-class` Rule 1) injecte `spec.priorityClassName: vixens-low` à l'admission si le pod template a le label `vixens.io/priority-class: vixens-low`.

## Apps modifiées

| App | Méthode |
|-----|---------|
| redis-shared | pod template label direct |
| local-path-provisioner | pod template label direct |
| kyverno (4 controllers) | `podLabels:` par contrôleur dans kyverno ArgoCD app |
| policy-reporter + kyvernoPlugin + ui | `podLabels:` par composant |
| keda (operator + metricsServer + webhooks) | `podLabels:` global chart |
| keda-http-addon (interceptor + scaler + controller) | `podLabels:` global chart |
| victoria-metrics-operator | `podLabels:` sous `victoria-metrics-operator:` |

## Non inclus
- `grok-proxy` (vixens namespace) — hors repo
- `hubble-relay` (kube-system) — Cilium via Talos bootstrap, hors repo

## Validation
- `just lint` ✅
- `kustomize build` sur les overlays prod ✅
- YAML parse kyverno.yaml + policy-reporter.yaml ✅

Closes #2543

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system infrastructure components with priority class labeling to improve resource scheduling and pod management across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->