### PR TITLE
fix(booklore): vpa.min-cpu=300m to fix startup throttle → crash loop

### DIFF
--- a/apps/20-media/booklore/base/deployment.yaml
+++ b/apps/20-media/booklore/base/deployment.yaml
@@ -18,6 +18,7 @@ spec:
         vixens.io/fast-start: "true"
         vixens.io/no-long-connections: "true"
         vixens.io/explicitly-allow-root: "true"
+        vixens.io/vpa.min-cpu: "300m"
       labels:
         app: booklore
         vixens.io/sizing.booklore: V-micro


### PR DESCRIPTION
Closes #2557

VPA in-place resized booklore to 49m req / 196m lim (V-micro × 4 ratio). At 196m CPU, Spring Boot + Hibernate (63 JPA repos) takes >25 min to start, exceeding the 30-min startup probe → perpetual restart loop (48+ restarts/15h).

`vpa.min-cpu: 300m` → VPA floors at 300m req / 1200m lim → startup ~3-4 min.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for optimized resource allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->