### PR TITLE
fix(crowdsec): ignorer deployment.kubernetes.io/revision — OutOfSync résiduel

### DIFF
--- a/argocd/overlays/prod/apps/crowdsec.yaml
+++ b/argocd/overlays/prod/apps/crowdsec.yaml
@@ -42,6 +42,7 @@ spec:
         - /metadata/labels/vixens.io~1maturity-missing
         - /metadata/labels/app.kubernetes.io~1name
         - /spec/template/metadata/labels/app.kubernetes.io~1name
+        - /metadata/annotations/deployment.kubernetes.io~1revision
     - group: apps
       kind: DaemonSet
       name: crowdsec-agent


### PR DESCRIPTION
Suite au PR #2860, crowdsec reste OutOfSync. L'annotation `deployment.kubernetes.io/revision` est ajoutée par le Deployment controller mais absente du Helm chart output.