### PR TITLE
security: fix LSIO s6-overlay /run ownership crash + remaining explicitly-allow-root (#2590)

### DIFF
--- a/apps/20-media/booklore/base/deployment.yaml
+++ b/apps/20-media/booklore/base/deployment.yaml
@@ -17,8 +17,8 @@ spec:
       annotations:
         vixens.io/fast-start: "true"
         vixens.io/no-long-connections: "true"
-
         vixens.io/vpa.min-cpu: "300m"
+        vixens.io/explicitly-allow-root: "true"
       labels:
         app: booklore
         vixens.io/sizing.booklore: V-small
@@ -196,9 +196,6 @@ spec:
             server: 192.168.111.69
             path: /volume3/Internal/incoming/ebooks
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:

--- a/apps/20-media/booklore/base/mariadb-deployment.yaml
+++ b/apps/20-media/booklore/base/mariadb-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       annotations:
         vixens.io/fast-start: "true"
-
+        vixens.io/explicitly-allow-root: "true"
       labels:
         app: booklore-mariadb
         vixens.io/sizing.mariadb: V-small
@@ -33,6 +33,17 @@ spec:
         runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: fix-run-dir
+          image: busybox:1.37.0
+          command: ["sh", "-c", "chown 1000:1000 /run"]
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: run
+              mountPath: /run
       containers:
         - name: mariadb
           image: lscr.io/linuxserver/mariadb:11.4.8

--- a/apps/20-media/lazylibrarian/base/deployment.yaml
+++ b/apps/20-media/lazylibrarian/base/deployment.yaml
@@ -30,12 +30,21 @@ spec:
         prometheus.io/path: "/metrics"
         vixens.io/no-long-connections: "true"
         kubectl.kubernetes.io/restartedAt: "2026-03-11T21:00:00Z"
+        vixens.io/explicitly-allow-root: "true"
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
       initContainers:
+        - name: fix-run-dir
+          image: busybox:1.37.0
+          command: ["sh", "-c", "chown 1000:1000 /run"]
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: run
+              mountPath: /run
         - name: restore-config
           image: rclone/rclone:1.73
           securityContext:
@@ -135,6 +144,8 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
           volumeMounts:
+            - name: run
+              mountPath: /run
             - name: config
               mountPath: /config
             - name: downloads
@@ -214,6 +225,8 @@ spec:
             - name: config
               mountPath: /config
       volumes:
+        - name: run
+          emptyDir: {}
         - name: config
           persistentVolumeClaim:
             claimName: lazylibrarian-config-pvc
@@ -229,5 +242,9 @@ spec:
           configMap:
             name: lazylibrarian-litestream-config
       securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault

--- a/apps/20-media/music-assistant/base/deployment.yaml
+++ b/apps/20-media/music-assistant/base/deployment.yaml
@@ -18,18 +18,20 @@ spec:
         app: music-assistant
         vixens.io/sizing.music-assistant: V-medium
         vixens.io/backup-profile: "relaxed"
-      annotations:
-        vixens.io/explicitly-allow-root: "true"
+      annotations: {}
     spec:
       securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
       priorityClassName: vixens-medium
-      initContainers: []
       containers:
         - name: music-assistant
           resources:
@@ -50,10 +52,6 @@ spec:
               name: slimproto-udp
               protocol: UDP
           env:
-            - name: PUID
-              value: "1000"
-            - name: PGID
-              value: "1000"
             - name: TZ
               value: Europe/Paris
           lifecycle:

--- a/apps/20-media/pyload/base/deployment.yaml
+++ b/apps/20-media/pyload/base/deployment.yaml
@@ -30,7 +30,15 @@ spec:
           operator: Exists
           effect: NoSchedule
       priorityClassName: vixens-low
-      initContainers: []
+      initContainers:
+        - name: fix-run-dir
+          image: busybox:1.37.0
+          command: ["sh", "-c", "chown 1000:1000 /run"]
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: run
+              mountPath: /run
       containers:
         - name: pyload
           resources:
@@ -80,12 +88,21 @@ spec:
             failureThreshold: 15
             periodSeconds: 10
             timeoutSeconds: 5
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
+            - name: run
+              mountPath: /run
             - name: config
               mountPath: /config
             - name: downloads
               mountPath: /downloads
       volumes:
+        - name: run
+          emptyDir: {}
         - name: config
           persistentVolumeClaim:
             claimName: pyload-config-pvc
@@ -94,5 +111,9 @@ spec:
             server: 192.168.111.69
             path: /volume3/Downloads/pyload
       securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault

--- a/apps/20-media/qbittorrent/base/deployment.yaml
+++ b/apps/20-media/qbittorrent/base/deployment.yaml
@@ -22,12 +22,21 @@ spec:
         vixens.io/service-binding: "false"
         vixens.io/no-long-connections: "true"
         kubectl.kubernetes.io/restartedAt: "2026-03-11T22:00:00Z"
+        vixens.io/explicitly-allow-root: "true"
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
-      initContainers: []
+      initContainers:
+        - name: fix-run-dir
+          image: busybox:1.37.0
+          command: ["sh", "-c", "chown 1000:1000 /run"]
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: run
+              mountPath: /run
       priorityClassName: vixens-medium
       containers:
         - name: qbittorrent
@@ -90,6 +99,11 @@ spec:
             failureThreshold: 15
             periodSeconds: 10
             timeoutSeconds: 5
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: run
               mountPath: /run
@@ -116,3 +130,5 @@ spec:
         runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault

--- a/apps/20-media/sabnzbd/base/deployment.yaml
+++ b/apps/20-media/sabnzbd/base/deployment.yaml
@@ -28,6 +28,9 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/path: "/metrics"
         vixens.io/no-long-connections: "true"
+        # s6-overlay v3 preinit validates /run ownership matches PUID.
+        # emptyDir is created uid=0 by Kubernetes; fix-run-dir chowns it before s6 starts.
+        vixens.io/explicitly-allow-root: "true"
 
     spec:
       priorityClassName: vixens-medium
@@ -36,6 +39,14 @@ spec:
           operator: Exists
           effect: NoSchedule
       initContainers:
+        - name: fix-run-dir
+          image: busybox:1.37.0
+          command: ["sh", "-c", "chown 1000:1000 /run"]
+          securityContext:
+            runAsUser: 0  # must run as root to chown /run (emptyDir created uid=0 by kubelet)
+          volumeMounts:
+            - name: run
+              mountPath: /run
         - name: restore-config
           image: rclone/rclone:1.73
           securityContext:
@@ -78,10 +89,10 @@ spec:
             - containerPort: 8080 # Default Sabnzbd UI port
               name: http
           securityContext:
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
-              add: ["SETGID", "SETUID", "CHOWN", "DAC_OVERRIDE"]
           livenessProbe:
             httpGet:
               path: /

--- a/apps/70-tools/stirling-pdf/base/values.yaml
+++ b/apps/70-tools/stirling-pdf/base/values.yaml
@@ -67,6 +67,13 @@ envs:
 securityContext:
   enabled: true
   fsGroup: 1000
+containerSecurityContext:
+  runAsUser: 1000
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
 podLabels:
   vixens.io/sizing.stirling-pdf-chart: SB-medium
   vixens.io/backup-profile: "relaxed"
@@ -76,6 +83,3 @@ podAnnotations:
   vixens.io/service-binding: "false"
   vixens.io/nometrics: "true"
   vixens.io/no-long-connections: "true"
-  # Stirling-PDF startup script chowns /tmp dirs and su-switches to stirlingpdfuser;
-  # mutate-security-context drops CAP_SETUID which breaks this — bypass required
-  vixens.io/explicitly-allow-root: "true"

--- a/apps/99-test/tandoor/base/deployment.yaml
+++ b/apps/99-test/tandoor/base/deployment.yaml
@@ -12,8 +12,7 @@ spec:
     metadata:
       labels:
         app: tandoor
-      annotations:
-        vixens.io/explicitly-allow-root: "true"
+      annotations: {}
     spec:
       tolerations:
         - key: node-role.kubernetes.io/control-plane
@@ -22,6 +21,9 @@ spec:
       containers:
         - name: tandoor
           image: vabene1111/recipes:latest
+          securityContext:
+            runAsUser: 1000
+            runAsNonRoot: true
           ports:
             - containerPort: 8080
               name: http
@@ -71,3 +73,5 @@ spec:
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault


### PR DESCRIPTION
## Résumé

Deux problèmes découverts lors de la correction massive root/fsGroup :

### 🚨 HOTFIX — CrashLoopBackOff actif (sabnzbd, qbittorrent, lazylibrarian, booklore-mariadb)

**Cause** : PR #2587 a appliqué `runAsUser: 1000 + /run emptyDir` à plusieurs images LSIO. s6-overlay **v3** `preinit` vérifie l'ownership de `/run` et fail car l'emptyDir est créé `uid=0` par le kubelet — mais le process tourne à `uid=1000` et ne peut pas le corriger.

**Fix** : init container `fix-run-dir` (busybox, `runAsUser: 0`) qui fait `chown 1000:1000 /run` *avant* que s6-overlay démarre. Pattern confirmé stable : pod `runAsUser: 1000` + `fix-run-dir` + `explicitly-allow-root` (pour l'init container root).

Apps fixées :
- **sabnzbd** — LSIO s6-overlay, fix-run-dir, capabilities drop ALL (SETUID/SETGID/CHOWN retirés)
- **qbittorrent** — idem + container securityContext explicite
- **lazylibrarian** — idem + `/run emptyDir` ajouté (s6-applyuidgid setgroups échouait via Kyverno drop ALL)
- **booklore-mariadb** — idem (db-backup sidecar reste `runAsUser: 0`, needs `explicitly-allow-root`)
- **pyload** — prévention (non déployé en dev) — même pattern LSIO

### 🔧 Corrections non-LSIO (explicitly-allow-root retiré)

- **music-assistant** — image officielle (`chmod 777 /app`), pas de gosu, `runAsUser: 1000` direct
- **stirling-pdf** — Helm chart: `containerSecurityContext.runAsUser: 1000` bypass le su-exec startup
- **tandoor** — Django app, supporte non-root depuis PR #4042 + `TANDOOR_PORT: 8080` déjà en place

### ⚠️ Revert booklore (grimmory)

PR #2589 a appliqué `runAsUser: 1000` à grimmory — erreur : l'image appelle `addgroup` au démarrage (requiert root). Restore `explicitly-allow-root`, suppression pod-level runAsUser/runAsNonRoot.

### Exceptions légitimes conservées

| App | Raison |
|-----|--------|
| synology-csi | kernel/hardware |
| homeassistant | ADR-0013 |
| amule | image abandonnée 2021 (issue #2588) |
| frigate | nginx root hardcodé |
| gluetun | VPN kernel modules |
| netvisor | daemon hardware |
| netbird/dashboard | port 80 nginx — déféré (requiert config nginx custom) |
| grimmory/booklore | addgroup au démarrage, pas de su-exec pattern |

Closes #2590

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security configurations across media and tool applications with stricter container execution policies, non-root enforcement, and improved system call filtering.
  * Standardized directory permission handling through initialization containers for consistent runtime behavior.
  * Improved container isolation and capability restrictions for better overall system security posture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->