### PR TITLE
fix(cilium): CCNP requires ingress/egress rules (CRD validation)

### DIFF
--- a/apps/00-infra/cilium-lb/base/ccnp-default-deny.yaml
+++ b/apps/00-infra/cilium-lb/base/ccnp-default-deny.yaml
@@ -19,3 +19,7 @@ spec:
   enableDefaultDeny:
     ingress: false
     egress: false
+  ingress:
+    - {}
+  egress:
+    - {}


### PR DESCRIPTION
The CiliumClusterwideNetworkPolicy CRD requires at least one ingress or egress rule even with enableDefaultDeny: false. Added allow-all rules which are no-ops given enableDefaultDeny: false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network policy configuration to include explicit ingress and egress rule definitions, improving clarity and consistency in how network traffic is handled across the cluster infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->