### PR TITLE
fix(music-assistant): fsGroupChangePolicy: Always

### DIFF
--- a/apps/20-media/music-assistant/base/deployment.yaml
+++ b/apps/20-media/music-assistant/base/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
-        fsGroupChangePolicy: OnRootMismatch
+        fsGroupChangePolicy: Always
         seccompProfile:
           type: RuntimeDefault
       tolerations:


### PR DESCRIPTION
Les fichiers dans /data sont owned root:root (backup datant d'avant le fix runAsUser:1000). `OnRootMismatch` ne rechown pas les fichiers imbriqués. `Always` force le rechown complet à chaque démarrage → music-assistant (UID 1000) peut écrire.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated music-assistant service deployment configuration for improved filesystem permission handling during pod initialization and runtime operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->