### PR TITLE
fix(crowdsec): disable PAPI/community blocklist, fix bouncer clientTrustedIps

### DIFF
--- a/apps/00-infra/crowdsec/values/common.yaml
+++ b/apps/00-infra/crowdsec/values/common.yaml
@@ -24,15 +24,7 @@ lapi:
         secretKeyRef:
           name: crowdsec-secrets
           key: CROWDSEC_BOUNCER_KEY
-    - name: ENROLL_KEY
-      valueFrom:
-        secretKeyRef:
-          name: crowdsec-secrets
-          key: ENROLL_KEY
-    - name: ENROLL_INSTANCE_NAME
-      value: "vixens-k8s"
-    - name: ENROLL_TAGS
-      value: "k8s linux homelab"
+    # ENROLL_KEY removed: PAPI/community blocklist disabled (DB too large → stream timeout)
 
   persistentVolume:
     data:

--- a/apps/00-infra/traefik/base/middleware-crowdsec-bouncer.yaml
+++ b/apps/00-infra/traefik/base/middleware-crowdsec-bouncer.yaml
@@ -12,7 +12,8 @@ spec:
       crowdsecLapiScheme: http
       crowdsecLapiHost: crowdsec-service.crowdsec.svc.cluster.local:8080
       crowdsecLapiKeyFile: /var/run/secrets/crowdsec/CROWDSEC_BOUNCER_KEY
-      forwardedHeadersTrustedIPs: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+      forwardedHeadersTrustedIps: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+      clientTrustedIps: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
       updateIntervalSeconds: "60"
       defaultDecisionSeconds: "60"
-      allowLocalRequests: "true"
+      updateMaxFailure: "-1"


### PR DESCRIPTION
## Problem

CrowdSec LAPI had PAPI (Central API) enabled, pulling the community blocklist (millions of IPs).
This caused SQLite \`QueryAllDecisionsWithFilters\` to timeout (>10s) on every stream request.
Result: bouncer stream = 500 → \`isCrowdsecStreamHealthy = false\` → **all services returning 403**.

## Root Cause

1. \`ENROLL_KEY\` env var triggered CAPI enrollment on startup
2. PAPI pulled community ban lists into SQLite DB
3. \`/v1/decisions/stream\` query on large table → 10s timeout → 500
4. Bouncer plugin: stream fail → fail-closed → blocks ALL traffic

## Fix

- Remove \`ENROLL_KEY\` from LAPI env: no more CAPI enrollment = no community blocklist
- \`online_api_credentials.yaml\` already deleted from config PVC
- Replace non-existent \`allowLocalRequests\` with correct \`clientTrustedIps\` (RFC1918 bypass)
- Add \`updateMaxFailure: -1\` for fail-open behavior (LAN homelab, no public exposure)
- Fix JSON tag: \`forwardedHeadersTrustedIPs\` → \`forwardedHeadersTrustedIps\`

## Closes
Closes #2289 (nexterm now accessible)