### PR TITLE
fix(openclaw): add /data volumeMount to install-gemini init container

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -238,6 +238,9 @@ spec:
               fi
               # Always fix permissions
               chown -R 1000:1000 /data/node_modules /data/gemini-cli /data/claude-cli 2>/dev/null || true
+          volumeMounts:
+            - name: data
+              mountPath: /data
       containers:
         - name: openclaw
           lifecycle:


### PR DESCRIPTION
## Summary
- `install-gemini` init container was writing `gemini-cli/`, `node_modules/`, and `claude-cli/` to the container's ephemeral root filesystem instead of the shared `emptyDir` volume
- The binaries were therefore invisible to the main `openclaw` container (and to dataangel for backup)
- This has been broken since `install-gemini` was introduced — `which claude` and `which gemini` never worked in the running pod

## Fix
Added `volumeMounts: - name: data, mountPath: /data` to the `install-gemini` init container spec.

## Test plan
- [ ] After merge + prod-stable promotion: `kubectl exec -c openclaw -- which claude` should return `/data/claude-cli/bin/claude`
- [ ] `kubectl exec -c openclaw -- which gemini` should return a path under `/data/gemini-cli/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where initialization processes were not properly accessing shared storage, ensuring consistent data access during service startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->