### PR TITLE
fix(openclaw): injecter ollama-local:default dans auth-profiles au démarrage

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -226,19 +226,29 @@ spec:
                       print(f'Warning: OAuth refresh failed: {e}')
               # Part 4: Inject provider API keys into all agent auth-profiles.json
               cerebras_key = os.environ.get('CEREBRAS_API_KEY', '')
-              if cerebras_key:
-                  for ap_path in glob.glob('/data/.openclaw/agents/*/agent/auth-profiles.json'):
-                      try:
-                          ap = json.loads(open(ap_path).read())
-                          ap.setdefault('profiles', {})['cerebras:default'] = {
+              for ap_path in glob.glob('/data/.openclaw/agents/*/agent/auth-profiles.json'):
+                  try:
+                      ap = json.loads(open(ap_path).read())
+                      profiles = ap.setdefault('profiles', {})
+                      # Cerebras: real API key
+                      if cerebras_key:
+                          profiles['cerebras:default'] = {
                               'type': 'api_key',
                               'provider': 'cerebras',
                               'key': cerebras_key,
                           }
-                          open(ap_path, 'w').write(json.dumps(ap, indent=2))
-                      except Exception as e:
-                          print(f'Warning: could not update {ap_path}: {e}')
+                      # Ollama: no auth needed, dummy key to satisfy openclaw
+                      profiles['ollama-local:default'] = {
+                          'type': 'api_key',
+                          'provider': 'ollama-local',
+                          'key': 'none',
+                      }
+                      open(ap_path, 'w').write(json.dumps(ap, indent=2))
+                  except Exception as e:
+                      print(f'Warning: could not update {ap_path}: {e}')
+              if cerebras_key:
                   print('Cerebras API key injected into auth profiles')
+              print('Ollama-local auth entry injected into auth profiles')
               print('Setup complete')
               PYEOF
           envFrom:


### PR DESCRIPTION
## Summary
- OpenClaw exige une entrée dans `auth-profiles.json` pour tout provider, même sans authentification
- Sans cette entrée, le fallback Ollama échoue avec `No API key found for provider "ollama-local"`
- Injection d'une clé dummy `none` pour `ollama-local:default` au même titre que Cerebras

## Test plan
- [ ] Pod redémarre → Ollama fallback fonctionnel quand Cerebras rate-limited
- [ ] `/models` dans Lisa/Sana montre `ollama-local`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to improve authentication profile initialization and ensure consistent setup of authentication entries across all agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->