### PR TITLE
security(storage): supprimer explicitly-allow-root des apps qui n'en ont pas besoin

### DIFF
--- a/apps/20-media/booklore/base/mariadb-deployment.yaml
+++ b/apps/20-media/booklore/base/mariadb-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       annotations:
         vixens.io/fast-start: "true"
-        vixens.io/explicitly-allow-root: "true"
+
       labels:
         app: booklore-mariadb
         vixens.io/sizing.mariadb: V-small
@@ -28,6 +28,11 @@ spec:
           operator: Exists
           effect: NoSchedule
       priorityClassName: vixens-low
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: mariadb
           image: lscr.io/linuxserver/mariadb:11.4.8
@@ -56,6 +61,8 @@ spec:
                   name: booklore-secrets
                   key: DB_PASSWORD
           volumeMounts:
+            - name: run
+              mountPath: /run
             - name: config
               mountPath: /config
           readinessProbe:
@@ -83,6 +90,8 @@ spec:
             periodSeconds: 10
         - name: db-backup
           image: alpine:3.23
+          securityContext:
+            runAsUser: 0
           command:
             - sh
             - -c
@@ -148,6 +157,8 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
       volumes:
+        - name: run
+          emptyDir: {}
         - name: config
           persistentVolumeClaim:
             claimName: booklore-mariadb-pvc

--- a/apps/20-media/qbittorrent/base/deployment.yaml
+++ b/apps/20-media/qbittorrent/base/deployment.yaml
@@ -21,7 +21,6 @@ spec:
       annotations:
         vixens.io/service-binding: "false"
         vixens.io/no-long-connections: "true"
-        vixens.io/explicitly-allow-root: "true"
         kubectl.kubernetes.io/restartedAt: "2026-03-11T22:00:00Z"
     spec:
       tolerations:
@@ -92,11 +91,15 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
           volumeMounts:
+            - name: run
+              mountPath: /run
             - name: config
               mountPath: /config
             - name: downloads
               mountPath: /downloads
       volumes:
+        - name: run
+          emptyDir: {}
         - name: config
           persistentVolumeClaim:
             claimName: qbittorrent-config-pvc
@@ -109,5 +112,7 @@ spec:
             server: 192.168.111.69
             path: /volume3/Downloads/blackhole/torrent
       securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch

--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/path: "/metrics"
         vixens.io/no-long-connections: "true"
-        vixens.io/explicitly-allow-root: "true"
+
     spec:
       priorityClassName: vixens-medium
       tolerations:
@@ -109,6 +109,8 @@ spec:
             - name: TZ
               value: Europe/Paris
           volumeMounts:
+            - name: run
+              mountPath: /run
             - name: config
               mountPath: /config
             - name: downloads
@@ -190,6 +192,8 @@ spec:
             - name: config
               mountPath: /config
       volumes:
+        - name: run
+          emptyDir: {}
         - name: config
           persistentVolumeClaim:
             claimName: sabnzbd-config-pvc
@@ -201,7 +205,8 @@ spec:
           configMap:
             name: sabnzbd-litestream-config
       securityContext:
-        # runAsNonRoot: true — DISABLED: linuxserver.io image (s6-overlay) démarre en root
+        runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:

--- a/apps/40-network/adguard-home/base/adguard-ss.yaml
+++ b/apps/40-network/adguard-home/base/adguard-ss.yaml
@@ -36,12 +36,14 @@ spec:
         prometheus.io/path: "/metrics"
         goldilocks.fairwinds.com/enabled: "true"
         autoscaling.k8s.io/vpa: auto
-        vixens.io/explicitly-allow-root: "true"
         vixens.io/no-long-connections: "true"
     spec:
       priorityClassName: vixens-critical
       securityContext:
-        runAsNonRoot: false
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
+        fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
       tolerations:
@@ -52,8 +54,8 @@ spec:
         - name: restore-config
           image: rclone/rclone:1.73
           securityContext:
-            runAsUser: 0
-            runAsGroup: 0
+            runAsUser: 65534
+            runAsGroup: 65534
           command:
             - sh
             - -c
@@ -74,8 +76,8 @@ spec:
         - name: restore-db
           image: litestream/litestream:0.5.10
           securityContext:
-            runAsUser: 0
-            runAsGroup: 0
+            runAsUser: 65534
+            runAsGroup: 65534
           args:
             - restore
             - -config
@@ -105,8 +107,8 @@ spec:
               name: dns-tcp
               protocol: TCP
           securityContext:
