### PR TITLE
feat(stalwart): deploy in 99-test for evaluation

### DIFF
--- a/apps/99-test/stalwart/base/deployment.yaml
+++ b/apps/99-test/stalwart/base/deployment.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stalwart
+  labels:
+    app: stalwart
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: stalwart
+  template:
+    metadata:
+      labels:
+        app: stalwart
+        vixens.io/sizing.stalwart: V-small
+      annotations:
+        vixens.io/explicitly-allow-root: "true"
+        prometheus.io/scrape: "false"
+    spec:
+      priorityClassName: vixens-low
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      securityContext:
+        fsGroup: 0
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: stalwart
+          image: ghcr.io/stalwartlabs/stalwart:v0.15.5
+          securityContext:
+            runAsUser: 0
+          env:
+            - name: TZ
+              value: Europe/Paris
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 25
+              name: smtp
+            - containerPort: 587
+              name: submission
+            - containerPort: 465
+              name: submissions
+            - containerPort: 143
+              name: imap
+            - containerPort: 993
+              name: imaps
+          startupProbe:
+            tcpSocket:
+              port: http
+            failureThreshold: 30
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          volumeMounts:
+            - name: data
+              mountPath: /opt/stalwart
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: stalwart-data-pvc

--- a/apps/99-test/stalwart/base/kustomization.yaml
+++ b/apps/99-test/stalwart/base/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 99-test
+resources:
+  - deployment.yaml
+  - service.yaml
+  - pvc.yaml
+  - networkpolicy.yaml
+components:
+  - ../../../_shared/components/revision-history-limit

--- a/apps/99-test/stalwart/base/networkpolicy.yaml
+++ b/apps/99-test/stalwart/base/networkpolicy.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: stalwart
+spec:
+  podSelector:
+    matchLabels:
+      app: stalwart
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: traefik
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    - {}

--- a/apps/99-test/stalwart/base/pvc.yaml
+++ b/apps/99-test/stalwart/base/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: stalwart-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path-delete
+  resources:
+    requests:
+      storage: 10Gi

--- a/apps/99-test/stalwart/base/service.yaml
+++ b/apps/99-test/stalwart/base/service.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: stalwart
+  labels:
+    app: stalwart
+spec:
+  selector:
+    app: stalwart
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+    - name: smtp
+      port: 25
+      targetPort: smtp
+    - name: submission
+      port: 587
+      targetPort: submission
+    - name: submissions
+      port: 465
+      targetPort: submissions
+    - name: imap
+      port: 143
+      targetPort: imap
+    - name: imaps
+      port: 993
+      targetPort: imaps

--- a/apps/99-test/stalwart/overlays/dev/ingress.yaml
+++ b/apps/99-test/stalwart/overlays/dev/ingress.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: stalwart-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    vixens.io/nossoneeded: "true"
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: stalwart.dev.truxonline.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: stalwart
+                port:
+                  number: 8080
+  tls:
+    - hosts:
+        - stalwart.dev.truxonline.com
+      secretName: stalwart-tls

--- a/apps/99-test/stalwart/overlays/dev/kustomization.yaml
+++ b/apps/99-test/stalwart/overlays/dev/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - ingress.yaml

--- a/argocd/overlays/prod/apps/stalwart.yaml
+++ b/argocd/overlays/prod/apps/stalwart.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: stalwart
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: prod-stable
+    path: apps/99-test/stalwart/overlays/dev
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: 99-test
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -101,3 +101,4 @@ resources:
   - apps/radar.yaml
   - apps/maturity-controller.yaml
   - apps/bookshelf.yaml
+  - apps/stalwart.yaml


### PR DESCRIPTION
Stalwart Mail v0.15.5 en dev pour évaluation (#2211).

- Admin UI : https://stalwart.dev.truxonline.com
- SMTP/IMAP : ClusterIP uniquement (pas d'exposition externe pour l'eval)
- Storage : 10Gi local-path-delete
- Premier boot : password admin généré aléatoirement → `kubectl logs -n 99-test deployment/stalwart`

Closes #2211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new stalwart service with support for email and messaging protocols (SMTP, IMAP, and related services).
  * Service is publicly accessible via a dedicated domain with TLS encryption.
  * Configured with automated deployment, persistent storage, and network security policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->