### PR TITLE
fix(pyload): upgrade sizing V-nano→V-small to fix OOMKill

### DIFF
--- a/apps/20-media/pyload/base/deployment.yaml
+++ b/apps/20-media/pyload/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: pyload
-        vixens.io/sizing.pyload: V-nano
+        vixens.io/sizing.pyload: V-small
         vixens.io/backup-profile: "relaxed"
       annotations:
         vixens.io/service-binding: "false"


### PR DESCRIPTION
## Root Cause

Kyverno \`sizing-v2-mutate\` injects container resources at pod admission based on the sizing label (runs after VPA, last write wins). V-nano = 64Mi req / 256Mi limit — insufficient for pyload's plugin indexing phase which peaks ~500Mi.

## Fix

V-nano → V-small = 256Mi req / 1Gi limit

## Investigation Summary

- VPA admission controller was applying stale cached values (pre-minAllowed update) 
- But root cause was \`sizing-v2-mutate\` overwriting ALL resources unconditionally at admission
- Manifest values and VPA recommendations both ignored — only the sizing label matters
- Confirmed via exit 137 (OOMKill) occurring ~2min after startup during plugin indexing

## Tests
- \`just lint\` ✅
- \`kustomize build apps/20-media/pyload/overlays/prod\` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore**
  * Updated the resource sizing configuration for the media service infrastructure. The service workload sizing profile has been increased from a minimal to a small configuration, providing improved resource allocation, performance handling, and operational efficiency. This adjustment optimizes the media service for better reliability and throughput management in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->