-            runAsUser: 0
-            runAsGroup: 0
+            runAsUser: 65534
+            runAsGroup: 65534
             allowPrivilegeEscalation: false
             capabilities:
               add: ["NET_BIND_SERVICE"]
@@ -133,8 +135,8 @@ spec:
         - name: litestream
           image: litestream/litestream:0.5.10
           securityContext:
-            runAsUser: 0
-            runAsGroup: 0
+            runAsUser: 65534
+            runAsGroup: 65534
           args:
             - replicate
             - -config
@@ -166,8 +168,8 @@ spec:
         - name: config-syncer
           image: rclone/rclone:1.73
           securityContext:
-            runAsUser: 0
-            runAsGroup: 0
+            runAsUser: 65534
+            runAsGroup: 65534
           command:
             - sh
             - -c

--- a/apps/40-network/adguard-home/overlays/prod/dataangel.yaml
+++ b/apps/40-network/adguard-home/overlays/prod/dataangel.yaml
@@ -28,8 +28,8 @@ spec:
           $patch: delete
         - name: dataangel
           securityContext:
-            runAsUser: 0
-            runAsGroup: 0
+            runAsUser: 65534
+            runAsGroup: 65534
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/apps/40-network/netbird/base/management.yaml
+++ b/apps/40-network/netbird/base/management.yaml
@@ -24,7 +24,7 @@ spec:
         vixens.io/backup-profile: "relaxed"
       annotations:
         vixens.io/fast-start: "true"
-        vixens.io/explicitly-allow-root: "true"
+
     spec:
       priorityClassName: vixens-low
       tolerations:
@@ -35,8 +35,8 @@ spec:
         - name: init-config
           image: busybox:1.37
           securityContext:
-            runAsUser: 0
-            runAsNonRoot: false
+            runAsUser: 1000
+            runAsNonRoot: true
           env:
             - name: AUTH_ISSUER
               value: "https://authentik.dev.truxonline.com/application/o/netbird/"
