### PR TITLE
fix(frigate): VPA updateMode Off — éviter eviction loop sur poison

### DIFF
--- a/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
+++ b/apps/00-infra/kyverno/base/policies/sizing-vpa-generate.yaml
@@ -96,8 +96,9 @@ spec:
             updatePolicy:
               # V-* sizing label present → InPlaceOrRecreate (in-place first, eviction fallback)
               # B-*/SB-*/G-* only → Off (Goldilocks recommend-only)
+              # Per-app override: vixens.io/vpa.update-mode annotation on pod template
               updateMode: >-
-                {{ request.object.spec.template.metadata.labels | values(@) | [?starts_with(@, 'V-')] | length(@) > `0` && 'InPlaceOrRecreate' || 'Off' }}
+                {{ request.object.spec.template.metadata.annotations."vixens.io/vpa.update-mode" || (request.object.spec.template.metadata.labels | values(@) | [?starts_with(@, 'V-')] | length(@) > `0` && 'InPlaceOrRecreate' || 'Off') }}
             resourcePolicy:
               containerPolicies:
                 - containerName: "*"

--- a/apps/20-media/frigate/overlays/prod/kustomization.yaml
+++ b/apps/20-media/frigate/overlays/prod/kustomization.yaml
@@ -40,6 +40,7 @@ patches:
               vixens.io/sizing.frigate: V-2xlarge
             annotations:
               vixens.io/explicitly-allow-root: "true"
+              vixens.io/vpa.update-mode: "Off"
           spec:
             securityContext:
               runAsNonRoot: false


### PR DESCRIPTION
## Summary

- Ajoute support annotation `vixens.io/vpa.update-mode` dans la policy Kyverno `sizing-vpa-generate`
- Frigate : `vixens.io/vpa.update-mode: "Off"` — Goldilocks continue de recommander, mais le VPA updater n'évicte plus

## Pourquoi

Le nœud `poison` n'a pas assez de CPU libre pour committer les resizes VPA in-place de frigate (~2431m recommandé, ~2286m disponible) → eviction loop infinie. En mode Off, on peut observer les recommandations Goldilocks et ajuster manuellement les requests/limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced pod autoscaler configuration with support for annotation-based overrides, enabling deployment-specific scaling behavior control without policy modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->