### PR TITLE
feat(scheduling): soft i915 node preferences — libérer GPU nodes pour frigate

### DIFF
--- a/apps/02-monitoring/descheduler/base/descheduler-gen.yaml
+++ b/apps/02-monitoring/descheduler/base/descheduler-gen.yaml
@@ -43,19 +43,20 @@ data:
       - args:
           nodeAffinityType:
           - requiredDuringSchedulingIgnoredDuringExecution
+          - preferredDuringSchedulingIgnoredDuringExecution
         name: RemovePodsViolatingNodeAffinity
       - name: RemovePodsViolatingNodeTaints
       - name: RemovePodsViolatingInterPodAntiAffinity
       - name: RemovePodsViolatingTopologySpreadConstraint
       - args:
           targetThresholds:
-            cpu: 50
-            memory: 50
-            pods: 50
+            cpu: 70
+            memory: 90
+            pods: 80
           thresholds:
-            cpu: 20
-            memory: 20
-            pods: 20
+            cpu: 30
+            memory: 78
+            pods: 50
         name: LowNodeUtilization
       plugins:
         balance:
@@ -79,12 +80,12 @@ data:
             - homeassistant
           nodeResourceUtilizationThresholds:
             targetThresholds:
-              cpu: 60
-              memory: 60
+              cpu: 70
+              memory: 90
             thresholds:
               cpu: 30
-              memory: 30
-          numberOfNodes: 3
+              memory: 78
+          numberOfNodes: 1
           priorityThreshold:
             value: 10000
       PodLifeTime:

--- a/apps/02-monitoring/grafana/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/grafana/overlays/prod/kustomization.yaml
@@ -6,6 +6,9 @@ labels:
     pairs:
       environment: prod
 namespace: monitoring
+components:
+  - ../../../../_shared/components/scheduling/avoid-i915
+
 patches:
   - path: patch-infisical-env.yaml
   - patch: |-

--- a/apps/02-monitoring/loki/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/loki/overlays/prod/kustomization.yaml
@@ -10,6 +10,7 @@ components:
   - ../../../../_shared/components/sync-wave/wave-7
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/poddisruptionbudget/1
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: infisical-patch.yaml

--- a/apps/03-security/authentik/overlays/prod/kustomization.yaml
+++ b/apps/03-security/authentik/overlays/prod/kustomization.yaml
@@ -9,6 +9,7 @@ labels:
 components:
   - ../../../../_shared/components/infisical/env-prod
   - ../../../../_shared/components/poddisruptionbudget/1
+  - ../../../../_shared/components/scheduling/avoid-i915
 patches:
   - path: deployment-patch.yaml
     target:

--- a/apps/04-databases/mariadb-shared/overlays/prod/kustomization.yaml
+++ b/apps/04-databases/mariadb-shared/overlays/prod/kustomization.yaml
@@ -9,6 +9,7 @@ components:
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/revision-history-limit
   - ../../../../_shared/components/poddisruptionbudget/1
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: patch-infisical-env.yaml

--- a/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
@@ -13,6 +13,7 @@ components:
   - ../../../../_shared/components/nometrics
   - ../../../../_shared/components/dataangel
   - ../../../../_shared/components/poddisruptionbudget/1
+  - ../../../../_shared/components/scheduling/prefer-i915
 
 patches:
   - target:

--- a/apps/10-home/mealie/overlays/prod/kustomization.yaml
+++ b/apps/10-home/mealie/overlays/prod/kustomization.yaml
@@ -12,6 +12,7 @@ components:
   - ../../../../_shared/components/nometrics
   - ../../../../_shared/components/dataangel
   - ../../../../_shared/components/poddisruptionbudget/1
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: dataangel.yaml

--- a/apps/20-media/birdnet-go/overlays/prod/kustomization.yaml
+++ b/apps/20-media/birdnet-go/overlays/prod/kustomization.yaml
@@ -13,6 +13,7 @@ components:
   - ../../../../_shared/components/nometrics
   - ../../../../_shared/components/poddisruptionbudget/1
   - ../../../../_shared/components/dataangel
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: resources-patch.yaml

