### PR TITLE
fix(netbird): revenir à PVC iSCSI pour netbird-data — geolocation DB OOMKill

### DIFF
--- a/apps/40-network/netbird/base/kustomization.yaml
+++ b/apps/40-network/netbird/base/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - infra.yaml
   - management.yaml
+  - pvc-data.yaml
   - dashboard.yaml
   - signal-relay.yaml
   - ca-bundle.yaml

--- a/apps/40-network/netbird/base/management.yaml
+++ b/apps/40-network/netbird/base/management.yaml
@@ -156,7 +156,8 @@ spec:
         - name: config-writable
           emptyDir: {}
         - name: netbird-data
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: netbird-data
         - name: ca-bundle
           configMap:
             name: netbird-ca-bundle

--- a/apps/40-network/netbird/base/pvc-data.yaml
+++ b/apps/40-network/netbird/base/pvc-data.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: netbird-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: synelia-iscsi-retain
+  resources:
+    requests:
+      storage: 5Gi


### PR DESCRIPTION
## Summary
- `netbird-data` revert de emptyDir → PVC iSCSI (`synelia-iscsi-retain`, 5Gi)
- La DB geolocation (`geonames_*.db`) est exclue du rclone (`*.db*`) → re-téléchargée à chaque restart → OOMKill (exit 137)
- Principe : storage persistant nécessaire = iSCSI (mobilité pod), pas local-path

## Cause
Migration emptyDir PR #2839 avait changé `netbird-data` en emptyDir. Mais netbird-management télécharge une DB geolocation au démarrage si absente (~400MB), dépassant le memory limit réduit par VPA.

## Test plan
- [ ] PVC créé et Bound sur le cluster prod
- [ ] netbird-management démarre sans OOMKill
- [ ] DB geolocation téléchargée une fois et persistée

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure Updates**
  * Netbird management service now uses persistent storage instead of temporary storage, ensuring data persists across pod restarts and service updates.
  * A persistent storage claim was added to provision 5Gi of durable storage for Netbird data, enabling sustained state across deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->