### PR TITLE
fix(traefik): externalTrafficPolicy Local→Cluster (incompatible avec Cilium L2 Announcement)

### DIFF
--- a/apps/00-infra/traefik/values/prod.yaml
+++ b/apps/00-infra/traefik/values/prod.yaml
@@ -10,7 +10,7 @@ service:
   annotations:
     io.cilium/lb-ipam-ips: 192.168.201.70
   spec:
-    externalTrafficPolicy: Local
+    externalTrafficPolicy: Cluster
 # ============================================================================
 # Production-Specific Settings
 # ============================================================================


### PR DESCRIPTION
## Problem

All external services timing out after Traefik pod restarts.

Cilium L2 Announcement holds a lease to advertise the VIP `192.168.201.70` via ARP. The lease holder (`poison`) had no Traefik pod running. With `externalTrafficPolicy: Local`, only nodes with local endpoints accept traffic → all connections timeout.

## Root Cause

`externalTrafficPolicy: Local` is **incompatible** with Cilium L2 Announcement. The lease election doesn't consider which node has local endpoints — any node can win. When a node without Traefik holds the ARP lease, external traffic is dropped.

## Fix

Change `externalTrafficPolicy: Cluster`. Cilium SNAT forwards traffic from any node to Traefik pods. The L2 lease holder doesn't matter anymore.

## Trade-off

Source IP is SNATed (becomes node IP instead of client IP). Mitigated by `clientTrustedIps: RFC1918` in CrowdSec bouncer config — all LAN traffic is trusted anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified Traefik load balancer configuration to update external traffic routing policy, changing how incoming requests are distributed to application endpoints across the infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->