### PR TITLE
fix(openclaw+homeassistant): claude-agent-acp ACP adapter + retirer affinité i915 homeassistant

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
@@ -13,7 +13,6 @@ components:
   - ../../../../_shared/components/nometrics
   - ../../../../_shared/components/dataangel
   - ../../../../_shared/components/poddisruptionbudget/1
-  - ../../../../_shared/components/scheduling/prefer-i915
 
 patches:
   - target:

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -236,8 +236,22 @@ spec:
                 echo "$CLAUDE_VERSION" > /data/claude-cli/.claude-version
                 echo "Claude Code installed successfully"
               fi
+              CLAUDE_AGENT_ACP_VERSION="0.26.0"
+              if [ -f /data/node_modules/.claude-agent-acp-version ] && \
+                 [ "$(cat /data/node_modules/.claude-agent-acp-version)" = "$CLAUDE_AGENT_ACP_VERSION" ]; then
+                echo "claude-agent-acp v$CLAUDE_AGENT_ACP_VERSION already installed, skipping"
+              else
+                echo "Installing claude-agent-acp v$CLAUDE_AGENT_ACP_VERSION..."
+                npm install --prefix /data @agentclientprotocol/claude-agent-acp@$CLAUDE_AGENT_ACP_VERSION
+                echo "$CLAUDE_AGENT_ACP_VERSION" > /data/node_modules/.claude-agent-acp-version
+                echo "claude-agent-acp installed successfully"
+              fi
+              # Always create claude-acp wrapper (idempotent)
+              mkdir -p /data/bin
+              printf '#!/bin/sh\nexport HOME=/data\nexport CLAUDE_CONFIG_DIR=/data/.claude\nexec /data/node_modules/.bin/claude-agent-acp "$@"\n' > /data/bin/claude-acp
+              chmod +x /data/bin/claude-acp
               # Always fix permissions
-              chown -R 1000:1000 /data/node_modules /data/gemini-cli /data/claude-cli 2>/dev/null || true
+              chown -R 1000:1000 /data/node_modules /data/gemini-cli /data/claude-cli /data/bin 2>/dev/null || true
           volumeMounts:
             - name: data
               mountPath: /data


### PR DESCRIPTION
## Summary

### openclaw — aurelia ACP fix
- Installe `@agentclientprotocol/claude-agent-acp@0.26.0` dans l'init container
- Crée `/data/bin/claude-acp` wrapper pointant vers l'adapteur ACP (pas le raw `claude` CLI)
- Root cause: `claude` CLI ne parle pas le protocole ACP → acpx timeout systématique → fallback Kimi

### homeassistant — libérer poison pour frigate
- Retire le composant `prefer-i915` de l'overlay prod
- homeassistant n'a pas besoin du GPU i915 — la préférence le forçait sur les control planes (poison/phoebe/powder)
- homeassistant et frigate sur le même nœud créaient une pression CPU qui empêchait le VPA de frigate de committer ses resizes in-place

## Test plan
- [ ] Pod openclaw redémarre proprement avec `claude-agent-acp` installé
- [ ] Message à @Aurelia dans Discord → répond via Claude (pas fallback Kimi)
- [ ] homeassistant se reprogramme sur un worker (peach ou pearl)
- [ ] Plus d'éviction frigate en boucle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Claude Agent ACP protocol support to openclaw service
  * Included wrapper script for convenient execution with proper environment configuration

* **Chores**
  * Removed component from Home Assistant production configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->