### PR TITLE
fix(nexterm): vpa.min-cpu=100m — VPA throttlait à 44m, control plane ne démarrait pas

### DIFF
--- a/apps/70-tools/nexterm/base/deployment.yaml
+++ b/apps/70-tools/nexterm/base/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         reloader.stakater.com/auto: "true"
         vixens.io/fast-start: "true"
         vixens.io/nometrics: "true"
+        vixens.io/vpa.min-cpu: "100m"
     spec:
       priorityClassName: vixens-medium
       securityContext:


### PR DESCRIPTION
## Cause

Le VPA avait appris que nexterm utilisait très peu de CPU (11m/44m) et a fait un resize in-place. Avec 44m CPU limit, le control plane Node.js nexterm est tellement throttlé qu'il ne bind pas assez vite sur port 7800 avant que l'engine abandonne (~2min).

Les certs TLS dans S3 (cp-cert.pem mis à jour le 2026-04-09) confirment que nexterm tournait bien hier — le crash a commencé après le resize VPA.

## Fix

Annotation `vixens.io/vpa.min-cpu: "100m"` sur le pod template → Kyverno régénère le VPA avec `minAllowed.cpu: 100m`.

## Test

Après merge + deploy : nexterm doit démarrer sans crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration: added a pod template annotation setting a minimum CPU value of 100m.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->