### PR TITLE
fix(kyverno): RespectIgnoreDifferences for large CRDs (>262KB annotation limit)

### DIFF
--- a/argocd/overlays/prod/apps/kyverno.yaml
+++ b/argocd/overlays/prod/apps/kyverno.yaml
@@ -172,6 +172,18 @@ spec:
         - .spec.rules[].match.all[].resources.namespaces
       jsonPointers:
         - /status
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: clusterpolicies.kyverno.io
+      jsonPointers:
+        - /spec
+        - /metadata/annotations
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: policies.kyverno.io
+      jsonPointers:
+        - /spec
+        - /metadata/annotations
   syncPolicy:
     automated:
       prune: true
@@ -180,6 +192,7 @@ spec:
       - CreateNamespace=true
       - ServerSideApply=true
       - Replace=true
+      - RespectIgnoreDifferences=true
     retry:
       limit: 3
       backoff:


### PR DESCRIPTION
## Root Cause

`clusterpolicies.kyverno.io` and `policies.kyverno.io` are each **655KB** — far exceeding the 262KB etcd annotation limit.

ArgoCD's `Replace=true` global option was not preventing the error because the Helm-sourced CRDs bypass the per-resource replace logic.

## Fix

Add `ignoreDifferences` for `/spec` and `/metadata/annotations` on these two CRDs, combined with `RespectIgnoreDifferences=true`. ArgoCD skips applying them entirely during sync.

Kyverno's migration job (included in the Helm chart templates) handles CRD schema updates during Helm upgrades.

Part of #2560