### PR TITLE
fix(probes+oom): pyload OOM + probe timeout fixes

### DIFF
--- a/apps/02-monitoring/grafana/base/values.yaml
+++ b/apps/02-monitoring/grafana/base/values.yaml
@@ -105,6 +105,7 @@ sidecar:
         - /tmp
     initialDelaySeconds: 30
     periodSeconds: 60
+    timeoutSeconds: 5
   readinessProbe:
     exec:
       command:
@@ -112,6 +113,7 @@ sidecar:
         - /tmp
     initialDelaySeconds: 10
     periodSeconds: 30
+    timeoutSeconds: 5
   startupProbe:
     exec:
       command:
@@ -119,6 +121,7 @@ sidecar:
         - /tmp
     failureThreshold: 15
     periodSeconds: 10
+    timeoutSeconds: 5
 
 # Deployment labels for maturity tracking (chart uses .Values.labels for deployment metadata)
 labels:

--- a/apps/20-media/booklore/base/mariadb-deployment.yaml
+++ b/apps/20-media/booklore/base/mariadb-deployment.yaml
@@ -124,6 +124,7 @@ spec:
                 - pgrep -f mariadb-dump || exit 1
             initialDelaySeconds: 30
             periodSeconds: 60
+            timeoutSeconds: 5
           lifecycle:
             preStop:
               exec:
@@ -136,6 +137,7 @@ spec:
                 - pgrep -f mariadb-dump || exit 1
             initialDelaySeconds: 10
             periodSeconds: 30
+            timeoutSeconds: 5
           startupProbe:
             exec:
               command:
@@ -144,6 +146,7 @@ spec:
                 - pgrep -f mariadb-dump || exit 1
             failureThreshold: 15
             periodSeconds: 10
+            timeoutSeconds: 5
       volumes:
         - name: config
           persistentVolumeClaim:

--- a/apps/20-media/pyload/base/deployment.yaml
+++ b/apps/20-media/pyload/base/deployment.yaml
@@ -23,6 +23,7 @@ spec:
         vixens.io/no-long-connections: "true"
         kubectl.kubernetes.io/restartedAt: "2026-03-11T22:15:00Z"
         vixens.io/explicitly-allow-root: "true"
+        vixens.io/vpa.min-memory: "512Mi"
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane
@@ -35,10 +36,10 @@ spec:
           resources:
             requests:
               cpu: 5m
-              memory: 64Mi
+              memory: 256Mi
             limits:
               cpu: 20m
-              memory: 256Mi
+              memory: 512Mi
           image: lscr.io/linuxserver/pyload-ng:0.5.0
           ports:
             - containerPort: 8000


### PR DESCRIPTION
## Summary

- **pyload** OOMKill (exit 137) : nouvelle image 2026-03-27 dépasse 256Mi. Bump memory 256Mi request / 512Mi limit + annotation \`vixens.io/vpa.min-memory: 512Mi\` pour floor VPA
- **booklore/db-backup** : probes \`pgrep -f mariadb-dump\` timeout après 1s (default) car startup de sh sur Alpine > 1s → \`timeoutSeconds: 5\` sur liveness/readiness/startup
- **grafana sidecar** \`grafana-sc-dashboard\` : probe \`ls /tmp\` même 1s timeout sous pression mémoire → \`timeoutSeconds: 5\`

## Root Cause

Kubernetes default \`timeoutSeconds: 1\` est trop court pour les exec probes sur conteneurs Alpine sous load. Règle napkin ajoutée.

## Tests
- \`just lint\` ✅
- \`kustomize build apps/20-media/pyload/overlays/prod\` ✅
- \`kustomize build apps/20-media/booklore/overlays/prod\` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Improved Kubernetes health check timeout configurations for Grafana and MariaDB services to enhance stability
  - Optimized memory resource allocation for media services to support better performance and scaling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->