### PR TITLE
fix(openclaw): fix claude binary path in install-gemini

### DIFF
--- a/apps/02-monitoring/descheduler/base/descheduler-gen.yaml
+++ b/apps/02-monitoring/descheduler/base/descheduler-gen.yaml
@@ -43,19 +43,20 @@ data:
       - args:
           nodeAffinityType:
           - requiredDuringSchedulingIgnoredDuringExecution
+          - preferredDuringSchedulingIgnoredDuringExecution
         name: RemovePodsViolatingNodeAffinity
       - name: RemovePodsViolatingNodeTaints
       - name: RemovePodsViolatingInterPodAntiAffinity
       - name: RemovePodsViolatingTopologySpreadConstraint
       - args:
           targetThresholds:
-            cpu: 50
-            memory: 50
-            pods: 50
+            cpu: 70
+            memory: 90
+            pods: 80
           thresholds:
-            cpu: 20
-            memory: 20
-            pods: 20
+            cpu: 30
+            memory: 78
+            pods: 50
         name: LowNodeUtilization
       plugins:
         balance:
@@ -79,12 +80,12 @@ data:
             - homeassistant
           nodeResourceUtilizationThresholds:
             targetThresholds:
-              cpu: 60
-              memory: 60
+              cpu: 70
+              memory: 90
             thresholds:
               cpu: 30
-              memory: 30
-          numberOfNodes: 3
+              memory: 78
+          numberOfNodes: 1
           priorityThreshold:
             value: 10000
       PodLifeTime:

--- a/apps/02-monitoring/grafana/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/grafana/overlays/prod/kustomization.yaml
@@ -6,6 +6,9 @@ labels:
     pairs:
       environment: prod
 namespace: monitoring
+components:
+  - ../../../../_shared/components/scheduling/avoid-i915
+
 patches:
   - path: patch-infisical-env.yaml
   - patch: |-

--- a/apps/02-monitoring/loki/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/loki/overlays/prod/kustomization.yaml
@@ -10,6 +10,7 @@ components:
   - ../../../../_shared/components/sync-wave/wave-7
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/poddisruptionbudget/1
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: infisical-patch.yaml

--- a/apps/03-security/authentik/overlays/prod/kustomization.yaml
+++ b/apps/03-security/authentik/overlays/prod/kustomization.yaml
@@ -9,6 +9,7 @@ labels:
 components:
   - ../../../../_shared/components/infisical/env-prod
   - ../../../../_shared/components/poddisruptionbudget/1
+  - ../../../../_shared/components/scheduling/avoid-i915
 patches:
   - path: deployment-patch.yaml
     target:

--- a/apps/04-databases/mariadb-shared/overlays/prod/kustomization.yaml
+++ b/apps/04-databases/mariadb-shared/overlays/prod/kustomization.yaml
@@ -9,6 +9,7 @@ components:
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/revision-history-limit
   - ../../../../_shared/components/poddisruptionbudget/1
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: patch-infisical-env.yaml

--- a/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
@@ -13,6 +13,7 @@ components:
   - ../../../../_shared/components/nometrics
   - ../../../../_shared/components/dataangel
   - ../../../../_shared/components/poddisruptionbudget/1
+  - ../../../../_shared/components/scheduling/prefer-i915
 
 patches:
   - target:

--- a/apps/10-home/mealie/overlays/prod/kustomization.yaml
+++ b/apps/10-home/mealie/overlays/prod/kustomization.yaml
@@ -12,6 +12,7 @@ components:
   - ../../../../_shared/components/nometrics
   - ../../../../_shared/components/dataangel
   - ../../../../_shared/components/poddisruptionbudget/1
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: dataangel.yaml

--- a/apps/20-media/birdnet-go/overlays/prod/kustomization.yaml
+++ b/apps/20-media/birdnet-go/overlays/prod/kustomization.yaml
@@ -13,6 +13,7 @@ components:
   - ../../../../_shared/components/nometrics
   - ../../../../_shared/components/poddisruptionbudget/1
   - ../../../../_shared/components/dataangel
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: resources-patch.yaml

--- a/apps/20-media/frigate/overlays/prod/node-affinity-patch.yaml
+++ b/apps/20-media/frigate/overlays/prod/node-affinity-patch.yaml
@@ -8,11 +8,9 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/hostname
-                    operator: In
-                    values:
-                      - powder
-                      - poison
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 90
+              preference:
+                matchExpressions:
+                  - key: vixens.io/has-i915
+                    operator: Exists

