### PR TITLE
fix(traefik): plugins-storage writable + bouncer middleware re-enabled

### DIFF
--- a/apps/00-infra/traefik/values/common.yaml
+++ b/apps/00-infra/traefik/values/common.yaml
@@ -126,6 +126,7 @@ volumes:
   - name: plugins-storage
     mountPath: /plugins-storage
     type: emptyDir
+    readOnly: false
 
 deployment:
   podAnnotations:

--- a/apps/00-infra/traefik/values/prod.yaml
+++ b/apps/00-infra/traefik/values/prod.yaml
@@ -32,9 +32,7 @@ resources:
 additionalArguments:
   - "--experimental.plugins.bouncer.moduleName=github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin"
   - "--experimental.plugins.bouncer.version=v1.5.1"
-  # traefik-bouncer@kubernetescrd disabled: plugin storage read-only filesystem
-  # TODO: mount emptyDir at /plugins-storage, then re-enable:
-  # - "--entrypoints.websecure.http.middlewares=traefik-bouncer@kubernetescrd"
+  - "--entrypoints.websecure.http.middlewares=traefik-bouncer@kubernetescrd"
 
 deployment:
   replicas: 2


### PR DESCRIPTION
plugins-storage emptyDir mounted readOnly:true (chart v25 default). Set readOnly:false so Traefik can download the CrowdSec plugin. Re-enable global websecure bouncer middleware.