### PR TITLE
fix(vpa): remove minReplicas:1 — unsafe with RWO PVCs

### DIFF
--- a/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
+++ b/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
@@ -49,8 +49,8 @@ metadata:
       StatefulSet whose pod template has at least one vixens.io/sizing.* label.
       No explicit trigger label required — presence of sizing labels is sufficient.
       V-* sizing labels → VPA updateMode: InPlaceOrRecreate (in-place resize first,
-      eviction fallback if in-place fails). minReplicas: 1 allows eviction fallback
-      even for single-replica deployments. B-*/SB-*/G-* only → Off (Goldilocks only).
+      eviction fallback only if in-place fails). Global minReplicas=2 intentionally
+      blocks eviction fallback for single-replica pods (safe for RWO PVCs).
       InPlaceOrRecreate is GA in VPA 1.6.0 + K8s 1.33+ (InPlacePodVerticalScaling GA).
       VPA uses RequestsAndLimits. minAllowed/maxAllowed always set.
       Per-app overrides via pod template annotations:
@@ -98,9 +98,6 @@ spec:
               # B-*/SB-*/G-* only → Off (Goldilocks recommend-only)
               updateMode: >-
                 {{ request.object.spec.template.metadata.labels | values(@) | [?starts_with(@, 'V-')] | length(@) > `0` && 'InPlaceOrRecreate' || 'Off' }}
-              # Allow eviction fallback even for single-replica deployments
-              # (overrides global --min-replicas=2 flag on the VPA updater)
-              minReplicas: 1
             resourcePolicy:
               containerPolicies:
                 - containerName: "*"


### PR DESCRIPTION
## Problem

\`minReplicas: 1\` on the generated VPA allows eviction fallback for single-replica pods. With RWO PVCs (node-locked \`local-path-retain\`), eviction can strand the pod if the node is saturated — new pod can't reschedule, service is down with an inaccessible PVC.

## Fix

Remove \`minReplicas: 1\`. Keep global \`minReplicas=2\` which blocks eviction fallback for single-replica pods. \`InPlaceOrRecreate\` handles resizing in-place (no eviction needed) — the common case works fine.

## Behavior after fix

| Scenario | Result |
|----------|--------|
| VPA wants to resize single-replica pod | In-place resize ✅ (no eviction) |
| In-place fails on single-replica pod | Blocked by globalMinReplicas=2 ✅ (safe) |
| VPA wants to resize multi-replica pod | In-place or eviction ✅ |

## Tests
- \`just lint\` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the sizing VPA policy to use global replica minimum settings for eviction fallback control instead of per-policy overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->