### PR TITLE
chore(netbox): auto-PR deployment.yaml après build + désactive Renovate sur image custom

### DIFF
--- a/.github/workflows/build-netbox-plugins.yaml
+++ b/.github/workflows/build-netbox-plugins.yaml
@@ -17,19 +17,23 @@ jobs:
     name: Build & Push to GHCR
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
+      pull-requests: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Extract NetBox version from Dockerfile
-        id: version
+      - name: Compute image tag
+        id: tag
         run: |
           VERSION=$(grep -oP 'FROM netboxcommunity/netbox:\K[^\s]+' docker/netbox-plugins/Dockerfile)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          TAG="${VERSION}-${SHORT_SHA}"
           echo "netbox_version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "NetBox version: ${VERSION}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "image=ghcr.io/${{ github.repository_owner }}/netbox-plugins:${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -46,9 +50,49 @@ jobs:
         with:
           context: docker/netbox-plugins
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/netbox-plugins:${{ steps.version.outputs.netbox_version }}
+          tags: ${{ steps.tag.outputs.image }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Open PR to update deployment image tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEW_IMAGE="${{ steps.tag.outputs.image }}"
+          BRANCH="chore/netbox-plugins-image-${{ steps.tag.outputs.tag }}"
+
+          CURRENT=$(grep -oP 'image: ghcr\.io/[^/]+/netbox-plugins:\K\S+' \
+            apps/70-tools/netbox/base/deployment.yaml || echo "")
+
+          if [ "$CURRENT" = "${{ steps.tag.outputs.tag }}" ]; then
+            echo "deployment.yaml already at ${NEW_IMAGE}, skipping PR"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+
+          sed -i \
+            "s|image: ghcr\.io/[^/]*/netbox-plugins:.*|image: ${NEW_IMAGE}|" \
+            apps/70-tools/netbox/base/deployment.yaml
+
+          git add apps/70-tools/netbox/base/deployment.yaml
+          git commit -m "chore(netbox): update plugins image to ${{ steps.tag.outputs.tag }}"
+          git push -u origin "$BRANCH"
+
+          gh pr create \
+            --title "chore(netbox): update plugins image to ${{ steps.tag.outputs.tag }}" \
+            --body "$(cat <<'EOF'
+          Auto-generated after successful image build.
+
+          **Image:** \`${{ steps.tag.outputs.image }}\`
+          **NetBox base:** \`${{ steps.tag.outputs.netbox_version }}\`
+          **Triggered by:** ${{ github.sha }}
+          EOF
+          )" \
+            --base main \
+            --head "$BRANCH"

--- a/renovate.json
+++ b/renovate.json
@@ -45,6 +45,11 @@
   },
   "packageRules": [
     {
+      "description": "netbox-plugins image managed by build workflow, not Renovate",
+      "matchPackageNames": ["ghcr.io/charchess/netbox-plugins"],
+      "enabled": false
+    },
+    {
       "description": "Group all minor and patch updates for non-critical dependencies",
       "matchUpdateTypes": [
         "minor",


### PR DESCRIPTION
## Summary

### Workflow mis à jour
- **Tag** : `v{version}-{sha}` — chaque build est unique et traçable (plugin update OU base image update)
- **Auto-PR** : après chaque build réussi, le workflow ouvre automatiquement une PR pour mettre à jour `deployment.yaml` avec le nouveau tag
- **Skip** : si l'image est déjà à jour, aucune PR créée

### Renovate mis à jour
- Désactive le tracking de `ghcr.io/charchess/netbox-plugins` — le workflow gère la mise à jour, évite les PRs en double

## Flux complet après ces changements

```
Renovate: netboxcommunity/netbox:v4.5.6 disponible
  → PR auto Dockerfile FROM (patch = automerge)
  → merge main → build workflow (~2min)
  → push ghcr.io/charchess/netbox-plugins:v4.5.6-<sha>
  → PR auto deployment.yaml (ce workflow)
  → automerge → dev cluster mis à jour
  → prod-stable promu → prod mis à jour
```

Délai total : ~5min au lieu de ~48h.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions CI/CD workflow for improved Docker image building, tagging, and automated deployment updates
  * Refined dependency management configuration for internal package versioning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->