### PR TITLE
fix(traefik): plugins-storage writable emptyDir via additionalVolumes

### DIFF
--- a/apps/00-infra/traefik/values/common.yaml
+++ b/apps/00-infra/traefik/values/common.yaml
@@ -123,12 +123,15 @@ volumes:
   - name: crowdsec-bouncer-key
     mountPath: /var/run/secrets/crowdsec
     type: secret
+
+additionalVolumeMounts:
   - name: plugins-storage
     mountPath: /plugins-storage
-    type: emptyDir
-    readOnly: false
 
 deployment:
+  additionalVolumes:
+    - name: plugins-storage
+      emptyDir: {}
   podAnnotations:
     vixens.io/fast-start: "true"
     vixens.io/service-binding: "false"


### PR DESCRIPTION
chart v25 volumes: list forces readOnly:true on all mounts. Use deployment.additionalVolumes + additionalVolumeMounts instead (no readOnly = writable by default).