--- a/apps/20-media/frigate/overlays/prod/node-affinity-patch.yaml
+++ b/apps/20-media/frigate/overlays/prod/node-affinity-patch.yaml
@@ -8,11 +8,9 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/hostname
-                    operator: In
-                    values:
-                      - powder
-                      - poison
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 90
+              preference:
+                matchExpressions:
+                  - key: vixens.io/has-i915
+                    operator: Exists

--- a/apps/20-media/hydrus-client/overlays/prod/kustomization.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/kustomization.yaml
@@ -21,6 +21,7 @@ components:
   - ../../../../_shared/components/poddisruptionbudget/0
   - ../../../../_shared/components/securitycontext/s6-overlay
   - ../../../../_shared/components/dataangel
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: dataangel.yaml

--- a/apps/20-media/mylar/overlays/prod/kustomization.yaml
+++ b/apps/20-media/mylar/overlays/prod/kustomization.yaml
@@ -18,6 +18,7 @@ components:
   - ../../../../_shared/components/poddisruptionbudget/0
   - ../../../../_shared/components/securitycontext/s6-overlay
   - ../../../../_shared/components/dataangel
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: dataangel.yaml

--- a/apps/20-media/pyload/overlays/prod/kustomization.yaml
+++ b/apps/20-media/pyload/overlays/prod/kustomization.yaml
@@ -14,6 +14,7 @@ components:
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics
   - ../../../../_shared/components/dataangel
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: patch-infisical-env.yaml

--- a/apps/20-media/radarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/radarr/overlays/prod/kustomization.yaml
@@ -18,6 +18,7 @@ components:
   - ../../../../_shared/components/poddisruptionbudget/0
   - ../../../../_shared/components/securitycontext/s6-overlay
   - ../../../../_shared/components/dataangel
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: dataangel.yaml

--- a/apps/20-media/sonarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/sonarr/overlays/prod/kustomization.yaml
@@ -18,6 +18,7 @@ components:
   - ../../../../_shared/components/poddisruptionbudget/0
   - ../../../../_shared/components/securitycontext/s6-overlay
   - ../../../../_shared/components/dataangel
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - target:

--- a/apps/60-services/g4f/overlays/prod/kustomization.yaml
+++ b/apps/60-services/g4f/overlays/prod/kustomization.yaml
@@ -7,3 +7,4 @@ components:
   - ../../../../_shared/components/sync-wave/wave-9
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics
+  - ../../../../_shared/components/scheduling/avoid-i915

--- a/apps/60-services/n8n/overlays/prod/kustomization.yaml
+++ b/apps/60-services/n8n/overlays/prod/kustomization.yaml
@@ -14,6 +14,7 @@ components:
   - ../../../../_shared/components/revision-history-limit
   - ../../../../_shared/components/dataangel
   - ../../../../_shared/components/poddisruptionbudget/1
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: dataangel.yaml

--- a/apps/70-tools/nocodb/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/nocodb/overlays/prod/kustomization.yaml
@@ -10,6 +10,7 @@ components:
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics
   - ../../../../_shared/components/dataangel
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: dataangel.yaml

