### PR TITLE
fix(homeassistant): prefer-i915 + soft anti-affinity avec frigate

### DIFF
--- a/apps/10-home/homeassistant/overlays/prod/anti-affinity-frigate.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/anti-affinity-frigate.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homeassistant
+spec:
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: frigate
+                topologyKey: kubernetes.io/hostname

--- a/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
@@ -13,7 +13,7 @@ components:
   - ../../../../_shared/components/nometrics
   - ../../../../_shared/components/dataangel
   - ../../../../_shared/components/poddisruptionbudget/1
-  - ../../../../_shared/components/scheduling/avoid-i915
+  - ../../../../_shared/components/scheduling/prefer-i915
 
 patches:
   - target:
@@ -25,3 +25,4 @@ patches:
         value: 250Gi
   - path: resources-patch.yaml
   - path: dataangel.yaml
+  - path: anti-affinity-frigate.yaml

--- a/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
@@ -13,6 +13,7 @@ components:
   - ../../../../_shared/components/nometrics
   - ../../../../_shared/components/dataangel
   - ../../../../_shared/components/poddisruptionbudget/1
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - target:


### PR DESCRIPTION
## Summary

- Remet `prefer-i915` sur homeassistant en prod (homeassistant doit rester sur gros node — c'était intentionnel)
- Ajoute une `podAntiAffinity` soft (weight 100) pour éviter la co-localisation avec frigate

## Pourquoi

homeassistant et frigate ont tous les deux `prefer-i915` → ils atterrissaient sur le même nœud (`poison`), créant une pression CPU qui empêchait le VPA de frigate de committer ses resizes in-place (eviction loop).

Avec l'anti-affinité, homeassistant ira préférentiellement sur `phoebe` ou `powder` plutôt que `poison` quand frigate est déjà là.

## Test plan
- [ ] homeassistant redémarre sur phoebe ou powder (pas poison)
- [ ] frigate reste sur poison sans eviction en boucle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated pod scheduling configuration to improve infrastructure resource distribution, ensuring homeassistant and frigate services run on separate cluster nodes.
  * Extended service initialization to include new npm package installation with dedicated configuration management and execution wrapper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->