### PR TITLE
feat(bookshelf): deploy to media namespace, replace lazylibrarian

### DIFF
--- a/apps/20-media/bookshelf/base/deployment.yaml
+++ b/apps/20-media/bookshelf/base/deployment.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bookshelf
+  labels:
+    app: bookshelf
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: bookshelf
+  template:
+    metadata:
+      labels:
+        app: bookshelf
+        vixens.io/sizing.bookshelf: V-small
+      annotations:
+        vixens.io/fast-start: "true"
+        vixens.io/explicitly-allow-root: "true"
+        vixens.io/no-long-connections: "true"
+        prometheus.io/scrape: "false"
+    spec:
+      priorityClassName: vixens-low
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: bookshelf
+          # hardcover = Hardcover.app metadata (higher quality than Goodreads)
+          # softcover = Goodreads backward compat (for migrating existing Readarr DB)
+          image: ghcr.io/pennydreadful/bookshelf:hardcover
+          ports:
+            - containerPort: 8787
+              name: http
+          env:
+            - name: TZ
+              value: Europe/Paris
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /ping
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: downloads
+              mountPath: /downloads
+            - name: books
+              mountPath: /books
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: bookshelf-config-pvc
+        - name: downloads
+          nfs:
+            server: 192.168.111.69
+            path: /volume3/Downloads
+        - name: books
+          nfs:
+            server: 192.168.111.69
+            path: /volume3/Content/ebooks

--- a/apps/20-media/bookshelf/base/kustomization.yaml
+++ b/apps/20-media/bookshelf/base/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: media
+resources:
+  - deployment.yaml
+  - service.yaml
+  - pvc.yaml
+  - networkpolicy.yaml
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/20-media/bookshelf/base/networkpolicy.yaml
+++ b/apps/20-media/bookshelf/base/networkpolicy.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bookshelf
+spec:
+  podSelector:
+    matchLabels:
+      app: bookshelf
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: traefik
+      ports:
+        - protocol: TCP
+          port: 8787
+  egress:
+    - {}

--- a/apps/20-media/bookshelf/base/pvc.yaml
+++ b/apps/20-media/bookshelf/base/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bookshelf-config-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: synelia-iscsi-retain
+  resources:
+    requests:
+      storage: 4Gi

--- a/apps/20-media/bookshelf/base/service.yaml
+++ b/apps/20-media/bookshelf/base/service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bookshelf
+  labels:
+    app: bookshelf
+spec:
+  selector:
+    app: bookshelf
+  ports:
+    - name: http
+      port: 8787
+      targetPort: http

--- a/apps/20-media/bookshelf/overlays/prod/ingress.yaml
+++ b/apps/20-media/bookshelf/overlays/prod/ingress.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: bookshelf-ingress
+  labels:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Bookshelf
+    gethomepage.dev/icon: readarr.png
+    gethomepage.dev/group: Media
+    vixens.io/nossoneeded: "true"
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: bookshelf.truxonline.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: bookshelf
+                port:
+                  number: 8787
+  tls:
+    - hosts:
+        - bookshelf.truxonline.com
+      secretName: bookshelf-tls

--- a/apps/20-media/bookshelf/overlays/prod/kustomization.yaml
+++ b/apps/20-media/bookshelf/overlays/prod/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - ingress.yaml
+components:
+  - ../../../../_shared/components/sync-wave/wave-10
+  - ../../../../_shared/components/goldilocks/enabled
+  - ../../../../_shared/components/nometrics
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: synelia-iscsi-retain
+    target:
+      kind: PersistentVolumeClaim
+      name: bookshelf-config-pvc

--- a/argocd/overlays/prod/apps/bookshelf.yaml
+++ b/argocd/overlays/prod/apps/bookshelf.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: bookshelf
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -11,10 +13,10 @@ spec:
   source:
     repoURL: https://github.com/charchess/vixens.git
     targetRevision: prod-stable
-    path: apps/99-test/bookshelf/overlays/dev
+    path: apps/20-media/bookshelf/overlays/prod
   destination:
     server: https://kubernetes.default.svc
-    namespace: 99-test
+    namespace: media
   syncPolicy:
     automated:
       prune: true

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -59,7 +59,6 @@ resources:
   - apps/firefly-iii-importer.yaml
   - apps/n8n.yaml
   - apps/lidarr.yaml
-  - apps/lazylibrarian.yaml
   - apps/booklore.yaml
   - apps/sonarr.yaml
   - apps/prowlarr.yaml


### PR DESCRIPTION
## Summary

- Deploy Bookshelf (Readarr fork, Hardcover.app metadata) to `media` namespace
- Replaces LazyLibrarian (archived upstream)
- Probes on `/ping` (root path requires auth → 401)
- iSCSI retain PVC 4Gi + NFS mounts (downloads + books)
- Production ingress: `bookshelf.truxonline.com`
- ArgoCD bookshelf app redirected from `99-test` to `media`/prod
- LazyLibrarian removed from ArgoCD app-of-apps (PVC retained)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployed bookshelf application to production, accessible at bookshelf.truxonline.com with TLS encryption and HTTPS redirection.
  * Configured persistent storage, network access controls, and service routing for the new application.

* **Chores**
  * Updated application deployment configuration paths and removed obsolete configuration reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->