### PR TITLE
fix(authentik,grafana): increase startup probe timeout and fix sidecar sizing

### DIFF
--- a/apps/02-monitoring/grafana/base/values.yaml
+++ b/apps/02-monitoring/grafana/base/values.yaml
@@ -130,4 +130,4 @@ labels:
 # Pod sizing labels
 podLabels:
   vixens.io/sizing.grafana: V-medium
-  vixens.io/sizing.grafana-sc-dashboard: G-small
+  vixens.io/sizing.grafana-sc-dashboard: V-small

--- a/apps/03-security/authentik/base/deployment-server.yaml
+++ b/apps/03-security/authentik/base/deployment-server.yaml
@@ -121,9 +121,9 @@ spec:
             httpGet:
               path: /-/health/live/
               port: http
-            failureThreshold: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
+          failureThreshold: 60
+          periodSeconds: 10
+          timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /-/health/live/


### PR DESCRIPTION
## Summary

- **authentik**: `failureThreshold: 30 → 60` — authentik 2026.2.x prend >5min à démarrer (chargement de ~50 modules Django + migrations DB). La startup probe tuait le container avant qu'il soit prêt → boucle de 29 restarts depuis 23h, SSO dégradé.
- **grafana**: `G-small → V-small` sur `grafana-sc-dashboard` — passage à sizing fixe (256Mi request / 1Gi limit) pour stabiliser le sidecar de chargement des dashboards.

## Root cause (authentik)

```
startupProbe: failureThreshold=30, period=10s → max 300s (5min)
```

Les logs montrent le container chargeant les modules et recevant un SIGTERM propre à T+5min exactement (exit 0, "shutting down webserver"). Le container n'avait jamais le temps de répondre `200` sur `/-/health/live/`.

## Tests

- Lint: ✅ passed
- Changes: minimal (2 integer/string values)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pod sizing configuration for Grafana dashboard component
  * Enhanced startup reliability for authentication server with increased failure tolerance during initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->