### PR TITLE
fix(traefik): load crowdsec plugin via additionalArguments

### DIFF
--- a/apps/00-infra/traefik/values/common.yaml
+++ b/apps/00-infra/traefik/values/common.yaml
@@ -119,15 +119,6 @@ securityContext:
 # ============================================================================
 # Fast-start bypass (traefik starts in < 10s)
 # ============================================================================
-# ============================================================================
-# CrowdSec Bouncer plugin
-# ============================================================================
-experimental:
-  plugins:
-    bouncer:
-      moduleName: "github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin"
-      version: "v1.5.1"
-
 volumes:
   - name: crowdsec-bouncer-key
     mountPath: /var/run/secrets/crowdsec

--- a/apps/00-infra/traefik/values/prod.yaml
+++ b/apps/00-infra/traefik/values/prod.yaml
@@ -30,6 +30,8 @@ resources:
     memory: 2Gi
 # High availability with multiple replicas
 additionalArguments:
+  - "--experimental.plugins.bouncer.moduleName=github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin"
+  - "--experimental.plugins.bouncer.version=v1.5.1"
   - "--entrypoints.websecure.http.middlewares=traefik-bouncer@kubernetescrd"
 
 deployment:


### PR DESCRIPTION
## 🚨 Incident critique — cluster HTTPS entièrement en 404

### Cause racine
Le bloc `experimental.plugins` dans `common.yaml` n'était pas rendu en args CLI par le Helm chart v25. Résultat: Traefik démarre sans les args `--experimental.plugins.bouncer.*`, le middleware `traefik-bouncer@kubernetescrd` est inconnu, et **toutes les routes websecure retournent 404**.

Erreur Traefik:
```
plugin: unknown plugin type: bouncer
```

### Fix
- Déplace la config du plugin CrowdSec vers `additionalArguments` dans `prod.yaml` (format fiable)
- Supprime le bloc `experimental.plugins` de `common.yaml` (ne fonctionnait pas)

### Impact
Restaure l'accès HTTPS à tous les services (ArgoCD, Grafana, mail.truxonline.com, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized Traefik security configuration to be environment-specific, moving protection plugin settings to production-only deployment. This enables tailored threat protection for production while maintaining flexible shared configurations for other environments.

* **Chores**
  * Updated infrastructure configuration file organization for improved environment separation and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->