### PR TITLE
fix(crowdsec): initContainer pour écrire db_config PostgreSQL sans env var expansion

### DIFF
--- a/apps/00-infra/crowdsec/values/common.yaml
+++ b/apps/00-infra/crowdsec/values/common.yaml
@@ -62,16 +62,6 @@ agent:
 # LAPI config
 # ============================================================================
 config:
-  config.yaml.local: |
-    db_config:
-      type: postgresql
-      user: crowdsec
-      password: ${CROWDSEC_DB_PASSWORD}
-      db_name: crowdsec
-      host: postgresql-shared-rw.databases.svc.cluster.local
-      port: 5432
-      sslmode: disable
-
   profiles.yaml: |
     name: default_ip_remediation
     filters:

--- a/apps/00-infra/crowdsec/values/prod.yaml
+++ b/apps/00-infra/crowdsec/values/prod.yaml
@@ -10,3 +10,22 @@ lapi:
       value: "vixens-k8s-prod"
     - name: ENROLL_TAGS
       value: "k8s linux homelab prod"
+
+  extraInitContainers:
+    - name: write-db-config
+      image: busybox:1.37.0
+      command:
+        - sh
+        - -c
+        - |
+          printf 'db_config:\n  type: postgresql\n  user: crowdsec\n  password: %s\n  db_name: crowdsec\n  host: postgresql-shared-rw.databases.svc.cluster.local\n  port: 5432\n  sslmode: disable\n' "$CROWDSEC_DB_PASSWORD" > /etc/crowdsec/config.yaml.local
+          echo "db config written to /etc/crowdsec/config.yaml.local"
+      env:
+        - name: CROWDSEC_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: crowdsec-secrets
+              key: CROWDSEC_DB_PASSWORD
+      volumeMounts:
+        - name: crowdsec-config
+          mountPath: /etc/crowdsec


### PR DESCRIPTION
CrowdSec config.yaml.local ne fait pas os.ExpandEnv(). Solution: initContainer write-db-config qui écrit la config avec le vrai password depuis le secret K8s, avant que cscli démarre.