### PR TITLE
fix(kyverno): retire ServerSideApply=true (override Replace=true)

### DIFF
--- a/argocd/overlays/prod/apps/kyverno.yaml
+++ b/argocd/overlays/prod/apps/kyverno.yaml
@@ -180,7 +180,6 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - ServerSideApply=true
       - Replace=true
     retry:
       limit: 3


### PR DESCRIPTION
Quand `ServerSideApply=true` et `Replace=true` sont tous les deux présents, SSA prend la priorité. ArgoCD utilise alors PATCH qui essaie de stocker les CRDs (655KB) en annotation → dépasse la limite 262KB. Sans SSA, `Replace=true` utilise PUT qui contourne cette limite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production deployment configuration to modify how manifests are applied during synchronization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->