### PR TITLE
fix(netbox): augmenter KEDA scaledownPeriod 300→600s

### DIFF
--- a/apps/70-tools/netbox/overlays/prod/httpscaledobject.yaml
+++ b/apps/70-tools/netbox/overlays/prod/httpscaledobject.yaml
@@ -17,4 +17,4 @@ spec:
   replicas:
     min: 0
     max: 1
-  scaledownPeriod: 300
+  scaledownPeriod: 600


### PR DESCRIPTION
Démarrage NetBox avec 7 plugins = ~9min (migrations). 300s trop court.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the scale-down timing configuration parameter for the netbox service in the production environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->