### PR TITLE
fix(booklore): startup probe timeout 5→30s for throttled JVM

### DIFF
--- a/apps/20-media/booklore/base/deployment.yaml
+++ b/apps/20-media/booklore/base/deployment.yaml
@@ -151,7 +151,7 @@ spec:
               port: http
             failureThreshold: 180
             periodSeconds: 10
-            timeoutSeconds: 5
+            timeoutSeconds: 30
         - name: config-syncer
           image: rclone/rclone:1.73
           securityContext:


### PR DESCRIPTION
Startup probe `context deadline exceeded` — JVM at 100m CPU (V-small) takes >5s to respond under CFS throttling. 30s timeout gives the JVM time to respond. VPA will in-place resize to 300m/1200m once pod is stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved startup stability by adjusting container initialization timing parameters to allow additional time for successful service startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->