### PR TITLE
fix(kyverno): crds.install=false — bypass dry-run apply 655KB CRDs

### DIFF
--- a/argocd/overlays/prod/apps/kyverno.yaml
+++ b/argocd/overlays/prod/apps/kyverno.yaml
@@ -139,6 +139,7 @@ spec:
                 effect: NoSchedule
 
           crds:
+            install: false
             migration:
               tolerations:
                 - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
crds.install: false empêche le chart de rendre les CRDs — ArgoCD ne les inclut plus dans le diff/sync. Les CRDs existantes restent en place.