### PR TITLE
fix(docspell): use Infisical-managed docspell-secrets for all creds

### DIFF
--- a/apps/60-services/docspell/base/statefulset-joex.yaml
+++ b/apps/60-services/docspell/base/statefulset-joex.yaml
@@ -69,12 +69,12 @@ spec:
             - name: MINIO_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: docspell-minio-secrets
+                  name: docspell-secrets
                   key: MINIO_ACCESS_KEY
             - name: MINIO_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: docspell-minio-secrets
+                  name: docspell-secrets
                   key: MINIO_SECRET_KEY
           livenessProbe:
             httpGet:

--- a/apps/60-services/docspell/base/statefulset-restserver.yaml
+++ b/apps/60-services/docspell/base/statefulset-restserver.yaml
@@ -66,17 +66,17 @@ spec:
             - name: MINIO_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: docspell-minio-secrets
+                  name: docspell-secrets
                   key: MINIO_ACCESS_KEY
             - name: MINIO_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: docspell-minio-secrets
+                  name: docspell-secrets
                   key: MINIO_SECRET_KEY
             - name: INTEGRATION_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: docspell-minio-secrets
+                  name: docspell-secrets
                   key: INTEGRATION_SECRET
           livenessProbe:
             httpGet:
@@ -124,7 +124,7 @@ spec:
             - name: INTEGRATION_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: docspell-minio-secrets
+                  name: docspell-secrets
                   key: INTEGRATION_SECRET
           securityContext:
             runAsNonRoot: true


### PR DESCRIPTION
## Summary

- Secrets MinIO (MINIO_ACCESS_KEY, MINIO_SECRET_KEY) et INTEGRATION_SECRET ajoutés dans Infisical `/apps/60-services/docspell` (prod + dev)
- statefulset-restserver + statefulset-joex : référencent maintenant `docspell-secrets` (Infisical-managed) au lieu du secret impératif `docspell-minio-secrets`
- Secret impératif `docspell-minio-secrets` supprimé du cluster

Closes #2221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Kubernetes secret references for MinIO credentials and integration settings to use consolidated secret configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->