### PR TITLE
fix(booklore): sizing V-micro→V-small to fix startup crash loop

### DIFF
--- a/apps/20-media/booklore/base/deployment.yaml
+++ b/apps/20-media/booklore/base/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         vixens.io/vpa.min-cpu: "300m"
       labels:
         app: booklore
-        vixens.io/sizing.booklore: V-micro
+        vixens.io/sizing.booklore: V-small
         vixens.io/sizing.config-syncer: V-nano
         vixens.io/sizing.restore-config: B-nano
         vixens.io/backup-profile: "standard"


### PR DESCRIPTION
Spring Boot + Hibernate takes >25 min at 40m CPU. VPA target=300m but sizing-v2-mutate always overrides to V-micro values at admission. V-small (25m/100m) + vpa.min-cpu=300m = VPA in-place resizes to 300m req / 1200m lim shortly after pod start. Closes #2557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the resource sizing configuration for the booklore service to allocate additional computing resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->