### PR TITLE
fix(shelfarr): use :latest tag (v0.8.5 not published to ghcr.io)

### DIFF
--- a/apps/99-test/shelfarr/base/deployment.yaml
+++ b/apps/99-test/shelfarr/base/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: shelfarr
-          image: ghcr.io/pedro-revez-silva/shelfarr:v0.8.5
+          image: ghcr.io/pedro-revez-silva/shelfarr:latest
           ports:
             - containerPort: 80
               name: http


### PR DESCRIPTION
The image ghcr.io/pedro-revez-silva/shelfarr:v0.8.5 does not exist on GHCR. The project only publishes `latest`, `main`, and commit SHA tags. Switch to `latest` for the evaluation deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shelfarr service container image configuration to use the latest available version instead of a fixed release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->