### PR TITLE
fix(nexterm): configurer dataangel sqlite-paths pour nexterm.db

### DIFF
--- a/apps/70-tools/nexterm/overlays/prod/dataangel.yaml
+++ b/apps/70-tools/nexterm/overlays/prod/dataangel.yaml
@@ -10,7 +10,7 @@ spec:
         vixens.io/sizing.dataangel: V-small
       annotations:
         dataangel.io/bucket: "vixens-prod-nexterm"
-        dataangel.io/sqlite-paths: ""
+        dataangel.io/sqlite-paths: "/app/data/nexterm.db"
         dataangel.io/fs-paths: "/app/data"
         dataangel.io/s3-endpoint: "http://192.168.111.69:9000"
         dataangel.io/deployment-name: "nexterm"


### PR DESCRIPTION
## Summary
- `nexterm.db` (240 Ko) non couvert par dataangel (`sqlite-paths: ""`)
- Le fichier `*.db` est exclu par rclone → perdu à chaque restart du pod
- Fix : ajouter `sqlite-paths: /app/data/nexterm.db` → litestream backup continu vers S3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the SQLite database path used by the dataangel component in the production overlay to point to the application data location.
  * Ensures the component now references the intended on-disk database file in prod, reducing risk of using an empty or unspecified path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->