### PR TITLE
fix(crowdsec): config PVC 1Gi minimum for Synology iSCSI

### DIFF
--- a/apps/00-infra/crowdsec/values/common.yaml
+++ b/apps/00-infra/crowdsec/values/common.yaml
@@ -36,7 +36,7 @@ lapi:
       storageClassName: synelia-iscsi-retain
     config:
       enabled: true
-      size: 100Mi
+      size: 1Gi
       storageClassName: synelia-iscsi-retain
 
   strategy:


### PR DESCRIPTION
Synology iSCSI CSI requires minimum 1G — config PVC was 100Mi.