### PR TITLE
fix(frigate): lower sizing V-3xlarge→V-2xlarge to unblock pending pods

### DIFF
--- a/.opencode/napkin.md
+++ b/.opencode/napkin.md
@@ -127,6 +127,20 @@ kubectl -n argocd patch application argocd --type merge -p '{"metadata":{"annota
 
 ---
 
+## 🎛️ Sizing System (Priority 2)
+
+1. **[2026-03-28] sizing-v2-mutate écrase TOUTES les resources à l'admission**
+   La Kyverno policy `sizing-v2-mutate` injecte cpu/memory req+lim selon le sizing label (`vixens.io/sizing.<container>: V-nano`) et tourne EN DERNIER — après VPA. Les valeurs du manifest et les recommendations VPA sont ignorées. Seul le sizing label détermine les ressources finales.
+   Do instead: pour changer les ressources d'un pod, changer son sizing label. V-nano=64Mi/256Mi, V-micro=128Mi/512Mi, V-small=256Mi/1Gi, V-medium=512Mi/2Gi, V-large=1Gi/4Gi.
+
+2. **[2026-03-28] VPA globalMinReplicas=2 bloque toute éviction single-replica**
+   L'updater VPA refuse d'évincer les pods avec `livePods=1` (log: "Too few replicas"). Les single-replica deployments ne seront JAMAIS resizés automatiquement par VPA. Le pod garde ses resources initiales jusqu'au prochain restart manuel.
+   Do instead: pour libérer de la mémoire sur un nœud saturé par un pod single-replica, supprimer le pod manuellement (il sera recréé avec le sizing label correct). Vérifier d'abord que le sizing label donne assez de mémoire (sinon OOMKill immédiat).
+
+3. **[2026-03-28] VPA uncappedTarget << minAllowed → cache stale injecte mauvaises valeurs**
+   Si le minAllowed VPA est augmenté (via annotation vixens.io/vpa.min-memory), l'admission controller continue d'injecter l'ancienne recommandation jusqu'au flush complet. Fix: `kubectl -n vpa rollout restart deployment vpa-vertical-pod-autoscaler-{recommender,updater,admission-controller}` + `kubectl delete vpa <name>` (Kyverno recrée).
+   Do instead: mais avec sizing-v2-mutate, tout ça est superflu — changer le sizing label est la seule vraie solution.
+
 ## 🏗️ Infrastructure Patterns (Priority 2)
 
 1. **[2026-03-28] Cilium eBPF egress cassé après incident nœud**

--- a/apps/20-media/frigate/overlays/prod/kustomization.yaml
+++ b/apps/20-media/frigate/overlays/prod/kustomization.yaml
@@ -38,7 +38,7 @@ patches:
         template:
           metadata:
             labels:
-              vixens.io/sizing.frigate: V-3xlarge
+              vixens.io/sizing.frigate: V-2xlarge
               vixens.io/sizing.litestream: V-nano
               vixens.io/sizing.config-syncer: V-nano
             annotations:


### PR DESCRIPTION
## Problem

Node \`poison\` at **99% memory requests** (15050Mi/15.2Gi), blocking 4 pods:
- mealie, vikunja, changedetection, linkwarden (PVs pinned to poison)

Root cause: frigate \`V-3xlarge\` = 8Gi request fills the node.

VPA \`globalMinReplicas=2\` prevents auto-eviction of single-replica pods → no automatic resolution.

## Fix

V-3xlarge (8Gi req / 32Gi limit) → **V-2xlarge (4Gi req / 16Gi limit)**

- Frigate actual usage: ~5.8Gi → stays within 16Gi limit, zero OOM risk
- Frees ~4Gi on poison → enough for the 4 pending pods (~3Gi total needed)

## Tests
- \`just lint\` ✅
- \`kustomize build apps/20-media/frigate/overlays/prod\` ✅