### PR TITLE
fix(netbird): correct NetworkPolicy ports

### DIFF
--- a/apps/40-network/netbird/base/networkpolicy-netbird-management.yaml
+++ b/apps/40-network/netbird/base/networkpolicy-netbird-management.yaml
@@ -18,7 +18,9 @@ spec:
               kubernetes.io/metadata.name: traefik
       ports:
         - protocol: TCP
-          port: 80
+          port: 8080
+        - protocol: TCP
+          port: 33073
   egress:
     # Allow all egress (homelab: DNS, inter-app, external APIs)
     - {}

--- a/apps/40-network/netbird/base/networkpolicy.yaml
+++ b/apps/40-network/netbird/base/networkpolicy.yaml
@@ -18,7 +18,7 @@ spec:
               kubernetes.io/metadata.name: traefik
       ports:
         - protocol: TCP
-          port: 80
+          port: 8080
   egress:
     # Allow all egress (homelab: DNS, inter-app, external APIs)
     - {}


### PR DESCRIPTION
dashboard nginx listens on 8080 (not 80), management on 8080+33073 (not 80).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network policy port configurations for netbird services
  * netbird-management service: inbound traffic ports changed from 80 to 8080 and 33073
  * netbird-dashboard service: inbound traffic port changed from 80 to 8080

<!-- end of auto-generated comment: release notes by coderabbit.ai -->