### PR TITLE
fix(kyverno): jqPathExpressions .spec+.metadata for large CRDs

### DIFF
--- a/argocd/overlays/prod/apps/kyverno.yaml
+++ b/argocd/overlays/prod/apps/kyverno.yaml
@@ -175,15 +175,15 @@ spec:
     - group: apiextensions.k8s.io
       kind: CustomResourceDefinition
       name: clusterpolicies.kyverno.io
-      jsonPointers:
-        - /spec
-        - /metadata/annotations
+      jqPathExpressions:
+        - .spec
+        - .metadata
     - group: apiextensions.k8s.io
       kind: CustomResourceDefinition
       name: policies.kyverno.io
-      jsonPointers:
-        - /spec
-        - /metadata/annotations
+      jqPathExpressions:
+        - .spec
+        - .metadata
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
Use jqPathExpressions instead of jsonPointers to catch all differences in spec and metadata for clusterpolicies and policies CRDs. More comprehensive than /spec and /metadata/annotations alone.