### PR TITLE
fix(eval): local-path-delete pour shelfarr+bookshelf

### DIFF
--- a/apps/99-test/bookshelf/base/pvc.yaml
+++ b/apps/99-test/bookshelf/base/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: synelia-iscsi-delete
+  storageClassName: local-path-delete
   resources:
     requests:
       storage: 2Gi
@@ -18,7 +18,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: synelia-iscsi-delete
+  storageClassName: local-path-delete
   resources:
     requests:
       storage: 10Gi

--- a/apps/99-test/shelfarr/base/pvc.yaml
+++ b/apps/99-test/shelfarr/base/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: synelia-iscsi-delete
+  storageClassName: local-path-delete
   resources:
     requests:
       storage: 5Gi


### PR DESCRIPTION
Synology CSI ne peut plus provisionner. Local-path-delete pour apps d'eval.