### PR TITLE
fix: résoudre 3 problèmes pré-existants (keda, mylar, crowdsec)

### DIFF
--- a/apps/20-media/mylar/base/deployment.yaml
+++ b/apps/20-media/mylar/base/deployment.yaml
@@ -26,6 +26,7 @@ spec:
         prometheus.io/path: "/metrics"
         vixens.io/no-long-connections: "true"
         kubectl.kubernetes.io/restartedAt: "2026-03-11T21:40:00Z"
+        vixens.io/vpa.min-memory: "1Gi"
     spec:
       priorityClassName: vixens-medium
       tolerations:

--- a/argocd/overlays/dev/apps/keda.yaml
+++ b/argocd/overlays/dev/apps/keda.yaml
@@ -13,7 +13,7 @@ spec:
   sources:
     - repoURL: https://kedacore.github.io/charts
       chart: keda
-      targetRevision: 2.17.1
+      targetRevision: 2.18.3
       helm:
         valueFiles:
           - $values/apps/00-infra/keda/values/common.yaml

--- a/argocd/overlays/prod/apps/crowdsec.yaml
+++ b/argocd/overlays/prod/apps/crowdsec.yaml
@@ -38,6 +38,8 @@ spec:
         - /metadata/annotations/argocd.argoproj.io~1sync-wave
         - /spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt
         - /spec/template/spec/tolerations
+        - /metadata/labels/vixens.io~1maturity
+        - /metadata/labels/vixens.io~1maturity-missing
     - group: apps
       kind: DaemonSet
       name: crowdsec-agent

--- a/argocd/overlays/prod/apps/keda.yaml
+++ b/argocd/overlays/prod/apps/keda.yaml
@@ -13,7 +13,7 @@ spec:
   sources:
     - repoURL: https://kedacore.github.io/charts
       chart: keda
-      targetRevision: 2.17.1
+      targetRevision: 2.18.3
       helm:
         valueFiles:
           - $values/apps/00-infra/keda/values/common.yaml


### PR DESCRIPTION
## Summary

- **keda**: upgrade 2.17.1 → 2.18.3 — résout le `CrashLoopBackOff` de `keda-operator-metrics-apiserver` sur K8s 1.34. KEDA 2.17.1 n'a pas été testé sur K8s 1.34, causant un échec de l'APIService `v1beta1.external.metrics.k8s.io` (MissingEndpoints → liveness probe fails → boucle infinie, 1076 restarts)
- **mylar**: ajoute `vixens.io/vpa.min-memory: "1Gi"` — empêche la VPA de réduire la limite mémoire sous 1Gi et causer des OOMKill répétés (la VPA avait calculé 512Mi comme optimal mais mylar spiké au-delà)  
- **crowdsec**: ajoute `/metadata/labels/vixens.io~1maturity` et `vixens.io~1maturity-missing` à `ignoreDifferences` — le contrôleur de maturity ajoute ces labels sur le cluster mais ils ne sont pas dans le chart Helm, causant un OutOfSync permanent

## Test plan

- [ ] keda: `kubectl get pods -n keda` → tous les pods Running/Ready (metrics-apiserver ne crashe plus)
- [ ] keda: `kubectl get apiservice v1beta1.external.metrics.k8s.io` → `Available: True`
- [ ] mylar: `kubectl get pods -n media -l app=mylar` → Running sans OOMKill
- [ ] mylar: `kubectl get vpa vixens-mylar -n media -o jsonpath='{.spec.resourcePolicy}'` → minAllowed.memory: 1Gi
- [ ] crowdsec: ArgoCD application crowdsec → Synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated KEDA deployment configuration across environments to version 2.18.3
  * Enhanced deployment annotations and synchronization configurations for improved infrastructure management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->