### PR TITLE
fix(hooks): restore pre-commit + pre-push validation after beads removal

### DIFF
--- a/justfile
+++ b/justfile
@@ -1290,6 +1290,16 @@ burst title:
     bd create "{{title}}" --status open --assignee coding-agent --label burst
     @echo "✅ Idée enregistrée dans Beads"
 
+install-hooks:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd "$(git rev-parse --show-toplevel)"
+    git config --unset-all core.hooksPath 2>/dev/null || true
+    pre-commit install --overwrite
+    printf '#!/usr/bin/env bash\nset -euo pipefail\ncd "$(git rev-parse --show-toplevel)"\necho "🔍 Pre-push validation..."\njust lint\necho "✅ Pre-push OK"\n' > .git/hooks/pre-push
+    chmod +x .git/hooks/pre-push
+    echo "✅ Hooks installés: pre-commit (pre-commit framework) + pre-push (just lint)"
+
 lint:
     #!/usr/bin/env bash
     set -euo pipefail


### PR DESCRIPTION
## Problem

\`git config core.hooksPath=/dev/null\` was set by beads (no longer used). All hooks were silently skipped:
- **pre-commit**: \`check-yaml\`, \`yamllint\`, \`gitleaks\`, \`validate-helm-values\` → never ran
- **pre-push**: nothing ran before pushing

This is why the policy-reporter YAML bug and booklore PDB selector bug passed all local checks undetected.

## Fix

New \`just install-hooks\` command:
1. Unsets \`core.hooksPath\`
2. Runs \`pre-commit install --overwrite\` → restores pre-commit framework
3. Writes pre-push hook → runs \`just lint\` before every push

**Run once per clone:**
\`\`\`bash
just install-hooks
\`\`\`

## Validation layers restored

| When | What runs | Catches |
|------|-----------|---------|
| `git commit` | pre-commit: gitleaks, check-yaml, yamllint, validate-helm-values | Secrets, syntax, YAML style, Helm values |
| `git push` | pre-push: just lint | yamllint + Helm values (full scan) |
| GitHub PR | CI validate.yaml | kustomize build, kubeconform, PDB selectors, security |