### PR TITLE
fix(grafana): corriger URL datasource VictoriaMetrics

### DIFF
--- a/apps/02-monitoring/grafana/base/values.yaml
+++ b/apps/02-monitoring/grafana/base/values.yaml
@@ -21,7 +21,7 @@ datasources:
     datasources:
       - name: VictoriaMetrics
         type: prometheus
-        url: http://vmsingle-victoria-metrics-victoria-metrics-k8s-stack.monitoring.svc.cluster.local:8428
+        url: http://vmsingle-vm-stack.monitoring.svc.cluster.local:8428
         access: proxy
         isDefault: true
         editable: true


### PR DESCRIPTION
## Summary
- URL datasource VictoriaMetrics périmée : `vmsingle-victoria-metrics-victoria-metrics-k8s-stack` → `vmsingle-vm-stack`
- Le service a été renommé lors d'une mise à jour du chart VictoriaMetrics

## Symptôme
Grafana affichait "no such host" sur tous les dashboards → no data partout

## Test plan
- [ ] ArgoCD sync Grafana → configmap mis à jour
- [ ] Redémarrage Grafana pour recharger le datasource
- [ ] Vérifier dashboards avec données

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated monitoring datasource endpoint configuration to ensure proper connectivity and data collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->