### PR TITLE
fix(crowdsec): ignorer checksum/lapi-secret — vraie cause OutOfSync

### DIFF
--- a/argocd/overlays/prod/apps/crowdsec.yaml
+++ b/argocd/overlays/prod/apps/crowdsec.yaml
@@ -37,6 +37,7 @@ spec:
         - /metadata/annotations/vpa.kubernetes.io~1updateMode
         - /metadata/annotations/argocd.argoproj.io~1sync-wave
         - /spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt
+        - /spec/template/metadata/annotations/checksum~1lapi-secret
         - /spec/template/spec/tolerations
         - /metadata/labels/vixens.io~1maturity
         - /metadata/labels/vixens.io~1maturity-missing


### PR DESCRIPTION
La vraie cause du OutOfSync crowdsec (découverte via `argocd app diff`): le checksum du secret `crowdsec-lapi-secrets` dans les annotations du pod template est différent entre Git et cluster. Le secret lui-même est ignoré (/data) mais pas son checksum → diff permanent sur `checksum/lapi-secret`.