### PR TITLE
fix(crowdsec): allowLocalRequests=true for LAN access

### DIFF
--- a/apps/00-infra/traefik/base/middleware-crowdsec-bouncer.yaml
+++ b/apps/00-infra/traefik/base/middleware-crowdsec-bouncer.yaml
@@ -15,3 +15,4 @@ spec:
       forwardedHeadersTrustedIPs: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
       updateIntervalSeconds: "60"
       defaultDecisionSeconds: "60"
+      allowLocalRequests: "true"


### PR DESCRIPTION
RFC1918 IPs (192.168.x.x, 10.x.x.x) were getting 403 from CrowdSec bouncer. Adding allowLocalRequests:true bypasses the bouncer check for private IPs — correct behavior for homelab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the security middleware configuration to allow local network requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->