### PR TITLE
security(storage): mealie + booklore — runAsUser court-circuite entrypoint root

### DIFF
--- a/apps/10-home/mealie/base/deployment.yaml
+++ b/apps/10-home/mealie/base/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         prometheus.io/port: "9000"
         prometheus.io/path: "/metrics"
         vixens.io/no-long-connections: "true"
-        vixens.io/explicitly-allow-root: "true"
+
         kubectl.kubernetes.io/restartedAt: "2026-03-12T10:40:00Z"
     spec:
       tolerations:
@@ -234,5 +234,10 @@ spec:
           configMap:
             name: mealie-litestream-config
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 911
+        runAsGroup: 911
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault

--- a/apps/20-media/booklore/base/deployment.yaml
+++ b/apps/20-media/booklore/base/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       annotations:
         vixens.io/fast-start: "true"
         vixens.io/no-long-connections: "true"
-        vixens.io/explicitly-allow-root: "true"
+
         vixens.io/vpa.min-cpu: "300m"
       labels:
         app: booklore
@@ -196,5 +196,10 @@ spec:
             server: 192.168.111.69
             path: /volume3/Internal/incoming/ebooks
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault


### PR DESCRIPTION
Court-circuite les entrypoints gosu/su-exec en forçant runAsUser avant leur démarrage. fsGroup remplace le chown. Supprime vixens.io/explicitly-allow-root sur ces 2 apps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened security configuration for Mealie and Booklore deployments with enforcement of non-root execution and runtime security sandboxing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->