### PR TITLE
fix(nexterm): correct image tag to :latest

### DIFF
--- a/apps/70-tools/nexterm/base/deployment.yaml
+++ b/apps/70-tools/nexterm/base/deployment.yaml
@@ -29,8 +29,8 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: nexterm
-          image: nexterm/aio:v1.2.0-BETA
-          imagePullPolicy: IfNotPresent
+          image: nexterm/aio:latest
+          imagePullPolicy: Always
           ports:
             - containerPort: 6989
               name: http


### PR DESCRIPTION
v1.2.0-BETA not available on Docker Hub, only :latest and :development.