--- a/apps/20-media/hydrus-client/overlays/prod/kustomization.yaml
+++ b/apps/20-media/hydrus-client/overlays/prod/kustomization.yaml
@@ -21,6 +21,7 @@ components:
   - ../../../../_shared/components/poddisruptionbudget/0
   - ../../../../_shared/components/securitycontext/s6-overlay
   - ../../../../_shared/components/dataangel
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: dataangel.yaml

--- a/apps/20-media/mylar/overlays/prod/kustomization.yaml
+++ b/apps/20-media/mylar/overlays/prod/kustomization.yaml
@@ -18,6 +18,7 @@ components:
   - ../../../../_shared/components/poddisruptionbudget/0
   - ../../../../_shared/components/securitycontext/s6-overlay
   - ../../../../_shared/components/dataangel
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: dataangel.yaml

--- a/apps/20-media/pyload/overlays/prod/kustomization.yaml
+++ b/apps/20-media/pyload/overlays/prod/kustomization.yaml
@@ -14,6 +14,7 @@ components:
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics
   - ../../../../_shared/components/dataangel
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: patch-infisical-env.yaml

--- a/apps/20-media/radarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/radarr/overlays/prod/kustomization.yaml
@@ -18,6 +18,7 @@ components:
   - ../../../../_shared/components/poddisruptionbudget/0
   - ../../../../_shared/components/securitycontext/s6-overlay
   - ../../../../_shared/components/dataangel
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: dataangel.yaml

--- a/apps/20-media/sonarr/overlays/prod/kustomization.yaml
+++ b/apps/20-media/sonarr/overlays/prod/kustomization.yaml
@@ -18,6 +18,7 @@ components:
   - ../../../../_shared/components/poddisruptionbudget/0
   - ../../../../_shared/components/securitycontext/s6-overlay
   - ../../../../_shared/components/dataangel
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - target:

--- a/apps/60-services/g4f/overlays/prod/kustomization.yaml
+++ b/apps/60-services/g4f/overlays/prod/kustomization.yaml
@@ -7,3 +7,4 @@ components:
   - ../../../../_shared/components/sync-wave/wave-9
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics
+  - ../../../../_shared/components/scheduling/avoid-i915

--- a/apps/60-services/n8n/overlays/prod/kustomization.yaml
+++ b/apps/60-services/n8n/overlays/prod/kustomization.yaml
@@ -14,6 +14,7 @@ components:
   - ../../../../_shared/components/revision-history-limit
   - ../../../../_shared/components/dataangel
   - ../../../../_shared/components/poddisruptionbudget/1
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: dataangel.yaml

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -165,9 +165,6 @@ spec:
                   d.pop('skills', None) if isinstance(s, dict) and not s else None
                   # Always force-disable claw-hass (crashes without HASS config)
                   d.setdefault('plugins', {}).setdefault('entries', {})['claw-hass'] = {'enabled': False}
-                  # Remove 'runtime' from agent definitions (field removed in 2026.4.9)
-                  for agent in d.get('agents', {}).get('list', []):
-                      agent.pop('runtime', None)
                   json.dump(d, open(p, 'w'))
                   print('Config keys checked')
 

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -229,8 +229,10 @@ spec:
               else
                 echo "Installing Claude Code v$CLAUDE_VERSION..."
                 npm install -g @anthropic-ai/claude-code@$CLAUDE_VERSION
-                mkdir -p /data/claude-cli
-                cp -r /usr/local/lib/node_modules/@anthropic-ai /data/claude-cli/
+                mkdir -p /data/claude-cli/bin
+                # Copy the claude binary (npm installs it to /usr/local/bin/claude)
+                cp -L /usr/local/bin/claude /data/claude-cli/bin/claude
+                chmod +x /data/claude-cli/bin/claude
                 echo "$CLAUDE_VERSION" > /data/claude-cli/.claude-version
                 echo "Claude Code installed successfully"
               fi
@@ -266,7 +268,7 @@ spec:
             - name: TZ
               value: Europe/Paris
             - name: PATH
-              value: /data/tools/usr/local/bin:/data/tools/local/bin:/data/tools/bin:/data/tools/lib:/data/gemini-cli:/data/gemini-cli/@google/gemini-cli/node_modules/.bin:/data/claude-cli/@anthropic-ai/claude-code/bin:/usr/local/bin:/usr/local/lib/node_modules/.bin:/usr/bin:/bin
+              value: /data/tools/usr/local/bin:/data/tools/local/bin:/data/tools/bin:/data/tools/lib:/data/gemini-cli:/data/gemini-cli/@google/gemini-cli/node_modules/.bin:/data/claude-cli/bin:/usr/local/bin:/usr/local/lib/node_modules/.bin:/usr/bin:/bin
             - name: LD_LIBRARY_PATH
               value: /usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/lib:/usr/lib:/data/tools/lib/blas
             - name: PYTHONPATH

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -165,6 +165,9 @@ spec:
                   d.pop('skills', None) if isinstance(s, dict) and not s else None
                   # Always force-disable claw-hass (crashes without HASS config)
                   d.setdefault('plugins', {}).setdefault('entries', {})['claw-hass'] = {'enabled': False}
