### PR TITLE
fix(crowdsec): storageClass + disable agent

### DIFF
--- a/apps/00-infra/crowdsec/values/common.yaml
+++ b/apps/00-infra/crowdsec/values/common.yaml
@@ -33,11 +33,11 @@ lapi:
     data:
       enabled: true
       size: 1Gi
-      storageClassName: synology-iscsi-retain
+      storageClassName: synelia-iscsi-retain
     config:
       enabled: true
       size: 100Mi
-      storageClassName: synology-iscsi-retain
+      storageClassName: synelia-iscsi-retain
 
   strategy:
     type: Recreate  # required with RWO PVC
@@ -50,31 +50,11 @@ lapi:
       cpu: 500m
       memory: 512Mi
 
-# ============================================================================
-# Agent (DaemonSet) - log acquisition from Traefik
-# ============================================================================
 agent:
-  enabled: true
-
-  acquisition:
-    - namespace: traefik
-      podName: traefik-*
-      program: traefik
-
-  env:
-    - name: COLLECTIONS
-      value: "crowdsecurity/traefik crowdsecurity/http-cve crowdsecurity/base-http-scenarios"
-
-  resources:
-    requests:
-      cpu: 50m
-      memory: 64Mi
-    limits:
-      cpu: 200m
-      memory: 256Mi
+  enabled: false
 
 # ============================================================================
-# CrowdSec config
+# LAPI config
 # ============================================================================
 config:
   profiles.yaml: |


### PR DESCRIPTION
Fix deux problèmes découverts au déploiement:
- StorageClass `synology-iscsi-retain` → `synelia-iscsi-retain` (nom correct)
- Agent DaemonSet désactivé: hostPath volumes bloqués par PodSecurity baseline. LAPI seul avec CAPI sync (threat intel communautaire) suffit pour bloquer les IPs malveillantes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated storage configuration for data persistence
  * Disabled CrowdSec agent component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->