### PR TITLE
fix(kyverno): SSA sans Replace (crds.install=false gère les CRDs)

### DIFF
--- a/argocd/overlays/prod/apps/kyverno.yaml
+++ b/argocd/overlays/prod/apps/kyverno.yaml
@@ -181,7 +181,7 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - Replace=true
+      - ServerSideApply=true
     retry:
       limit: 3
       backoff:


### PR DESCRIPTION
crds.install=false exclut les CRDs du rendering. Plus besoin de Replace=true (qui causait des erreurs create/already-exists sur RBAC). SSA seul suffit pour les autres ressources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production synchronization configuration to improve consistency in deployment application handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->