### PR TITLE
fix(kyverno): skipCrds=true (KISS — CRDs 655KB > 262KB annotation limit)

### DIFF
--- a/argocd/overlays/prod/apps/kyverno.yaml
+++ b/argocd/overlays/prod/apps/kyverno.yaml
@@ -17,6 +17,7 @@ spec:
       targetRevision: 3.4.0
       helm:
         releaseName: kyverno
+        skipCrds: true
         values: |
           admissionController:
             replicas: 3
@@ -172,18 +173,7 @@ spec:
         - .spec.rules[].match.all[].resources.namespaces
       jsonPointers:
         - /status
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: clusterpolicies.kyverno.io
-      jqPathExpressions:
-        - .spec
-        - .metadata
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: policies.kyverno.io
-      jqPathExpressions:
-        - .spec
-        - .metadata
+
   syncPolicy:
     automated:
       prune: true
@@ -192,7 +182,6 @@ spec:
       - CreateNamespace=true
       - ServerSideApply=true
       - Replace=true
-      - RespectIgnoreDifferences=true
     retry:
       limit: 3
       backoff:


### PR DESCRIPTION
Replaces the over-engineered ignoreDifferences approach with the correct single-line fix: `skipCrds: true` on the Helm source tells ArgoCD to use `helm template --skip-crds`, excluding the 655KB CRDs from the sync. The kyverno migration job handles CRD lifecycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kyverno Helm release configuration to skip custom resource definition installation, enabling separate management outside of Helm.
  * Adjusted Argo CD synchronization policy settings to refine how deployment differences are handled during sync operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->