### PR TITLE
fix(crowdsec): noms de machines stables + PVC config LAPI

### DIFF
--- a/apps/00-infra/crowdsec/values/common.yaml
+++ b/apps/00-infra/crowdsec/values/common.yaml
@@ -35,15 +35,25 @@ lapi:
         secretKeyRef:
           name: crowdsec-secrets
           key: CROWDSEC_DB_PASSWORD
+    # Fixed machine name: prevents creating a new CAPI identity on every pod restart
+    - name: CUSTOM_HOSTNAME
+      value: "crowdsec-lapi"
 
   persistentVolume:
     data:
       enabled: false
+    # Persist /etc/crowdsec config (online_api_credentials.yaml, local_api_credentials.yaml)
+    # Without this, the LAPI re-registers with CAPI on every restart → duplicate machine entries
     config:
-      enabled: false
+      enabled: true
+      storageClassName: synelia-iscsi-retain
+      accessModes:
+        - ReadWriteOnce
+      size: 100Mi
 
+  # Recreate: avoid overlap between old/new pods both registering simultaneously
   strategy:
-    type: RollingUpdate
+    type: Recreate
 
   resources:
     requests:
@@ -81,6 +91,13 @@ agent:
   env:
     - name: COLLECTIONS
       value: "crowdsecurity/traefik crowdsecurity/http-cve crowdsecurity/base-http-scenarios"
+    # Stable machine name based on node name: prevents new entry on every DaemonSet pod restart
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: CUSTOM_HOSTNAME
+      value: "crowdsec-agent-$(NODE_NAME)"
 
   resources:
     requests:

--- a/apps/00-infra/crowdsec/values/prod.yaml
+++ b/apps/00-infra/crowdsec/values/prod.yaml
@@ -13,6 +13,8 @@ lapi:
           key: ENROLL_KEY
     - name: ENROLL_INSTANCE_NAME
       value: "vixens-k8s-prod"
+    - name: CUSTOM_HOSTNAME
+      value: "crowdsec-lapi-prod"
     - name: ENROLL_TAGS
       value: "k8s linux homelab prod"
     - name: CROWDSEC_DB_PASSWORD


### PR DESCRIPTION
## Problem
Chaque restart de pod CrowdSec crée une nouvelle identité dans PostgreSQL et une nouvelle registration CAPI → accumulation infinie → alertes "no news" dans la console CrowdSec.

## Root Cause
- `CUSTOM_HOSTNAME` non défini → nom de machine = nom du pod (change à chaque restart)
- Pas de PV pour `/etc/crowdsec` → `online_api_credentials.yaml` perdu → nouveau `capi register` à chaque restart

## Fix
- **LAPI**: `CUSTOM_HOSTNAME=crowdsec-lapi-prod` (fixe) + PVC 100Mi (synelia-iscsi-retain) pour persister les credentials CAPI + `strategy: Recreate`
- **Agents**: `CUSTOM_HOSTNAME=crowdsec-agent-$(NODE_NAME)` via downward API → stable sur le même nœud

## Test plan
- [ ] Après déploiement: `cscli machines list` montre 6 machines avec noms stables
- [ ] Après restart LAPI: même machine `crowdsec-lapi-prod`, pas de nouvelle entrée
- [ ] Console CrowdSec: plus d'enrollments en attente

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved machine identification for CrowdSec services with fixed, descriptive hostnames for both API and agents
  * Enabled persistent storage for CrowdSec configuration to ensure data durability across restarts
  * Updated deployment strategy to enhance reliability during updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->