### PR TITLE
fix(authentik): correct startupProbe YAML indentation

### DIFF
--- a/apps/03-security/authentik/base/deployment-server.yaml
+++ b/apps/03-security/authentik/base/deployment-server.yaml
@@ -121,9 +121,9 @@ spec:
             httpGet:
               path: /-/health/live/
               port: http
-          failureThreshold: 60
-          periodSeconds: 10
-          timeoutSeconds: 5
+            failureThreshold: 60
+            periodSeconds: 10
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /-/health/live/


### PR DESCRIPTION
## Summary

Fix de l'indentation YAML sur la `startupProbe` d'authentik-server.

## Problème

Le PR #2567 avait une erreur d'indentation : `failureThreshold`, `periodSeconds` et `timeoutSeconds` étaient au niveau container (10 espaces) au lieu d'être dans `startupProbe` (12 espaces). Kubernetes tombait sur ses defaults : `failureThreshold=3, timeoutSeconds=1s` — le container était tué en 30s au lieu des 10 minutes voulues.

## Fix

```yaml
# Avant (cassé)
startupProbe:
  httpGet: ...
failureThreshold: 60   # ← niveau container = ignoré
periodSeconds: 10
timeoutSeconds: 5

# Après (correct)
startupProbe:
  httpGet: ...
  failureThreshold: 60  # ← dans startupProbe ✅
  periodSeconds: 10
  timeoutSeconds: 5
```

Closes le bug introduit par #2567.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted configuration formatting for improved code organization and maintainability.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->