### PR TITLE
fix(mariadb-shared): ouvrir ingress port 3306

### DIFF
--- a/apps/04-databases/mariadb-shared/base/networkpolicy.yaml
+++ b/apps/04-databases/mariadb-shared/base/networkpolicy.yaml
@@ -10,7 +10,10 @@ spec:
   policyTypes:
     - Ingress
     - Egress
-  ingress: []
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 3306
   egress:
     # Allow all egress (homelab: DNS, inter-app, external APIs)
     - {}


### PR DESCRIPTION
NetworkPolicy avait ingress: [] — bloquait toutes les connexions entrantes.

Ouverture port 3306 pour permettre aux apps du cluster de se connecter.
Correction urgente : booklore ne démarrait pas (HikariPool timeout).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network access policies to allow inbound TCP connections on port 3306 to the MariaDB database service, ensuring proper database connectivity while maintaining existing outbound traffic configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->