### PR TITLE
fix(netbird): correct ingress ports for dashboard and signal

### DIFF
--- a/apps/40-network/netbird/overlays/prod/ingress.yaml
+++ b/apps/40-network/netbird/overlays/prod/ingress.yaml
@@ -26,7 +26,7 @@ spec:
               service:
                 name: netbird-dashboard
                 port:
-                  number: 33073
+                  number: 80
   tls:
     - hosts:
         - netbird.truxonline.com
@@ -84,7 +84,7 @@ spec:
               service:
                 name: netbird-signal
                 port:
-                  number: 33073
+                  number: 80
   tls:
     - hosts:
         - netbird-signal.truxonline.com


### PR DESCRIPTION
dashboard and signal services expose port 80, not 33073. Fixes 'service port not found' errors in Traefik logs.

Closes #2259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated backend service port mappings for netbird-dashboard and netbird-signal services to improve network routing and service connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->