### PR TITLE
chore(amule): migrer tchabaud/amule → ngosang/amule:2.3.3-20

### DIFF
--- a/apps/20-media/amule/base/deployment.yaml
+++ b/apps/20-media/amule/base/deployment.yaml
@@ -39,7 +39,7 @@ spec:
             limits:
               cpu: 100m
               memory: 1Gi
-          image: tchabaud/amule@sha256:66351396337f50b40613222c5c47adfbc8685eb631b38e73f217358f54182d64
+          image: ngosang/amule:2.3.3-20
           ports:
             - containerPort: 4711
               name: http


### PR DESCRIPTION
Closes #2588

Image \`tchabaud/amule\` abandonnée depuis juin 2021. Migration vers \`ngosang/amule:2.3.3-20\` — successeur communautaire, 500K+ pulls, maintenu activement (dernière update oct 2025).

**Compatibilité** : drop-in replacement — mêmes env vars, même chemin config \`/home/amule/.aMule\`, même port WebUI 4711. Aucune migration de données nécessaire.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated amule container image to version 2.3.3-20.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->