### PR TITLE
fix(frigate): supprimer références mortes litestream/config-syncer dans overlay prod

### DIFF
--- a/apps/20-media/frigate/overlays/prod/kustomization.yaml
+++ b/apps/20-media/frigate/overlays/prod/kustomization.yaml
@@ -38,8 +38,6 @@ patches:
           metadata:
             labels:
               vixens.io/sizing.frigate: V-2xlarge
-              vixens.io/sizing.litestream: V-nano
-              vixens.io/sizing.config-syncer: V-nano
             annotations:
               vixens.io/explicitly-allow-root: "true"
           spec:
@@ -48,10 +46,6 @@ patches:
               runAsUser: 0
               fsGroup: 0
             initContainers:
-              - name: restore-config
-                securityContext:
-                  runAsUser: 0
-                  runAsGroup: 0
               - name: validate-config
                 securityContext:
                   runAsUser: 0
@@ -60,14 +54,6 @@ patches:
               - name: frigate
                 securityContext:
                   privileged: true
-                  runAsUser: 0
-                  runAsGroup: 0
-              - name: litestream
-                securityContext:
-                  runAsUser: 0
-                  runAsGroup: 0
-              - name: config-syncer
-                securityContext:
                   runAsUser: 0
                   runAsGroup: 0
   - path: pvc-patch.yaml


### PR DESCRIPTION
## Summary

- Suite au cleanup PR #2853 (suppression code mort litestream), l'overlay prod de frigate patchait encore des containers supprimés (`litestream`, `config-syncer`, `restore-config`)
- Kustomize les ajoutait comme nouveaux containers sans image → ArgoCD sync échouait: `spec.template.spec.containers[1/2].image: Required value`
- Suppression des labels `vixens.io/sizing.litestream` / `vixens.io/sizing.config-syncer` et des patches `securityContext` pour ces containers disparus

## Test plan

- [ ] `kubectl kustomize apps/20-media/frigate/overlays/prod` → aucune erreur, 1 seul container `frigate`
- [ ] ArgoCD application `frigate` → Synced/Healthy
- [ ] Frigate pod démarre correctement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Frigate deployment configuration by removing unnecessary sidecar containers and associated pod metadata labels, reducing deployment complexity while preserving core validation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->