### PR TITLE
fix: pyload/music-assistant/firefly-importer — 3 apps dégradées

### DIFF
--- a/apps/20-media/music-assistant/base/deployment.yaml
+++ b/apps/20-media/music-assistant/base/deployment.yaml
@@ -32,6 +32,7 @@ spec:
           operator: Exists
           effect: NoSchedule
       priorityClassName: vixens-medium
+      initContainers: []
       containers:
         - name: music-assistant
           resources:

--- a/apps/20-media/pyload/base/deployment.yaml
+++ b/apps/20-media/pyload/base/deployment.yaml
@@ -89,10 +89,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
           securityContext:
-            runAsNonRoot: true
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
+            runAsUser: 0
           volumeMounts:
             - name: run
               mountPath: /run
@@ -111,8 +108,6 @@ spec:
             server: 192.168.111.69
             path: /volume3/Downloads/pyload
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:

--- a/apps/60-services/firefly-iii-importer/base/deployment.yaml
+++ b/apps/60-services/firefly-iii-importer/base/deployment.yaml
@@ -30,6 +30,7 @@ spec:
           effect: NoSchedule
       securityContext:
         runAsNonRoot: true
+        runAsUser: 33
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:


### PR DESCRIPTION
### pyload
CrashLoopBackOff — `s6-applyuidgid: unable to set supplementary group list`
LSIO s6-overlay démarre en root puis drop vers PUID. Le mauvais fix précédent avait ajouté `runAsUser:1000 + runAsNonRoot:true` au niveau pod/container → bloque le démarrage root. Fix: `runAsUser:0` au container level.

### music-assistant
ComparisonError — kustomize build échoue: `add operation does not apply: initContainers/-: missing value`
Le composant dataangel essaie d'ajouter à un array inexistant. Fix: `initContainers: []` dans la base.

### firefly-iii-importer
CreateContainerConfigError — `runAsNonRoot + image user www-data (non-numeric)`
Kubernetes ne peut pas vérifier que www-data est non-root. Fix: `runAsUser: 33` (UID www-data).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configurations for music-assistant, pyload, and firefly-iii-importer services
  * Modified security context settings for pyload, changing execution mode from non-root to root
  * Adjusted security context for firefly-iii-importer with updated user privilege configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->