### PR TITLE
fix(crowdsec): ignorer label app.kubernetes.io/name — OutOfSync permanent

### DIFF
--- a/argocd/overlays/prod/apps/crowdsec.yaml
+++ b/argocd/overlays/prod/apps/crowdsec.yaml
@@ -40,6 +40,8 @@ spec:
         - /spec/template/spec/tolerations
         - /metadata/labels/vixens.io~1maturity
         - /metadata/labels/vixens.io~1maturity-missing
+        - /metadata/labels/app.kubernetes.io~1name
+        - /spec/template/metadata/labels/app.kubernetes.io~1name
     - group: apps
       kind: DaemonSet
       name: crowdsec-agent


### PR DESCRIPTION
## Summary

Le label `app.kubernetes.io/name` est ajouté par un contrôleur Kubernetes sur le Deployment `crowdsec-lapi` (metadata et pod template), mais n'est pas généré par le chart Helm 0.22.1. ArgoCD détecte un diff permanent → selfHeal retire le label → contrôleur le remet → boucle infinie OutOfSync.

Ajout des deux chemins dans `ignoreDifferences` pour arrêter le cycle.

## Test plan

- [ ] ArgoCD application `crowdsec` → Synced/Healthy stable (ne rebascule plus en OutOfSync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)