### PR TITLE
chore: integrate components with home assistant

### DIFF
--- a/apps/10-home/mosquitto/base/networkpolicy.yaml
+++ b/apps/10-home/mosquitto/base/networkpolicy.yaml
@@ -10,7 +10,14 @@ spec:
   policyTypes:
     - Ingress
     - Egress
-  ingress: []
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: homeassistant
+      ports:
+        - protocol: TCP
+          port: 1883
   egress:
     # Allow all egress (homelab: DNS, inter-app, external APIs)
     - {}


### PR DESCRIPTION
Work in progress.

Closes #2204

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated networking configuration to enable communication between services, allowing the message broker to receive TCP connections on its standard port from the home automation service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->