### PR TITLE
fix(booklore,policy-reporter): PDB selector + YAML indentation

### DIFF
--- a/apps/20-media/booklore/base/pdb.yaml
+++ b/apps/20-media/booklore/base/pdb.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: booklore
+      app: booklore

--- a/argocd/overlays/prod/apps/policy-reporter.yaml
+++ b/argocd/overlays/prod/apps/policy-reporter.yaml
@@ -66,7 +66,7 @@ spec:
               prometheus.io/scrape: "true"
               prometheus.io/port: "8080"
               prometheus.io/path: "/metrics"
-             podLabels:
+            podLabels:
               vixens.io/priority-class: vixens-low
             annotations:  # Deployment metadata (Gold maturity)
               argocd.argoproj.io/sync-wave: "10"


### PR DESCRIPTION
Closes #2557 (partially — PDB fix only, booklore crash loop separate)
Closes #2558

## Changes

**booklore PDB** (`apps/20-media/booklore/base/pdb.yaml`)
- Selector `app.kubernetes.io/name: booklore` → `app: booklore`
- PDB now covers actual pods → ArgoCD health restored

**policy-reporter values** (`argocd/overlays/prod/apps/policy-reporter.yaml`)
- `podLabels` under `kyvernoPlugin` had 13 spaces indentation (sibling to `podAnnotations` requires 12)
- Fixed → Helm values parse correctly → ArgoCD sync status restored

## Why CI missed these

See PR description — these are **semantic** errors, not structural ones. CI validates YAML syntax and kustomize structure, not label selector correctness or Helm values semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected pod disruption budget configuration to properly identify and protect application pods during infrastructure maintenance.
* Fixed configuration formatting in policy-reporter plugin settings to ensure policy reporting features function as intended.

## Chores
* Updated platform configuration settings for improved pod management and availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->