### PR TITLE
feat(vpa): prometheus + vmsingle → V-* sizing (InPlaceOrRecreate)

### DIFF
--- a/apps/02-monitoring/prometheus/base/values.yaml
+++ b/apps/02-monitoring/prometheus/base/values.yaml
@@ -5,7 +5,7 @@
 server:
   priorityClassName: vixens-critical
   podLabels:
-    vixens.io/sizing.prometheus-server: "SB-xlarge"
+    vixens.io/sizing.prometheus-server: "V-xlarge"
   podAnnotations:
     vixens.io/fast-start: "true"
     prometheus.io/scrape: "true"

--- a/apps/02-monitoring/victoria-metrics/base/values.yaml
+++ b/apps/02-monitoring/victoria-metrics/base/values.yaml
@@ -43,7 +43,7 @@ vmsingle:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8429"
       labels:
-        vixens.io/sizing.vmsingle: G-large
+        vixens.io/sizing.vmsingle: V-large
     priorityClassName: vixens-critical
 
 # --- VMAgent (scraper, replaces prometheus scraping) ---


### PR DESCRIPTION
Migrate from SB-/G- (Goldilocks recommend-only) to V-* (InPlaceOrRecreate) for prometheus-server and vmsingle. Kyverno will update the VPAs from Auto→InPlaceOrRecreate.

Closes #2559

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated monitoring infrastructure pod sizing configurations for Prometheus and Victoria Metrics deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->