### PR TITLE
fix(crowdsec): CROWDSEC_DB_PASSWORD manquant (Helm array override) + config.yaml.local avec PostgreSQL

### DIFF
--- a/apps/00-infra/crowdsec/values/common.yaml
+++ b/apps/00-infra/crowdsec/values/common.yaml
@@ -62,6 +62,16 @@ agent:
 # LAPI config
 # ============================================================================
 config:
+  config.yaml.local: |
+    db_config:
+      type: postgresql
+      user: crowdsec
+      password: ${CROWDSEC_DB_PASSWORD}
+      db_name: crowdsec
+      host: postgresql-shared-rw.databases.svc.cluster.local
+      port: 5432
+      sslmode: disable
+
   profiles.yaml: |
     name: default_ip_remediation
     filters:

--- a/apps/00-infra/crowdsec/values/prod.yaml
+++ b/apps/00-infra/crowdsec/values/prod.yaml
@@ -6,26 +6,17 @@ lapi:
         secretKeyRef:
           name: crowdsec-secrets
           key: CROWDSEC_BOUNCER_KEY
+    - name: ENROLL_KEY
+      valueFrom:
+        secretKeyRef:
+          name: crowdsec-secrets
+          key: ENROLL_KEY
     - name: ENROLL_INSTANCE_NAME
       value: "vixens-k8s-prod"
     - name: ENROLL_TAGS
       value: "k8s linux homelab prod"
-
-  extraInitContainers:
-    - name: write-db-config
-      image: busybox:1.37.0
-      command:
-        - sh
-        - -c
-        - |
-          printf 'db_config:\n  type: postgresql\n  user: crowdsec\n  password: %s\n  db_name: crowdsec\n  host: postgresql-shared-rw.databases.svc.cluster.local\n  port: 5432\n  sslmode: disable\n' "$CROWDSEC_DB_PASSWORD" > /etc/crowdsec/config.yaml.local
-          echo "db config written to /etc/crowdsec/config.yaml.local"
-      env:
-        - name: CROWDSEC_DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: crowdsec-secrets
-              key: CROWDSEC_DB_PASSWORD
-      volumeMounts:
-        - name: crowdsec-config
-          mountPath: /etc/crowdsec
+    - name: CROWDSEC_DB_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: crowdsec-secrets
+          key: CROWDSEC_DB_PASSWORD


### PR DESCRIPTION
prod.yaml env array override common.yaml env array (comportement Helm avec arrays). CROWDSEC_DB_PASSWORD absent du pod → ${VAR} non expandé → auth PostgreSQL échoue avec password littéral. Fix: déplacer toutes les env vars dans prod.yaml.