### PR TITLE
fix(netbox): retire netbox-data-flows — conflit modèle Application avec netbox-security

### DIFF
--- a/apps/70-tools/netbox/base/plugins-config.yaml
+++ b/apps/70-tools/netbox/base/plugins-config.yaml
@@ -13,7 +13,6 @@ data:
         "netbox_security",
         "netbox_interface_synchronization",
         "slurpit_netbox",
-        "netbox_data_flows",
         "netbox_floorplan",
     ]
 
@@ -32,6 +31,5 @@ data:
             "exclude_virtual_interfaces": True,
         },
         "slurpit_netbox": {},
-        "netbox_data_flows": {},
         "netbox_floorplan": {},
     }

--- a/docker/netbox-plugins/requirements.txt
+++ b/docker/netbox-plugins/requirements.txt
@@ -4,5 +4,4 @@ netbox-inventory==2.5.0
 netbox-security==1.4.4
 netbox-interface-synchronization==4.5.1
 slurpit_netbox==1.3.3
-netbox-data-flows==1.5.0
 netbox-floorplan-plugin==0.9.1


### PR DESCRIPTION
Conflit Django ORM : `netbox_data_flows.Application` et `netbox_security.Application` ont des reverse accessors identiques. Retire data-flows, garde security (UDM zones/NAT).