### PR TITLE
fix(traefik): disable bouncer middleware + add plugins-storage emptyDir

### DIFF
--- a/apps/00-infra/traefik/values/common.yaml
+++ b/apps/00-infra/traefik/values/common.yaml
@@ -123,6 +123,9 @@ volumes:
   - name: crowdsec-bouncer-key
     mountPath: /var/run/secrets/crowdsec
     type: secret
+  - name: plugins-storage
+    mountPath: /plugins-storage
+    type: emptyDir
 
 deployment:
   podAnnotations:

--- a/apps/00-infra/traefik/values/prod.yaml
+++ b/apps/00-infra/traefik/values/prod.yaml
@@ -32,7 +32,9 @@ resources:
 additionalArguments:
   - "--experimental.plugins.bouncer.moduleName=github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin"
   - "--experimental.plugins.bouncer.version=v1.5.1"
-  - "--entrypoints.websecure.http.middlewares=traefik-bouncer@kubernetescrd"
+  # traefik-bouncer@kubernetescrd disabled: plugin storage read-only filesystem
+  # TODO: mount emptyDir at /plugins-storage, then re-enable:
+  # - "--entrypoints.websecure.http.middlewares=traefik-bouncer@kubernetescrd"
 
 deployment:
   replicas: 2


### PR DESCRIPTION
## 🚨 Fix suite incident HTTPS cluster

### Problème
Le filesystem read-only de Traefik empêche le téléchargement du plugin CrowdSec bouncer vers `/plugins-storage` :
```
Plugins are disabled because an error has occurred.
error: unable to create directory /plugins-storage/sources: mkdir plugins-storage: read-only file system
```

### Fix
1. **Désactive temporairement** le middleware `traefik-bouncer@kubernetescrd` comme default websecure (les routes HTTPS ne fonctionnent plus sans plugin)
2. **Ajoute un volume emptyDir** à `/plugins-storage` pour permettre le téléchargement du plugin au prochain démarrage

### TODO (PR suivant)
Une fois confirmé que le plugin se télécharge correctement avec l'emptyDir, re-activer :
```yaml
- "--entrypoints.websecure.http.middlewares=traefik-bouncer@kubernetescrd"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added plugin storage volume to Traefik deployment.
  * Temporarily disabled bouncer middleware in production pending storage configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->