### PR TITLE
fix(sabnzbd): revert runAsNonRoot — image linuxserver.io requiert root

### DIFF
--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/path: "/metrics"
         vixens.io/no-long-connections: "true"
+        vixens.io/explicitly-allow-root: "true"
     spec:
       priorityClassName: vixens-medium
       tolerations:
@@ -200,7 +201,7 @@ spec:
           configMap:
             name: sabnzbd-litestream-config
       securityContext:
-        runAsNonRoot: true
+        # runAsNonRoot: true — DISABLED: linuxserver.io image (s6-overlay) démarre en root
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:


### PR DESCRIPTION
Hotfix: runAsNonRoot: true activé par erreur dans #2585. L'image linuxserver.io/s6-overlay démarre en root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sabnzbd deployment security configuration to permit root-level execution when required, adjusting previous non-root-only constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->