+                  # Remove 'runtime' from agent definitions (field removed in 2026.4.9)
+                  for agent in d.get('agents', {}).get('list', []):
+                      agent.pop('runtime', None)
                   json.dump(d, open(p, 'w'))
                   print('Config keys checked')
 

--- a/apps/70-tools/nocodb/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/nocodb/overlays/prod/kustomization.yaml
@@ -10,6 +10,7 @@ components:
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/nometrics
   - ../../../../_shared/components/dataangel
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: dataangel.yaml

--- a/apps/_shared/components/scheduling/avoid-i915/kustomization.yaml
+++ b/apps/_shared/components/scheduling/avoid-i915/kustomization.yaml
@@ -1,0 +1,56 @@
+---
+# Kustomize Component: avoid-i915
+#
+# Adds a SOFT preference (weight 80) to schedule on nodes WITHOUT i915 GPU.
+# Leaves GPU nodes (powder, poison, phoebe) available for frigate/HA.
+#
+# This is preferredDuringSchedulingIgnoredDuringExecution — pod CAN still land
+# on an i915 node if no capacity elsewhere. Not a hard constraint.
+#
+# Node label: vixens.io/has-i915=true on powder, poison, phoebe
+#
+# Usage:
+#   components:
+#     - ../../../../_shared/components/scheduling/avoid-i915
+
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: placeholder
+      spec:
+        template:
+          spec:
+            affinity:
+              nodeAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 80
+                    preference:
+                      matchExpressions:
+                        - key: vixens.io/has-i915
+                          operator: DoesNotExist
+    target:
+      kind: Deployment
+
+  - patch: |-
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: placeholder
+      spec:
+        template:
+          spec:
+            affinity:
+              nodeAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 80
+                    preference:
+                      matchExpressions:
+                        - key: vixens.io/has-i915
+                          operator: DoesNotExist
+    target:
+      kind: StatefulSet

--- a/apps/_shared/components/scheduling/prefer-i915/kustomization.yaml
+++ b/apps/_shared/components/scheduling/prefer-i915/kustomization.yaml
@@ -1,0 +1,37 @@
+---
+# Kustomize Component: prefer-i915
+#
+# Adds a SOFT preference (weight 80) to schedule on nodes WITH i915 GPU.
+# For apps requiring hardware video decode (frigate, homeassistant).
+#
+# This is preferredDuringSchedulingIgnoredDuringExecution — pod CAN still land
+# on a non-i915 node if no i915 node has capacity. Not a hard constraint.
+#
+# Node label: vixens.io/has-i915=true on powder, poison, phoebe
+#
+# Usage:
+#   components:
+#     - ../../../../_shared/components/scheduling/prefer-i915
+
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: placeholder
+      spec:
+        template:
+          spec:
+            affinity:
+              nodeAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 80
+                    preference:
+                      matchExpressions:
+                        - key: vixens.io/has-i915
+                          operator: Exists
+    target:
+      kind: Deployment


### PR DESCRIPTION
## Summary

- `npm install -g @anthropic-ai/claude-code` in node:24 installs the binary to `/usr/local/bin/claude` (a symlink), not inside `node_modules/@anthropic-ai/claude-code/bin/`
- The previous `cp -r /usr/local/lib/node_modules/@anthropic-ai /data/claude-cli/` copied package sources but missed the binary
- Result: `/data/claude-cli/` was always empty → `claude` never in PATH → acpx can't spawn Aurelia's ACP sessions

## Fix

- Use `cp -L /usr/local/bin/claude /data/claude-cli/bin/claude` to resolve and copy the actual binary
- Update `PATH` from `/data/claude-cli/@anthropic-ai/claude-code/bin` → `/data/claude-cli/bin`

## Test plan
- [ ] After merge + pod restart: `which claude` in openclaw container returns `/data/claude-cli/bin/claude`
- [ ] Aurelia ACP sessions spawn correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared pod scheduling and affinity components enabling optimized workload placement and resource distribution across the cluster
  * Fine-tuned resource utilization policies and node evaluation strategies to improve overall cluster efficiency and performance

* **Configuration Updates**
  * Modified Frigate scheduling constraints from hard to soft node affinity requirements for increased scheduling flexibility
  * Updated Claude CLI installation process and configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->