### PR TITLE
feat(crowdsec): deploy CrowdSec LAPI + Traefik Bouncer

### DIFF
--- a/.opencode/napkin.md
+++ b/.opencode/napkin.md
@@ -140,6 +140,14 @@ kubectl -n argocd patch application argocd --type merge -p '{"metadata":{"annota
 3. **[2026-03-28] VPA uncappedTarget << minAllowed → cache stale injecte mauvaises valeurs**
    Si le minAllowed VPA est augmenté (via annotation vixens.io/vpa.min-memory), l'admission controller continue d'injecter l'ancienne recommandation. `sizing-v2-mutate` écrase tout de toute façon → changer le sizing label est la seule vraie solution, pas kubectl restart.
 
+## 🔑 Agent Credentials (Priority 1)
+
+1. **[2026-03-31] Infisical write access via machine identity in ~/.agents/credentials/**
+   Les credentials agents (Infisical write, GitHub PATs, MinIO admin) sont dans `~/.agents/credentials/infisical-write.env`.
+   Do instead: `source ~/.agents/credentials/infisical-write.env` puis `INFISICAL_TOKEN=$(curl ... login)` avant tout `infisical secrets set`. Ne JAMAIS utiliser la machine identity read-only du cluster (`infisical-universal-auth`) pour écrire.
+
+---
+
 ## 🔐 Security Hardening Patterns (Priority 2)
 
 ### LSIO s6-overlay non-root pattern

--- a/apps/00-infra/crowdsec/base/infisical-secret.yaml
+++ b/apps/00-infra/crowdsec/base/infisical-secret.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: crowdsec-secrets-sync
+  namespace: crowdsec
+spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
+  authentication:
+    universalAuth:
+      credentialsRef:
+        secretName: infisical-universal-auth
+        secretNamespace: argocd
+      secretsScope:
+        projectSlug: vixens
+        envSlug: dev
+        secretsPath: /apps/00-infra/crowdsec
+  managedSecretReference:
+    secretName: crowdsec-secrets
+    secretNamespace: crowdsec
+    creationPolicy: Owner

--- a/apps/00-infra/crowdsec/base/kustomization.yaml
+++ b/apps/00-infra/crowdsec/base/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - infisical-secret.yaml

--- a/apps/00-infra/crowdsec/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/crowdsec/overlays/prod/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+patches:
+  - path: patch-infisical-secret.yaml

--- a/apps/00-infra/crowdsec/overlays/prod/patch-infisical-secret.yaml
+++ b/apps/00-infra/crowdsec/overlays/prod/patch-infisical-secret.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: crowdsec-secrets-sync
+  namespace: crowdsec
+spec:
+  authentication:
+    universalAuth:
+      secretsScope:
+        envSlug: prod

--- a/apps/00-infra/crowdsec/values/common.yaml
+++ b/apps/00-infra/crowdsec/values/common.yaml
@@ -1,0 +1,95 @@
+---
+# CrowdSec Helm values - common (all environments)
+# Chart: crowdsecurity/crowdsec
+# Docs: https://docs.crowdsec.net/docs/getting_started/install_crowdsec_service
+
+container_runtime: containerd
+
+image:
+  repository: crowdsecurity/crowdsec
+  tag: ""  # uses chart AppVersion
+  pullPolicy: IfNotPresent
+
+# ============================================================================
+# LAPI (Local API) - decision engine
+# ============================================================================
+lapi:
+  enabled: true
+  replicas: 1
+
+  env:
+    # Bouncer key for Traefik - generated via Infisical, injected by chart
+    - name: BOUNCER_KEY_traefik
+      valueFrom:
+        secretKeyRef:
+          name: crowdsec-secrets
+          key: CROWDSEC_BOUNCER_KEY
+    - name: ENROLL_INSTANCE_NAME
+      value: "vixens-k8s"
+    - name: ENROLL_TAGS
+      value: "k8s linux homelab"
+
+  persistentVolume:
+    data:
+      enabled: true
+      size: 1Gi
+      storageClassName: synology-iscsi-retain
+    config:
+      enabled: true
+      size: 100Mi
+      storageClassName: synology-iscsi-retain
+
+  strategy:
+    type: Recreate  # required with RWO PVC
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# ============================================================================
+# Agent (DaemonSet) - log acquisition from Traefik
+# ============================================================================
+agent:
+  enabled: true
+
+  acquisition:
+    - namespace: traefik
+      podName: traefik-*
+      program: traefik
+
+  env:
+    - name: COLLECTIONS
+      value: "crowdsecurity/traefik crowdsecurity/http-cve crowdsecurity/base-http-scenarios"
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
+# ============================================================================
+# CrowdSec config
+# ============================================================================
+config:
+  profiles.yaml: |
+    name: default_ip_remediation
+    filters:
+      - Alert.Remediation == true && Alert.GetScope() == "Ip"
+    decisions:
+      - type: ban
+        duration: 4h
+    on_success: break
+    ---
+    name: default_range_remediation
+    filters:
+      - Alert.Remediation == true && Alert.GetScope() == "Range"
+    decisions:
+      - type: ban
+        duration: 4h
+    on_success: break

--- a/apps/00-infra/crowdsec/values/dev.yaml
+++ b/apps/00-infra/crowdsec/values/dev.yaml
@@ -1,0 +1,6 @@
+---
+lapi:
+  replicas: 0
+
+agent:
+  enabled: false

--- a/apps/00-infra/crowdsec/values/prod.yaml
+++ b/apps/00-infra/crowdsec/values/prod.yaml
@@ -1,0 +1,12 @@
+---
+lapi:
+  env:
+    - name: BOUNCER_KEY_traefik
+      valueFrom:
+        secretKeyRef:
+          name: crowdsec-secrets
+          key: CROWDSEC_BOUNCER_KEY
+    - name: ENROLL_INSTANCE_NAME
+      value: "vixens-k8s-prod"
+    - name: ENROLL_TAGS
+      value: "k8s linux homelab prod"

--- a/apps/00-infra/traefik/base/infisical-crowdsec-bouncer.yaml
+++ b/apps/00-infra/traefik/base/infisical-crowdsec-bouncer.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: crowdsec-bouncer-key-sync
+  namespace: traefik
+spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
+  authentication:
+    universalAuth:
+      credentialsRef:
+        secretName: infisical-universal-auth
+        secretNamespace: argocd
+      secretsScope:
+        projectSlug: vixens
+        envSlug: prod
+        secretsPath: /apps/00-infra/crowdsec
+  managedSecretReference:
+    secretName: crowdsec-bouncer-key
+    secretNamespace: traefik
+    creationPolicy: Owner

--- a/apps/00-infra/traefik/base/kustomization.yaml
+++ b/apps/00-infra/traefik/base/kustomization.yaml
@@ -3,3 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - middleware-redirect-https.yaml
+  - middleware-crowdsec-bouncer.yaml
+  - infisical-crowdsec-bouncer.yaml

--- a/apps/00-infra/traefik/base/middleware-crowdsec-bouncer.yaml
+++ b/apps/00-infra/traefik/base/middleware-crowdsec-bouncer.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: bouncer
+  namespace: traefik
+spec:
+  plugin:
+    bouncer:
+      enabled: "true"
+      crowdsecMode: stream
+      crowdsecLapiScheme: http
+      crowdsecLapiHost: crowdsec-service.crowdsec.svc.cluster.local:8080
+      crowdsecLapiKeyFile: /var/run/secrets/crowdsec/CROWDSEC_BOUNCER_KEY
+      forwardedHeadersTrustedIPs: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+      updateIntervalSeconds: "60"
+      defaultDecisionSeconds: "60"

--- a/apps/00-infra/traefik/values/common.yaml
+++ b/apps/00-infra/traefik/values/common.yaml
@@ -119,6 +119,25 @@ securityContext:
 # ============================================================================
 # Fast-start bypass (traefik starts in < 10s)
 # ============================================================================
+# ============================================================================
+# CrowdSec Bouncer plugin
+# ============================================================================
+experimental:
+  plugins:
+    bouncer:
+      moduleName: "github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin"
+      version: "v1.5.1"
+
+volumes:
+  - name: crowdsec-bouncer-key
+    secret:
+      secretName: crowdsec-bouncer-key
+
+additionalVolumeMounts:
+  - name: crowdsec-bouncer-key
+    mountPath: /var/run/secrets/crowdsec
+    readOnly: true
+
 deployment:
   podAnnotations:
     vixens.io/fast-start: "true"

--- a/apps/00-infra/traefik/values/prod.yaml
+++ b/apps/00-infra/traefik/values/prod.yaml
@@ -9,6 +9,8 @@ service:
   type: LoadBalancer
   annotations:
     io.cilium/lb-ipam-ips: 192.168.201.70
+  spec:
+    externalTrafficPolicy: Local
 # ============================================================================
 # Production-Specific Settings
 # ============================================================================
@@ -27,6 +29,9 @@ resources:
     cpu: 2000m
     memory: 2Gi
 # High availability with multiple replicas
+additionalArguments:
+  - "--entrypoints.websecure.http.middlewares=traefik-bouncer@kubernetescrd"
+
 deployment:
   replicas: 2
   podLabels:

--- a/argocd/overlays/prod/apps/crowdsec.yaml
+++ b/argocd/overlays/prod/apps/crowdsec.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: crowdsec
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: crowdsec
+  sources:
+    - repoURL: https://crowdsecurity.github.io/helm-charts
+      chart: crowdsec
+      targetRevision: 0.22.1
+      helm:
+        valueFiles:
+          - $values/apps/00-infra/crowdsec/values/common.yaml
+          - $values/apps/00-infra/crowdsec/values/prod.yaml
+    - repoURL: https://github.com/charchess/vixens.git
+      targetRevision: prod-stable
+      ref: values
+    - repoURL: https://github.com/charchess/vixens.git
+      targetRevision: prod-stable
+      path: apps/00-infra/crowdsec/overlays/prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - apps/velero.yaml
   # - apps/velero-maintenance-config.yaml  # removed 2026-03-05 — CM now owned by Helm chart (velero values repositoryMaintenanceJob)
   - apps/cilium-lb.yaml
+  - apps/crowdsec.yaml
   - apps/traefik.yaml
   - apps/traefik-middlewares.yaml
   - apps/metrics-server.yaml


### PR DESCRIPTION
## Summary

- **CrowdSec** déployé dans namespace `crowdsec` (Helm chart 0.22.1)
  - LAPI: 1 replica, SQLite, PVC Synology iSCSI
  - Agent DaemonSet: acquisition logs depuis pods `traefik-*`
  - Collections: `crowdsecurity/traefik crowdsecurity/http-cve crowdsecurity/base-http-scenarios`
- **Traefik**: plugin `crowdsec-bouncer-traefik-plugin v1.5.1` + middleware `bouncer` global sur websecure
- **Sécurité**: clé bouncer dans Infisical `/apps/00-infra/crowdsec`, montée en fichier dans Traefik (pas de credentials en git)
- **IPs réelles**: `externalTrafficPolicy: Local` sur le service Traefik prod

## Architecture

```
Internet → Traefik (externalTrafficPolicy: Local) 
  → middleware bouncer (stream mode, cache local 60s)
    → CrowdSec LAPI :8080
      ← Agent lit logs traefik-* pods
```

Closes #2222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated CrowdSec threat detection and automated response system
  * Added reverse proxy plugin for dynamic request filtering based on threat detection
  * Configured automatic secret synchronization across development and production environments
  * Enabled environment-specific deployment configurations

* **Chores**
  * Added operational documentation for credentials management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->