### PR TITLE
fix(bookshelf): use /ping for probes (401 on /)

### DIFF
--- a/apps/99-test/bookshelf/base/deployment.yaml
+++ b/apps/99-test/bookshelf/base/deployment.yaml
@@ -41,21 +41,21 @@ spec:
               value: Europe/Paris
           livenessProbe:
             httpGet:
-              path: /
+              path: /ping
               port: http
             initialDelaySeconds: 60
             periodSeconds: 30
             timeoutSeconds: 5
           readinessProbe:
             httpGet:
-              path: /
+              path: /ping
               port: http
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
           startupProbe:
             httpGet:
-              path: /
+              path: /ping
               port: http
             failureThreshold: 30
             periodSeconds: 10


### PR DESCRIPTION
Bookshelf is a Readarr fork — the root path requires authentication and returns 401. Kubernetes treats 401 as a probe failure → pod restart loop. `/ping` is unauthenticated and returns 200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application health check probes to use a dedicated endpoint for improved monitoring and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->