### PR TITLE
fix(traefik): correct volumes format for chart v25

### DIFF
--- a/apps/00-infra/traefik/values/common.yaml
+++ b/apps/00-infra/traefik/values/common.yaml
@@ -130,13 +130,8 @@ experimental:
 
 volumes:
   - name: crowdsec-bouncer-key
-    secret:
-      secretName: crowdsec-bouncer-key
-
-additionalVolumeMounts:
-  - name: crowdsec-bouncer-key
     mountPath: /var/run/secrets/crowdsec
-    readOnly: true
+    type: secret
 
 deployment:
   podAnnotations:


### PR DESCRIPTION
Chart v25 uses a custom volumes format combining volume+mountPath in a single entry with `type: secret`. Fix the `additionalVolumeMounts` approach which produced empty mountPaths.