### PR TITLE
fix(music-assistant): chown-data init container pour volumes hostPath

### DIFF
--- a/apps/20-media/music-assistant/base/deployment.yaml
+++ b/apps/20-media/music-assistant/base/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
-        fsGroupChangePolicy: Always
+        fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
       tolerations:
@@ -32,7 +32,15 @@ spec:
           operator: Exists
           effect: NoSchedule
       priorityClassName: vixens-medium
-      initContainers: []
+      initContainers:
+        - name: chown-data
+          image: busybox:1.37.0
+          command: ["sh", "-c", "chown -R 1000:1000 /data"]
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: config
+              mountPath: /data
       containers:
         - name: music-assistant
           resources:


### PR DESCRIPTION
fsGroup/fsGroupChangePolicy ne s'applique pas aux volumes hostPath (local-path = hostPath sous le capot — limitation Kubernetes documentée). Init container `chown-data` (busybox, runAsUser:0) fait le chown explicite avant démarrage, comme le pattern `fix-run-dir` utilisé pour les apps LSIO.