### PR TITLE
fix(crowdsec): remove CUSTOM_HOSTNAME from lapi.env — conflict value+valueFrom

### DIFF
--- a/apps/00-infra/crowdsec/values/common.yaml
+++ b/apps/00-infra/crowdsec/values/common.yaml
@@ -35,9 +35,8 @@ lapi:
         secretKeyRef:
           name: crowdsec-secrets
           key: CROWDSEC_DB_PASSWORD
-    # Fixed machine name: prevents creating a new CAPI identity on every pod restart
-    - name: CUSTOM_HOSTNAME
-      value: "crowdsec-lapi"
+    # Note: CUSTOM_HOSTNAME is already set by the chart template (metadata.name).
+    # Do NOT override via lapi.env — chart merges by name, causing value+valueFrom conflict.
 
   persistentVolume:
     data:

--- a/apps/00-infra/crowdsec/values/prod.yaml
+++ b/apps/00-infra/crowdsec/values/prod.yaml
@@ -13,8 +13,6 @@ lapi:
           key: ENROLL_KEY
     - name: ENROLL_INSTANCE_NAME
       value: "vixens-k8s-prod"
-    - name: CUSTOM_HOSTNAME
-      value: "crowdsec-lapi-prod"
     - name: ENROLL_TAGS
       value: "k8s linux homelab prod"
     - name: CROWDSEC_DB_PASSWORD


### PR DESCRIPTION
## Problem

ArgoCD sync failing with:
```
Deployment.apps "crowdsec-lapi" is invalid: spec.template.spec.containers[0].env[5].valueFrom:
Invalid value: "": may not be specified when `value` is not empty
```

The crowdsec chart v0.22.1 already injects `CUSTOM_HOSTNAME` at env index 5 via `fieldRef: metadata.name`. When we also add `CUSTOM_HOSTNAME` via `lapi.env`, the chart's merge-by-name produces an entry with both `value` and `valueFrom` set → Kubernetes rejects it.

## Fix

Remove `CUSTOM_HOSTNAME` from `lapi.env` in both `common.yaml` and `prod.yaml`.

The PVC for `/etc/crowdsec` (already in place) is sufficient: it persists `online_api_credentials.yaml` across pod restarts, preventing CAPI re-registration even if the pod name (and thus `CUSTOM_HOSTNAME`) changes.

## Impact

- ArgoCD will be able to sync the Deployment
- The Deployment will be updated with the config PVC mount
- LAPI will restart with persistent `/etc/crowdsec` → no more CAPI duplicates
- Agent token mismatch will resolve once LAPI restarts with the new `registrationToken`

🤖 Generated with [Claude Code](https://claude.com/claude-code)