### PR TITLE
fix(nexterm): use :development image tag

### DIFF
--- a/apps/70-tools/nexterm/base/deployment.yaml
+++ b/apps/70-tools/nexterm/base/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: nexterm
-          image: nexterm/aio:latest
+          image: nexterm/aio:development
           imagePullPolicy: Always
           ports:
             - containerPort: 6989


### PR DESCRIPTION
Only available tag on Docker Hub for nexterm/aio is :development.