### PR TITLE
fix(argocd): prod-stable targetRevision for shelfarr+bookshelf

### DIFF
--- a/argocd/overlays/prod/apps/bookshelf.yaml
+++ b/argocd/overlays/prod/apps/bookshelf.yaml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/charchess/vixens.git
-    targetRevision: main
+    targetRevision: prod-stable
     path: apps/99-test/bookshelf/overlays/dev
   destination:
     server: https://kubernetes.default.svc

--- a/argocd/overlays/prod/apps/shelfarr.yaml
+++ b/argocd/overlays/prod/apps/shelfarr.yaml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/charchess/vixens.git
-    targetRevision: main
+    targetRevision: prod-stable
     path: apps/99-test/shelfarr/overlays/dev
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
shelfarr and bookshelf ArgoCD apps had `targetRevision: main` instead of `prod-stable`, failing the Production Configuration CI check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configurations for Bookshelf and Shelfarr applications to track from the prod-stable branch instead of main. This ensures deployments are sourced from stable, tested releases rather than the development branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->