### PR TITLE
feat(networking): Phase 1+2 CiliumNetworkPolicy migration (#2623)

### DIFF
--- a/.opencode/napkin.md
+++ b/.opencode/napkin.md
@@ -198,9 +198,27 @@ Do instead: TOUJOURS utiliser le pattern fix-run-dir pour les images LSIO/s6-ove
 
 ---
 
+## 🛡️ CrowdSec Bouncer Gotchas (Priority 2)
+
+1. **[2026-04-01] PAPI community blocklist → SQLite timeout → all 403 (fail-closed)**
+   CrowdSec LAPI pulls millions of community IPs via PAPI → `QueryAllDecisionsWithFilters` >10s → stream 500 → `isCrowdsecStreamHealthy=false` → bouncer blocks ALL traffic.
+   Do instead: Remove `ENROLL_KEY` from LAPI env to disable CAPI. Also set `updateMaxFailure: "-1"` (fail-open) and `clientTrustedIps: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"` in middleware.
+
+2. **[2026-04-01] `allowLocalRequests` does NOT exist in crowdsec-bouncer-traefik-plugin v1.5.x**
+   The field was never in the Config struct. Use `clientTrustedIps` (JSON tag: `clientTrustedIps`) instead. Trusted IPs bypass ALL bouncer checks including `isCrowdsecStreamHealthy=false`.
+   Do instead: `clientTrustedIps: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"` in Middleware CRD.
+
+3. **[2026-04-01] CrowdSec SQLite DB corrupt/slow → delete and restart LAPI**
+   If `QueryAllDecisionsWithFilters: context canceled` persists after restart, the DB is too large or corrupt.
+   Do instead: `kubectl exec -n crowdsec <pod> -- rm /var/lib/crowdsec/data/crowdsec.db` then `kubectl rollout restart deployment crowdsec-lapi -n crowdsec`. Also delete `online_api_credentials.yaml` to prevent PAPI re-pull.
+
 ## 🏗️ Infrastructure Patterns (Priority 2)
 
-1. **[2026-03-28] Cilium eBPF egress cassé après incident nœud**
+1. **[2026-04-01] Cilium L2 Announcement incompatible avec externalTrafficPolicy:Local**
+   Lease holder ARP peut être un nœud SANS pod local → trafic droppé → connexion timeout. Vérifier: `kubectl get lease -n kube-system cilium-l2announce-<svc>-<ns>` — si holder n'a pas de pod, supprimer le lease OU passer à Cluster.
+   Do instead: toujours `externalTrafficPolicy: Cluster` avec Cilium L2 Announcement. SNAT Cilium forward vers pods correctement depuis n'importe quel nœud.
+
+2. **[2026-03-28] Cilium eBPF egress cassé après incident nœud**
    Symptôme: pod sur le nœud ne peut plus joindre internet (context deadline exceeded), les autres nœuds OK.
    Do instead: `kubectl -n kube-system delete pod $(kubectl -n kube-system get pod -l k8s-app=cilium --field-selector spec.nodeName=<NODE> -o jsonpath='{.items[0].metadata.name}')` — le nouveau pod réinitialise l'eBPF state.
 

--- a/apps/00-infra/cilium-lb/base/ccnp-default-deny.yaml
+++ b/apps/00-infra/cilium-lb/base/ccnp-default-deny.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: default-deny-baseline
+spec:
+  endpointSelector:
+    matchExpressions:
+      - key: io.kubernetes.pod.namespace
+        operator: NotIn
+        values:
+          - kube-system
+          - cilium-secrets
+          - cert-manager
+          - argocd
+          - infisical-operator-system
+          - snapshot-controller
+          - velero
+  enableDefaultDeny:
+    ingress: false
+    egress: false

--- a/apps/00-infra/cilium-lb/base/kustomization.yaml
+++ b/apps/00-infra/cilium-lb/base/kustomization.yaml
@@ -10,5 +10,6 @@ commonLabels:
 resources:
   - ippool.yaml
   - l2policy.yaml
+  - ccnp-default-deny.yaml
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/02-monitoring/loki/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/loki/base/cilium-networkpolicy.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: loki
+spec:
+  endpointSelector:
+    matchLabels:
+      app: loki
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "3100"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/02-monitoring/loki/base/kustomization.yaml
+++ b/apps/02-monitoring/loki/base/kustomization.yaml
@@ -8,4 +8,5 @@ resources:
   - configmap.yaml
   - infisical-secret.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
   - pdb.yaml

--- a/apps/03-security/authentik/base/cilium-networkpolicy.yaml
+++ b/apps/03-security/authentik/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: authentik-server
+spec:
+  endpointSelector:
+    matchLabels:
+      app: authentik-server
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/03-security/authentik/base/kustomization.yaml
+++ b/apps/03-security/authentik/base/kustomization.yaml
@@ -13,4 +13,5 @@ resources:
   - middleware-forward-auth.yaml
   - servicemonitor.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
   - networkpolicy-authentik-worker.yaml

--- a/apps/04-databases/mariadb-shared/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/mariadb-shared/base/cilium-networkpolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: mariadb-shared
+spec:
+  endpointSelector:
+    matchLabels:
+      app: mariadb-shared
+  ingress:
+    - fromEndpoints:
+        - {}
+      toPorts:
+        - ports:
+            - port: "3306"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/04-databases/mariadb-shared/base/kustomization.yaml
+++ b/apps/04-databases/mariadb-shared/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - statefulset.yaml
   - service.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/04-databases/redis-shared/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/redis-shared/base/cilium-networkpolicy.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: redis-shared
+spec:
+  endpointSelector:
+    matchLabels:
+      app: redis-shared
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: auth
+        - matchLabels:
+            io.kubernetes.pod.namespace: tools
+        - matchLabels:
+            io.kubernetes.pod.namespace: networking
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/04-databases/redis-shared/base/kustomization.yaml
+++ b/apps/04-databases/redis-shared/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - service.yaml
   - redis-credentials.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/10-home/homeassistant/base/cilium-networkpolicy.yaml
+++ b/apps/10-home/homeassistant/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: homeassistant
+spec:
+  endpointSelector:
+    matchLabels:
+      app: homeassistant
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "8123"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/10-home/homeassistant/base/kustomization.yaml
+++ b/apps/10-home/homeassistant/base/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - vpa.yaml
   - servicemonitor.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/10-home/mealie/base/cilium-networkpolicy.yaml
+++ b/apps/10-home/mealie/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: mealie
+spec:
+  endpointSelector:
+    matchLabels:
+      app: mealie
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/10-home/mealie/base/kustomization.yaml
+++ b/apps/10-home/mealie/base/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - pvc.yaml
 
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/10-home/mosquitto/base/cilium-networkpolicy.yaml
+++ b/apps/10-home/mosquitto/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: mosquitto
+spec:
+  endpointSelector:
+    matchLabels:
+      app: mosquitto
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: homeassistant
+      toPorts:
+        - ports:
+            - port: "1883"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/10-home/mosquitto/base/kustomization.yaml
+++ b/apps/10-home/mosquitto/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - statefulset.yaml
   - service.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: mosquitto

--- a/apps/20-media/booklore/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/booklore/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: booklore
+spec:
+  endpointSelector:
+    matchLabels:
+      app: booklore
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "6060"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/booklore/base/kustomization.yaml
+++ b/apps/20-media/booklore/base/kustomization.yaml
@@ -8,4 +8,5 @@ resources:
   - pvc.yaml
   - infisical-secret.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
   - pdb.yaml

--- a/apps/20-media/bookshelf/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/bookshelf/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: bookshelf
+spec:
+  endpointSelector:
+    matchLabels:
+      app: bookshelf
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "8787"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/bookshelf/base/kustomization.yaml
+++ b/apps/20-media/bookshelf/base/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - service.yaml
   - pvc.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/20-media/frigate/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/frigate/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: frigate
+spec:
+  endpointSelector:
+    matchLabels:
+      app: frigate
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/frigate/base/kustomization.yaml
+++ b/apps/20-media/frigate/base/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - configmap.yaml
   - pdb.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
   - infisical-secret.yaml
   - litestream-config.yaml
   - servicemonitor.yaml

--- a/apps/20-media/hydrus-client/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/hydrus-client/base/cilium-networkpolicy.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: hydrus-client
+spec:
+  endpointSelector:
+    matchLabels:
+      app: hydrus-client
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "5800"
+              protocol: TCP
+            - port: "45869"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/hydrus-client/base/kustomization.yaml
+++ b/apps/20-media/hydrus-client/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - pvc.yaml
   - pdb.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
   - infisical-secret.yaml
   - litestream-config.yaml
   - servicemonitor.yaml

--- a/apps/20-media/jellyfin/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/jellyfin/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: jellyfin
+spec:
+  endpointSelector:
+    matchLabels:
+      app: jellyfin
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "8096"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/jellyfin/base/kustomization.yaml
+++ b/apps/20-media/jellyfin/base/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - service.yaml
   - pvc.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/20-media/jellyseerr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/jellyseerr/base/cilium-networkpolicy.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: jellyseerr
+spec:
+  endpointSelector:
+    matchLabels:
+      app: jellyseerr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+        - matchLabels:
+            io.kubernetes.pod.namespace: keda
+      toPorts:
+        - ports:
+            - port: "5055"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/jellyseerr/base/kustomization.yaml
+++ b/apps/20-media/jellyseerr/base/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - service.yaml
   - pvc.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/20-media/lazylibrarian/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/lazylibrarian/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: lazylibrarian
+spec:
+  endpointSelector:
+    matchLabels:
+      app: lazylibrarian
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "5299"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/lazylibrarian/base/kustomization.yaml
+++ b/apps/20-media/lazylibrarian/base/kustomization.yaml
@@ -10,5 +10,6 @@ resources:
   - litestream-config.yaml
   - servicemonitor.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/20-media/lidarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/lidarr/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: lidarr
+spec:
+  endpointSelector:
+    matchLabels:
+      app: lidarr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "8686"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/lidarr/base/kustomization.yaml
+++ b/apps/20-media/lidarr/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - pvc.yaml
   - pdb.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
   - infisical-secret.yaml
   - litestream-config.yaml
   - servicemonitor.yaml

--- a/apps/20-media/music-assistant/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/music-assistant/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: music-assistant
+spec:
+  endpointSelector:
+    matchLabels:
+      app: music-assistant
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "8095"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/music-assistant/base/kustomization.yaml
+++ b/apps/20-media/music-assistant/base/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
   - pvc.yaml
   - ingressroute-slimproto.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/20-media/mylar/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/mylar/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: mylar
+spec:
+  endpointSelector:
+    matchLabels:
+      app: mylar
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "8090"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/mylar/base/kustomization.yaml
+++ b/apps/20-media/mylar/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - pvc.yaml
   - pdb.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
   - infisical-secret.yaml
   - litestream-config.yaml
   - servicemonitor.yaml

--- a/apps/20-media/prowlarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/prowlarr/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: prowlarr
+spec:
+  endpointSelector:
+    matchLabels:
+      app: prowlarr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "9696"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/prowlarr/base/kustomization.yaml
+++ b/apps/20-media/prowlarr/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - pvc.yaml
   - pdb.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
   - infisical-secret.yaml
   - litestream-config.yaml
   - servicemonitor.yaml

--- a/apps/20-media/radarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/radarr/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: radarr
+spec:
+  endpointSelector:
+    matchLabels:
+      app: radarr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "7878"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/radarr/base/kustomization.yaml
+++ b/apps/20-media/radarr/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - deployment.yaml
   - service.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
   - pdb.yaml
   - pvc.yaml
   - infisical-secret.yaml

--- a/apps/20-media/sabnzbd/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/sabnzbd/base/cilium-networkpolicy.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: sabnzbd
+spec:
+  endpointSelector:
+    matchLabels:
+      app: sabnzbd
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/sabnzbd/base/kustomization.yaml
+++ b/apps/20-media/sabnzbd/base/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - litestream-config.yaml
   - servicemonitor.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/20-media/sonarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/sonarr/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: sonarr
+spec:
+  endpointSelector:
+    matchLabels:
+      app: sonarr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "8989"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/sonarr/base/kustomization.yaml
+++ b/apps/20-media/sonarr/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - pvc.yaml
   - pdb.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
   - infisical-secret.yaml
   - litestream-config.yaml
   - servicemonitor.yaml

--- a/apps/20-media/whisparr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/whisparr/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: whisparr
+spec:
+  endpointSelector:
+    matchLabels:
+      app: whisparr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "6969"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/whisparr/base/kustomization.yaml
+++ b/apps/20-media/whisparr/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - pvc.yaml
   - pdb.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
   - infisical-secret.yaml
   - litestream-config.yaml
   - servicemonitor.yaml

--- a/apps/40-network/adguard-home/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/adguard-home/base/cilium-networkpolicy.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: adguard-home
+spec:
+  endpointSelector:
+    matchLabels:
+      app: adguard-home
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+            - port: "53"
+              protocol: TCP
+            - port: "53"
+              protocol: UDP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: TCP
+            - port: "53"
+              protocol: UDP
+  egress:
+    - {}

--- a/apps/40-network/adguard-home/base/kustomization.yaml
+++ b/apps/40-network/adguard-home/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - service.yaml
   - pdb.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
   - ingressroute-dns.yaml
   - infisical-secret.yaml
   - litestream-config.yaml

--- a/apps/40-network/netbird/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/netbird/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: netbird-dashboard
+spec:
+  endpointSelector:
+    matchLabels:
+      app: netbird-dashboard
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/40-network/netbird/base/kustomization.yaml
+++ b/apps/40-network/netbird/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - signal-relay.yaml
   - ca-bundle.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
   - networkpolicy-netbird-management.yaml
   - networkpolicy-netbird-signal.yaml
   - networkpolicy-netbird-relay.yaml

--- a/apps/40-network/netvisor/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/netvisor/base/cilium-networkpolicy.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: netvisor-server
+spec:
+  endpointSelector:
+    matchLabels:
+      app: netvisor-server
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+        - matchLabels:
+            io.kubernetes.pod.namespace: keda
+      toPorts:
+        - ports:
+            - port: "60072"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/40-network/netvisor/base/kustomization.yaml
+++ b/apps/40-network/netvisor/base/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - server-service.yaml
   - infisical-secret.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/60-services/docspell/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/docspell/base/cilium-networkpolicy.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: docspell
+spec:
+  endpointSelector:
+    matchLabels:
+      app: docspell
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+        - matchLabels:
+            io.kubernetes.pod.namespace: keda
+      toPorts:
+        - ports:
+            - port: "7880"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/60-services/docspell/base/kustomization.yaml
+++ b/apps/60-services/docspell/base/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - middleware-redirect.yaml
   - middleware.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
 labels:
   - pairs:
       app: docspell

--- a/apps/60-services/gluetun/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/gluetun/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: gluetun
+spec:
+  endpointSelector:
+    matchLabels:
+      app: gluetun
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "8888"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/60-services/gluetun/base/kustomization.yaml
+++ b/apps/60-services/gluetun/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/60-services/n8n/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/n8n/base/cilium-networkpolicy.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: n8n
+spec:
+  endpointSelector:
+    matchLabels:
+      app: n8n
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "5678"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: tools
+  egress:
+    - {}

--- a/apps/60-services/n8n/base/kustomization.yaml
+++ b/apps/60-services/n8n/base/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - service.yaml
   - pvc.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
   - infisical-secret.yaml
   - infisical-config.yaml

--- a/apps/60-services/openclaw/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/openclaw/base/cilium-networkpolicy.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: openclaw
+spec:
+  endpointSelector:
+    matchLabels:
+      app: openclaw
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "18789"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: tools
+    - fromEndpoints:
+        - matchLabels:
+            app: n8n
+            io.kubernetes.pod.namespace: services
+  egress:
+    - {}

--- a/apps/60-services/openclaw/base/kustomization.yaml
+++ b/apps/60-services/openclaw/base/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - infisical-secret.yaml
   - infisical-config.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/60-services/vaultwarden/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/vaultwarden/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: vaultwarden
+spec:
+  endpointSelector:
+    matchLabels:
+      app: vaultwarden
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/60-services/vaultwarden/base/kustomization.yaml
+++ b/apps/60-services/vaultwarden/base/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - litestream-config.yaml
   - servicemonitor.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/70-tools/changedetection/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/changedetection/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: changedetection
+spec:
+  endpointSelector:
+    matchLabels:
+      app: changedetection
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/70-tools/changedetection/base/kustomization.yaml
+++ b/apps/70-tools/changedetection/base/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - pvc.yaml
   - infisical-secret.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/70-tools/headlamp/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/headlamp/base/cilium-networkpolicy.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: headlamp
+spec:
+  endpointSelector:
+    matchLabels:
+      app: headlamp
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+        - matchLabels:
+            io.kubernetes.pod.namespace: keda
+      toPorts:
+        - ports:
+            - port: "4466"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/70-tools/headlamp/base/kustomization.yaml
+++ b/apps/70-tools/headlamp/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - infisical-secret.yaml
   - serviceaccount.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
   # vpa.yaml removed - Kyverno generates vixens-headlamp VPA via sizing-v2 label
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/70-tools/linkwarden/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/linkwarden/base/cilium-networkpolicy.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: linkwarden
+spec:
+  endpointSelector:
+    matchLabels:
+      app: linkwarden
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+        - matchLabels:
+            io.kubernetes.pod.namespace: keda
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/70-tools/linkwarden/base/kustomization.yaml
+++ b/apps/70-tools/linkwarden/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - deployment.yaml
   - service.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
 labels:
   - pairs:
       app: linkwarden

--- a/apps/70-tools/netbox/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/netbox/base/cilium-networkpolicy.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: netbox
+spec:
+  endpointSelector:
+    matchLabels:
+      app: netbox
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+        - matchLabels:
+            io.kubernetes.pod.namespace: keda
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/70-tools/netbox/base/kustomization.yaml
+++ b/apps/70-tools/netbox/base/kustomization.yaml
@@ -8,4 +8,5 @@ resources:
   - netbox-db-secrets.yaml
   - infisical-secret.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
   - plugins-config.yaml

--- a/apps/70-tools/penpot/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/penpot/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: penpot-backend
+spec:
+  endpointSelector:
+    matchLabels:
+      app: penpot-backend
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "6060"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/70-tools/penpot/base/kustomization.yaml
+++ b/apps/70-tools/penpot/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - service-ingress.yaml
   - infisical-secret.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
   - networkpolicy-penpot-exporter.yaml
   - networkpolicy-penpot-frontend.yaml
 components:

--- a/apps/99-test/whoami/base/cilium-networkpolicy.yaml
+++ b/apps/99-test/whoami/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: whoami
+spec:
+  endpointSelector:
+    matchLabels:
+      app: whoami
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+  egress:
+    - {}

--- a/apps/99-test/whoami/base/kustomization.yaml
+++ b/apps/99-test/whoami/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - service.yaml
   - pdb.yaml
   - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
 components:
   - ../../../_shared/components/revision-history-limit
   - ../../../_shared/components/base


### PR DESCRIPTION
## Summary

Migration des 36 NetworkPolicies K8s vers CiliumNetworkPolicy en approche progressive **sans bascule**.

### Phase 1 — Conversion en parallèle (zéro risque)
- 36 `CiliumNetworkPolicy` ajoutées **à côté** des K8s NPs existantes
- Sémantique OR de Cilium = K8s NP reste le filet de sécurité
- Patterns convertis: namespaceSelector→fromEndpoints, matchExpressions→multi-fromEndpoints, podSelector{}→namespace label, ports int→string

### Phase 2 — CCNP baseline avec audit mode
- `CiliumClusterwideNetworkPolicy default-deny-baseline` déployée avec `enableDefaultDeny: false`
- Sélectionne tous les endpoints non-système mais **n'active pas encore** le default-deny
- Prête à basculer en Phase 3 en changeant `false → true`

### Phase 3 (future, issue séparée)
1. Valider CNPs via Hubble: `hubble observe flows -t policy-verdict`
2. Ajouter CNPs pour les apps sans NP (nocodb, trilium, firefly-iii...)
3. Activer PolicyAuditMode: `kubectl patch -n kube-system configmap cilium-config --type merge --patch '{"data":{"policy-audit-mode":"true"}}'`
4. Changer `enableDefaultDeny: false → true`
5. Observer 48h → désactiver audit mode → supprimer K8s NPs

Closes #2623

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cilium NetworkPolicies across multiple services to enforce explicit network segmentation and traffic control rules between application pods.

* **Documentation**
  * Enhanced operational troubleshooting guides for CrowdSec Bouncer configuration and failure scenarios.
  * Updated Cilium network guidance with improved compatibility notes and recommended configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->