--- a/apps/_shared/components/scheduling/avoid-i915/kustomization.yaml
+++ b/apps/_shared/components/scheduling/avoid-i915/kustomization.yaml
@@ -1,0 +1,56 @@
+---
+# Kustomize Component: avoid-i915
+#
+# Adds a SOFT preference (weight 80) to schedule on nodes WITHOUT i915 GPU.
+# Leaves GPU nodes (powder, poison, phoebe) available for frigate/HA.
+#
+# This is preferredDuringSchedulingIgnoredDuringExecution — pod CAN still land
+# on an i915 node if no capacity elsewhere. Not a hard constraint.
+#
+# Node label: vixens.io/has-i915=true on powder, poison, phoebe
+#
+# Usage:
+#   components:
+#     - ../../../../_shared/components/scheduling/avoid-i915
+
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: placeholder
+      spec:
+        template:
+          spec:
+            affinity:
+              nodeAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 80
+                    preference:
+                      matchExpressions:
+                        - key: vixens.io/has-i915
+                          operator: DoesNotExist
+    target:
+      kind: Deployment
+
+  - patch: |-
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: placeholder
+      spec:
+        template:
+          spec:
+            affinity:
+              nodeAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 80
+                    preference:
+                      matchExpressions:
+                        - key: vixens.io/has-i915
+                          operator: DoesNotExist
+    target:
+      kind: StatefulSet

--- a/apps/_shared/components/scheduling/prefer-i915/kustomization.yaml
+++ b/apps/_shared/components/scheduling/prefer-i915/kustomization.yaml
@@ -1,0 +1,37 @@
+---
+# Kustomize Component: prefer-i915
+#
+# Adds a SOFT preference (weight 80) to schedule on nodes WITH i915 GPU.
+# For apps requiring hardware video decode (frigate, homeassistant).
+#
+# This is preferredDuringSchedulingIgnoredDuringExecution — pod CAN still land
+# on a non-i915 node if no i915 node has capacity. Not a hard constraint.
+#
+# Node label: vixens.io/has-i915=true on powder, poison, phoebe
+#
+# Usage:
+#   components:
+#     - ../../../../_shared/components/scheduling/prefer-i915
+
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: placeholder
+      spec:
+        template:
+          spec:
+            affinity:
+              nodeAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 80
+                    preference:
+                      matchExpressions:
+                        - key: vixens.io/has-i915
+                          operator: Exists
+    target:
+      kind: Deployment


### PR DESCRIPTION
## Contexte

Frigate est Pending : powder (91%) et poison (95%) sont saturés. Les deux ont i915 (GPU decode pour les caméras). Phoebe est aussi i915 mais ignoré jusqu'ici dans l'affinity de frigate.

## Changements

### Composants partagés
- `_shared/components/scheduling/avoid-i915` — préférence `weight: 80` pour nodes sans `vixens.io/has-i915`
- `_shared/components/scheduling/prefer-i915` — préférence `weight: 80` pour nodes avec `vixens.io/has-i915`

### Apps (avoid-i915)
14 apps lourdes sur powder/poison/phoebe : hydrus-client, mylar, nocodb, birdnet-go, pyload, n8n, mealie, radarr, sonarr, authentik, g4f, loki, grafana, mariadb-shared

### frigate
`requiredDuringScheduling(powder|poison)` → `preferredDuringScheduling(vixens.io/has-i915, weight 90)`
Phoebe (aussi i915) est désormais éligible.

### homeassistant
Ajout `prefer-i915` (weight 80).

### Descheduler
- `RemovePodsViolatingNodeAffinity` : ajout `preferredDuringSchedulingIgnoredDuringExecution` → éviction active des pods mal placés
- `LowNodeUtilization` : seuils 20%/60% → 78%/90%, `numberOfNodes` 3 → 1 (était complètement inactif)

## Post-merge

```bash
# Labelliser les nodes i915
kubectl label node powder poison phoebe vixens.io/has-i915=true

# Déclencher le descheduler manuellement
kubectl create job -n kube-system descheduler-manual --from=cronjob/descheduler
```

Puis surveiller le rescheduling des apps et la disponibilité de frigate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated descheduler policy with enhanced node affinity configuration and optimized resource utilization thresholds for improved cluster efficiency.
  * Added i915 hardware scheduling preferences across multiple services to optimize workload placement.
  * Updated Frigate scheduling from hard to soft preference constraints for increased deployment flexibility.
  * Added minimum CPU resource configuration for Nexterm.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->