### PR TITLE
fix(netbox): retire netbox-routing — conflit GraphQL StrFilterLookup

### DIFF
--- a/apps/70-tools/netbox/base/plugins-config.yaml
+++ b/apps/70-tools/netbox/base/plugins-config.yaml
@@ -11,7 +11,6 @@ data:
         "netbox_dns",
         "netbox_inventory",
         "netbox_security",
-        "netbox_routing",
         "netbox_interface_synchronization",
         "slurpit_netbox",
         "netbox_data_flows",
@@ -29,7 +28,6 @@ data:
         "netbox_security": {
             "top_level_menu": True,
         },
-        "netbox_routing": {},
         "netbox_interface_synchronization": {
             "exclude_virtual_interfaces": True,
         },

--- a/docker/netbox-plugins/requirements.txt
+++ b/docker/netbox-plugins/requirements.txt
@@ -2,7 +2,6 @@ netbox-topology-views==4.5.0
 netbox-plugin-dns==1.5.5
 netbox-inventory==2.5.0
 netbox-security==1.4.4
-netbox-routing==0.4.1
 netbox-interface-synchronization==4.5.1
 slurpit_netbox==1.3.3
 netbox-data-flows==1.5.0


### PR DESCRIPTION
Retire `netbox-routing` qui cause un `DuplicatedTypeName: StrFilterLookup` au démarrage. Plugin non nécessaire (pas de BGP/OSPF dans l'infra).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the NetBox routing plugin and its associated dependencies from the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->