### PR TITLE
chore(netbox): update plugins image to v4.5.5-9d0b4e1

### DIFF
--- a/apps/70-tools/netbox/base/deployment.yaml
+++ b/apps/70-tools/netbox/base/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             limits:
               cpu: 500m
               memory: 1Gi
-          image: ghcr.io/charchess/netbox-plugins:v4.5.5-3469b42
+          image: ghcr.io/charchess/netbox-plugins:v4.5.5-9d0b4e1
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
Hotfix: image sans netbox-routing (conflit GraphQL StrFilterLookup).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the netbox container image to the latest version, ensuring the deployment uses the most current plugin build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->