@@ -61,7 +61,7 @@ spec:
               cat <<EOF > /etc/netbird/management.json
               {
                 "HttpConfig": {
-                  "Address": ":80",
+                  "Address": ":8080",
                   "AuthIssuer": "$AUTH_ISSUER",
                   "AuthAudience": "$AUTH_AUDIENCE",
                   "AuthKeysLocation": "$AUTH_KEYS_LOCATION",
@@ -101,27 +101,28 @@ spec:
             - name: config-writable
               mountPath: /etc/netbird
       securityContext:
-        # runAsNonRoot: true  # disabled — management writes to /etc/netbird/management.json (permission denied as non-root)
-        # runAsUser: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
       containers:
         - name: management
           image: netbirdio/management:0.67.1
-          args: ["--port=80", "--log-file=console", "--log-level=info", "--config=/etc/netbird/management.json"]
+          args: ["--port=8080", "--log-file=console", "--log-level=info", "--config=/etc/netbird/management.json"]
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
-              add: ["NET_BIND_SERVICE"]
               drop: ["ALL"]
           livenessProbe:
             tcpSocket:
-              port: 80
+              port: 8080
             initialDelaySeconds: 30
             periodSeconds: 10
           readinessProbe:
             tcpSocket:
-              port: 80
+              port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5
           env:
@@ -135,7 +136,7 @@ spec:
             - name: NETBIRD_STORE_ENGINE_POSTGRES_DSN
               value: "host=postgresql-shared-rw.databases.svc.cluster.local user=netbird password=$(NB_POSTGRES_PASSWORD) dbname=netbird port=5432 sslmode=disable"
           ports:
-            - containerPort: 80
+            - containerPort: 8080
               name: http
             - containerPort: 33073
               name: grpc
@@ -168,7 +169,7 @@ metadata:
 spec:
   ports:
     - port: 80
-      targetPort: 80
+      targetPort: 8080
       name: http
     - port: 33073
       targetPort: 33073

--- a/apps/60-services/docspell/base/statefulset-joex.yaml
+++ b/apps/60-services/docspell/base/statefulset-joex.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         vixens.io/fast-start: "true"
         vixens.io/no-long-connections: "true"
-        vixens.io/explicitly-allow-root: "true"
+
       labels:
         app: docspell
         component: joex
@@ -30,6 +30,14 @@ spec:
           operator: Exists
           effect: NoSchedule
       priorityClassName: vixens-medium
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: joex
           image: ghcr.io/docspell/joex:v0.43.0

--- a/apps/60-services/docspell/base/statefulset-restserver.yaml
+++ b/apps/60-services/docspell/base/statefulset-restserver.yaml
@@ -22,13 +22,21 @@ spec:
         vixens.io/backup-profile: standard
       annotations:
         vixens.io/no-long-connections: "true"
-        vixens.io/explicitly-allow-root: "true"
+
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
       priorityClassName: vixens-medium
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: restserver
           image: ghcr.io/docspell/restserver:v0.43.0

--- a/apps/60-services/firefly-iii-importer/base/deployment.yaml
+++ b/apps/60-services/firefly-iii-importer/base/deployment.yaml
@@ -17,7 +17,6 @@ spec:
         vixens.io/fast-start: "true"
         vixens.io/service-binding: "false"
         vixens.io/no-long-connections: "true"
-        vixens.io/explicitly-allow-root: "true"
         kubectl.kubernetes.io/restartedAt: "2026-03-11T22:20:00Z"
       labels:
         app.kubernetes.io/name: firefly-iii-importer
@@ -29,6 +28,12 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      securityContext:
+        runAsNonRoot: true
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: importer
           resources:

--- a/apps/70-tools/changedetection/base/deployment.yaml
+++ b/apps/70-tools/changedetection/base/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       annotations:
         vixens.io/fast-start: "true"
         vixens.io/no-long-connections: "true"
-        vixens.io/explicitly-allow-root: "true"
+
       labels:
         kubectl.kubernetes.io/restartedAt: "2026-03-12T110000Z"
         app: changedetection
@@ -178,5 +178,10 @@ spec:
           persistentVolumeClaim:
             claimName: changedetection-datastore-pvc
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault

--- a/apps/70-tools/nocodb/base/deployment.yaml
+++ b/apps/70-tools/nocodb/base/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         reloader.stakater.com/auto: "true"
         vixens.io/service-binding: "false"
         vixens.io/no-long-connections: "true"
-        vixens.io/explicitly-allow-root: "true"
+
     spec:
       priorityClassName: vixens-low
       tolerations:
@@ -98,8 +98,9 @@ spec:
           persistentVolumeClaim:
             claimName: nocodb-data
       securityContext:
-        # runAsNonRoot: true  # disabled — SQLITE_READONLY (PVC owned by root, nocodb needs root to write)
-        # runAsUser: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:


### PR DESCRIPTION
## Contexte

Suite à l'audit complet des images Docker (#2236), suppression de `vixens.io/explicitly-allow-root` des apps qui n'en ont pas réellement besoin.

## Apps corrigées (9)

| App | Situation | Fix |
|-----|-----------|-----|
| adguard-home | Image runs as `nobody` (65534), setcap pour port 53 | runAsNonRoot + runAsUser: 65534 |
| firefly-iii-importer | Base image termine par `USER www-data` | runAsNonRoot: true |
| nocodb | Node.js pur, zéro op privilégiée | runAsUser: 1000 |
| changedetection | Python pur | runAsUser: 1000 |
| docspell-joex + restserver | JVM pur (Nix-built) | runAsUser: 1000 |
| qbittorrent | LSIO `nonroot_supported: true` | runAsUser: 1000 + /run emptyDir |
| sabnzbd | LSIO `nonroot_supported: true` | runAsUser: 1000 + /run emptyDir |
| mariadb (booklore) | LSIO `nonroot_supported: true` | runAsUser: 1000 + /run emptyDir |
| netbird-management | Port 80→8080, binaire sans dépendance root | runAsNonRoot + port 8080 |

## Exceptions conservées (légitimes)

- **gluetun, synology-csi, netvisor** — kernel/hardware obligatoire
- **homeassistant** — ADR-0013 (décision officielle, jamais de drop root)
- **frigate** — nginx `user root` hardcodé, pas de support officiel non-root
- **amule** — image abandonnée 2021, à remplacer séparément
- **netbird/dashboard** — nginx port change déféré
- **mealie, grimmory** — gosu/su-exec entrypoint, déféré

Closes #2236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security configurations across multiple services (MariaDB, qBittorrent, SABnzbd, AdGuard Home, Netbird, Docspell, Firefly III Importer, Changedetection, NocoDB) to run containers with non-root user permissions
  * Netbird management service port changed from 80 to 8080

<!-- end of auto-generated comment: release notes by coderabbit.ai -->