### PR TITLE
feat(crowdsec): enroll in CrowdSec Console

### DIFF
--- a/apps/00-infra/crowdsec/values/common.yaml
+++ b/apps/00-infra/crowdsec/values/common.yaml
@@ -24,6 +24,11 @@ lapi:
         secretKeyRef:
           name: crowdsec-secrets
           key: CROWDSEC_BOUNCER_KEY
+    - name: ENROLL_KEY
+      valueFrom:
+        secretKeyRef:
+          name: crowdsec-secrets
+          key: ENROLL_KEY
     - name: ENROLL_INSTANCE_NAME
       value: "vixens-k8s"
     - name: ENROLL_TAGS


### PR DESCRIPTION
Add ENROLL_KEY from Infisical to register the LAPI instance on app.crowdsec.net.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced infrastructure security by implementing credential management for enrollment authentication. Configuration now integrates Kubernetes secrets to protect sensitive credentials, ensuring proper storage and access control in accordance with cloud-native security best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->