### PR TITLE
fix(frigate): VPA updateMode Off — éviter eviction loop sur poison

### DIFF
--- a/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
+++ b/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
@@ -96,8 +96,9 @@ spec:
             updatePolicy:
               # V-* sizing label present → InPlaceOrRecreate (in-place first, eviction fallback)
               # B-*/SB-*/G-* only → Off (Goldilocks recommend-only)
+              # Per-app override: vixens.io/vpa.update-mode annotation on pod template
               updateMode: >-
-                {{ request.object.spec.template.metadata.labels | values(@) | [?starts_with(@, 'V-')] | length(@) > `0` && 'InPlaceOrRecreate' || 'Off' }}
+                {{ request.object.spec.template.metadata.annotations."vixens.io/vpa.update-mode" || (request.object.spec.template.metadata.labels | values(@) | [?starts_with(@, 'V-')] | length(@) > `0` && 'InPlaceOrRecreate' || 'Off') }}
             resourcePolicy:
               containerPolicies:
                 - containerName: "*"

--- a/apps/10-home/homeassistant/overlays/prod/anti-affinity-frigate.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/anti-affinity-frigate.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homeassistant
+spec:
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: frigate
+                topologyKey: kubernetes.io/hostname

--- a/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
@@ -13,7 +13,7 @@ components:
   - ../../../../_shared/components/nometrics
   - ../../../../_shared/components/dataangel
   - ../../../../_shared/components/poddisruptionbudget/1
-  - ../../../../_shared/components/scheduling/avoid-i915
+  - ../../../../_shared/components/scheduling/prefer-i915
 
 patches:
   - target:
@@ -25,3 +25,4 @@ patches:
         value: 250Gi
   - path: resources-patch.yaml
   - path: dataangel.yaml
+  - path: anti-affinity-frigate.yaml

--- a/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
@@ -13,6 +13,7 @@ components:
   - ../../../../_shared/components/nometrics
   - ../../../../_shared/components/dataangel
   - ../../../../_shared/components/poddisruptionbudget/1
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - target:

--- a/apps/20-media/frigate/overlays/prod/kustomization.yaml
+++ b/apps/20-media/frigate/overlays/prod/kustomization.yaml
@@ -40,6 +40,7 @@ patches:
               vixens.io/sizing.frigate: V-2xlarge
             annotations:
               vixens.io/explicitly-allow-root: "true"
+              vixens.io/vpa.update-mode: "Off"
           spec:
             securityContext:
               runAsNonRoot: false


### PR DESCRIPTION
## Summary

- Ajoute support annotation `vixens.io/vpa.update-mode` dans la policy Kyverno `sizing-vpa-generate` (cohérent avec les autres overrides per-app : min-cpu, max-cpu, etc.)
- Frigate : `vixens.io/vpa.update-mode: "Off"` — Goldilocks continue de recommander, mais le VPA updater n'évicte plus

## Pourquoi

Le nœud `poison` n'a pas assez de CPU libre pour committer les resizes VPA in-place de frigate (~2431m recommandé, ~2286m disponible) → eviction loop infinie. En attendant de dimensionner correctement les requests/limits manuellement, le VPA est mis en mode observation only.

## Test plan
- [ ] VPA `vixens-frigate` passe en `updateMode: Off` après sync Kyverno
- [ ] Frigate ne reboot plus par éviction VPA
- [ ] Goldilocks dashboard montre toujours les recommandations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pod scheduling with node anti-affinity rules
  * Added per-application override capability for pod autoscaler update modes via annotations
  * Introduced GPU scheduling preference infrastructure component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->