### PR TITLE
fix(nexterm): remove sync-wave (WaitForFirstConsumer PVC deadlock)

### DIFF
--- a/apps/70-tools/nexterm/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/nexterm/overlays/prod/kustomization.yaml
@@ -7,6 +7,5 @@ resources:
 patches:
   - path: patch-infisical-secret.yaml
 components:
-  - ../../../../_shared/components/sync-wave/wave-3
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/infisical/env-prod


### PR DESCRIPTION
sync-wave/wave-3 on Deployment + wave-0 PVC creates deadlock with WaitForFirstConsumer storage class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a shared component reference from the production deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->