### PR TITLE
fix(persistence): iSCSI retain frigate cache + dataangel config birdnet

### DIFF
--- a/apps/20-media/birdnet-go/base/deployment.yaml
+++ b/apps/20-media/birdnet-go/base/deployment.yaml
@@ -61,8 +61,9 @@ spec:
               cpu: 1000m
               memory: 1Gi
           volumeMounts:
-            - name: config
+            - name: data
               mountPath: /home/birdnet/.config/birdnet-go
+              subPath: birdnet-config
             - name: data
               mountPath: /data
             - name: internals
@@ -85,8 +86,6 @@ spec:
             timeoutSeconds: 3
             failureThreshold: 3
       volumes:
-        - name: config
-          emptyDir: {}
         - name: data
           emptyDir: {}
         - name: internals

--- a/apps/20-media/frigate/base/deployment.yaml
+++ b/apps/20-media/frigate/base/deployment.yaml
@@ -141,9 +141,8 @@ spec:
           medium: Memory
           sizeLimit: 1024Mi
       - name: cache
-        emptyDir:
-          medium: Memory
-          sizeLimit: 512Mi
+        persistentVolumeClaim:
+          claimName: frigate-cache-pvc
       - name: dri
         hostPath:
           path: /dev/dri

--- a/apps/20-media/frigate/base/pvc.yaml
+++ b/apps/20-media/frigate/base/pvc.yaml
@@ -10,3 +10,15 @@ spec:
   resources:
     requests:
       storage: 2Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: frigate-cache-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path-delete
+  resources:
+    requests:
+      storage: 10Gi

--- a/apps/20-media/frigate/overlays/prod/pvc-patch.yaml
+++ b/apps/20-media/frigate/overlays/prod/pvc-patch.yaml
@@ -7,3 +7,13 @@ spec:
   resources:
     requests:
       storage: 50Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: frigate-cache-pvc
+spec:
+  storageClassName: synelia-iscsi-retain
+  resources:
+    requests:
+      storage: 10Gi


### PR DESCRIPTION
## Summary

### Frigate — perte des embeddings de reconnaissance faciale
- Le volume `cache` (contenant `frigate.db` avec les embeddings) était un `emptyDir: Memory` → **perdu à chaque eviction VPA**
- Remplacé par `frigate-cache-pvc` (iSCSI `synelia-iscsi-retain`, 10Gi)
- La db persiste maintenant directement sur le bloc iSCSI, sans dépendre du restore S3 de dataangel
- Dataangel continue de backup la db en S3 pour disaster recovery

### Birdnet-go — perte de configuration
- La config (`/home/birdnet/.config/birdnet-go`) était sur un `emptyDir` séparé **non couvert par dataangel**
- Montée comme `subPath: birdnet-config` du volume `data` → dataangel la sauvegarde automatiquement

## Notes
- frigate-cache-pvc doit être provisionné sur Synology avant le premier déploiement (iSCSI CSI)
- birdnet: au premier redémarrage, dataangel restaurera la config depuis S3 si elle y était déjà

## Test plan
- [ ] `frigate-cache-pvc` provisionné → `kubectl get pvc -n media frigate-cache-pvc`
- [ ] Après VPA eviction: `kubectl exec -c frigate -- ls /tmp/cache/frigate.db` → présent
- [ ] Birdnet: restart pod → config restaurée depuis S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment storage configurations for media services to enhance data persistence across service lifecycle events and improve overall storage consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->