### PR TITLE
fix(maturity): correct priority-class levels — redis-high, local-path-critical, kyverno-high, keda-medium

### DIFF
--- a/apps/00-infra/keda-http-addon/values/common.yaml
+++ b/apps/00-infra/keda-http-addon/values/common.yaml
@@ -1,7 +1,7 @@
 ---
 # KEDA HTTP Add-on
 podLabels:
-  vixens.io/priority-class: vixens-low
+  vixens.io/priority-class: vixens-medium
 
 interceptor:
   replicas:

--- a/apps/00-infra/keda/values/common.yaml
+++ b/apps/00-infra/keda/values/common.yaml
@@ -43,7 +43,7 @@ resources:
       memory: 64Mi
 
 podLabels:
-  vixens.io/priority-class: vixens-low
+  vixens.io/priority-class: vixens-medium
 
 podAnnotations:
   vixens.io/fast-start: "true"

--- a/apps/00-infra/kyverno/base/policies/mutate-priority-class.yaml
+++ b/apps/00-infra/kyverno/base/policies/mutate-priority-class.yaml
@@ -46,11 +46,11 @@ spec:
   validationFailureAction: Audit
   background: false
   rules:
-    # Rule 1: Generic — inject priorityClassName from pod label vixens.io/priority-class
-    # Context variable extracts the label value (avoids JMESPath escaped quotes in patchesJson6902).
-    # WARNING: This generic rule does NOT patch spec.priority. It is only safe for PriorityClasses
-    # with value=0 (e.g. vixens-low), which match the K8s default priority and cause no conflict.
-    # For non-zero PriorityClasses, create a dedicated rule with apiCall (see rules 2, 3, 5).
+     # Rule 1: Generic — inject priorityClassName + priority from pod label vixens.io/priority-class
+     # Uses apiCall to read the numeric value from the PriorityClass object (DRY — source of truth).
+     # Patching spec.priority is required for non-zero classes: K8s sets priority=0 by default before
+     # the webhook runs, causing a conflict with priorityClassName if only the name is patched.
+     # If the apiCall fails (Kyverno not yet ready), failurePolicy:Ignore admits the pod without patch.
     - name: inject-priority-class-from-label
       match:
         any:
@@ -61,9 +61,12 @@ spec:
         - name: priorityClassLabel
           variable:
             value: "{{ request.object.metadata.labels.\"vixens.io/priority-class\" || '' }}"
+        - name: priorityValue
+          apiCall:
+            urlPath: "/apis/scheduling.k8s.io/v1/priorityclasses/{{ priorityClassLabel }}"
+            jmesPath: "value || `0`"
       preconditions:
         all:
-          # Only act when the label is present
           - key: "{{ priorityClassLabel }}"
             operator: NotEquals
             value: ""
@@ -72,6 +75,9 @@ spec:
           - op: add
             path: /spec/priorityClassName
             value: "{{ priorityClassLabel }}"
+          - op: add
+            path: /spec/priority
+            value: {{ priorityValue }}
 
     # Rule 2: infisical-operator — chart has no podLabels support
     # Match on existing chart label: control-plane=controller-manager in infisical-operator-system

--- a/apps/01-storage/local-path-provisioner/base/deployment.yaml
+++ b/apps/01-storage/local-path-provisioner/base/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         app: local-path-provisioner
-        vixens.io/priority-class: vixens-low
+        vixens.io/priority-class: vixens-critical
     spec:
       serviceAccountName: local-path-provisioner-service-account
       tolerations:

--- a/apps/04-databases/redis-shared/base/deployment.yaml
+++ b/apps/04-databases/redis-shared/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: redis-shared
         vixens.io/sizing.redis: V-micro
         vixens.io/backup-profile: "relaxed"
-        vixens.io/priority-class: vixens-low
+        vixens.io/priority-class: vixens-high
       annotations:
         vixens.io/fast-start: "true"
         vixens.io/no-long-connections: "true"

--- a/argocd/overlays/prod/apps/kyverno.yaml
+++ b/argocd/overlays/prod/apps/kyverno.yaml
@@ -35,7 +35,7 @@ spec:
                 cpu: "1"
                 memory: 1Gi
             podLabels:
-              vixens.io/priority-class: vixens-low
+              vixens.io/priority-class: vixens-high
             podAnnotations:
               prometheus.io/scrape: "true"
               prometheus.io/port: "8000"


### PR DESCRIPTION
## Summary

Suite de #2543. Les niveaux `vixens-low` uniformes étaient incorrects pour les services critiques.

## Changements

### mutate-priority-class Rule 1 — générique pour toutes les priorités
Ajout d'un `apiCall` pour lire la valeur numérique depuis l'objet `PriorityClass` et patcher `spec.priority`. **Requis** : K8s set `priority: 0` par défaut avant le webhook → conflit si seul `priorityClassName` est patché pour une classe non-zero.

### Niveaux corrigés

| Service | Avant | Après | Raison |
|---------|-------|-------|--------|
| redis-shared | vixens-low | **vixens-high** | Authentik (`vixens-critical`) en dépend pour les sessions SSO |
| local-path-provisioner | vixens-low | **vixens-critical** | Infrastructure storage — 76 PVCs, même niveau que CSI drivers |
| kyverno admission-controller | vixens-low | **vixens-high** | Webhook bloquant à l'admission |
| keda operator + metricsServer + webhooks | vixens-low | **vixens-medium** | Contrôle le scaling + webhooks bloquants |
| keda-http (interceptor + scaler + controller) | vixens-low | **vixens-medium** | Proxifie le trafic vers 9 apps (jellyseerr, docspell, headlamp…) |

### Conservés vixens-low ✅
kyverno background/cleanup/reports, victoria-metrics-operator, policy-reporter (tous non-bloquants)

Closes #2545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated pod scheduling priority configurations across critical infrastructure components, including KEDA HTTP Add-on, KEDA, Redis shared storage, local path provisioner, and Kyverno admission controller. These adjustments optimize resource allocation and system resilience during high-load scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->