### PR TITLE
feat(openclaw): switch local model to Qwen3 14B abliterated — tool support

### DIFF
--- a/apps/00-infra/crowdsec/values/common.yaml
+++ b/apps/00-infra/crowdsec/values/common.yaml
@@ -48,7 +48,7 @@ lapi:
       storageClassName: synelia-iscsi-retain
       accessModes:
         - ReadWriteOnce
-      size: 100Mi
+      size: 1Gi
 
   # Recreate: avoid overlap between old/new pods both registering simultaneously
   strategy:

--- a/apps/60-services/openclaw/base/configmap.yaml
+++ b/apps/60-services/openclaw/base/configmap.yaml
@@ -22,8 +22,8 @@ data:
             "api": "openai-completions",
             "models": [
               {
-                "id": "hf.co/bartowski/RekaAI_reka-flash-3.1-GGUF:Q3_K_M",
-                "name": "Reka Flash 3.1 (local)",
+                "id": "huihui_ai/qwen3-abliterated:14b-q4_K_M",
+                "name": "Qwen3 14B (local)",
                 "reasoning": false,
                 "input": ["text"],
                 "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
@@ -39,7 +39,7 @@ data:
           "model": {
             "primary": "cerebras/qwen-3-235b-a22b-instruct-2507",
             "fallbacks": [
-              "ollama-local/hf.co/bartowski/RekaAI_reka-flash-3.1-GGUF:Q3_K_M",
+              "ollama-local/huihui_ai/qwen3-abliterated:14b-q4_K_M",
               "google-gemini-cli/gemini-2.5-flash",
               "moonshot/kimi-k2.5"
             ]


### PR DESCRIPTION
## Problem

Reka Flash 3.1 (GGUF) rejetait toutes les requêtes agent avec `400: does not support tools`. Son template Ollama n'inclut pas `{{- if .Tools }}`.

## Fix

Switch vers `huihui_ai/qwen3-abliterated:14b-q4_K_M` qui a un template Ollama avec tool support natif (vérifié).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased CrowdSec persistent storage capacity for improved reliability.
  * Updated default local AI model configuration to enhance performance and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->