### PR TITLE
fix(argocd): Replace=true on large CRDs (>262KB annotation limit)

### DIFF
--- a/apps/00-infra/argocd/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/argocd/overlays/prod/kustomization.yaml
@@ -10,6 +10,7 @@ patches:
   - path: resources-patch.yaml
   - path: patches/argocd-params.yaml
   - path: patches/argocd-cm-ignore-differences.yaml
+  - path: patches/crds-replace-sync.yaml
   - target:
       group: apps
       version: v1

--- a/apps/00-infra/argocd/overlays/prod/patches/crds-replace-sync.yaml
+++ b/apps/00-infra/argocd/overlays/prod/patches/crds-replace-sync.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: applications.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: applicationsets.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true


### PR DESCRIPTION
## Root Cause

`applications.argoproj.io` (194KB) and `applicationsets.argoproj.io` (364KB) exceed the Kubernetes annotation size limit (262144 bytes) when applied with client-side apply.

ArgoCD's `ServerSideApply=true` on the `argocd` Application should bypass this, but SSA still fails for these CRDs in practice.

## Fix

Add `argocd.argoproj.io/sync-options: Replace=true` to the two large CRDs via kustomize patch. This forces ArgoCD to use `kubectl replace` (PUT) instead of `kubectl apply` (PATCH) for these specific resources, bypassing the annotation storage entirely.

`appprojects.argoproj.io` (10KB) is unaffected.

Closes #2560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production infrastructure configuration for Argo CD to enhance resource synchronization behavior during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->