### PR TITLE
fix(radarr): augmenter startupProbe failureThreshold dataangel 150→600

### DIFF
--- a/apps/20-media/radarr/overlays/prod/dataangel.yaml
+++ b/apps/20-media/radarr/overlays/prod/dataangel.yaml
@@ -23,6 +23,12 @@ spec:
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 9090
+            periodSeconds: 2
+            failureThreshold: 600
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:


### PR DESCRIPTION
## Summary

- Radarr a ~1000+ WAL segments litestream en S3 → restore dataangel > 5 minutes
- Le startup probe par défaut de dataangel: `periodSeconds: 2 × failureThreshold: 150 = 5min` → timeout → SIGTERM → restart en boucle
- Fix: override `failureThreshold: 600` (20min) pour laisser le temps à la restauration

## Test plan

- [ ] Pod radarr démarre et complète la restauration WAL
- [ ] `kubectl get pods -n media -l app=radarr` → `2/2 Running`

🤖 Generated with [Claude Code](https://claude.com/claude-code)