### PR TITLE
fix(openclaw): toujours écraser openclaw.json depuis ConfigMap (DataAngel restore)

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -146,11 +146,10 @@ spec:
             - -c
           args:
             - |
-              # Ensure default config exists
-              if [ ! -s /data/openclaw.json ]; then
-                echo "No config found, copying default..."
-                cp /default-config/openclaw.json /data/openclaw.json 2>/dev/null || true
-              fi
+              # Always overwrite config from ConfigMap (source of truth)
+              # DataAngel restores /data from S3 (including old openclaw.json) — must overwrite
+              echo "Copying config from ConfigMap..."
+              cp /default-config/openclaw.json /data/openclaw.json
               python3 << 'PYEOF'
               import json, base64, os, pathlib
 


### PR DESCRIPTION
## Problem

`setup-config` ne copiait le ConfigMap → `/data/openclaw.json` que si le fichier était absent. DataAngel restaure toujours `/data` depuis S3 au démarrage, donc le modèle local restait sur l'ancienne version (Reka Flash) même après mise à jour du ConfigMap.

## Fix

Supprimer le `if [ ! -s ]` — toujours écraser depuis le ConfigMap. Le ConfigMap est la source de vérité pour la config OpenClaw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration initialization to unconditionally synchronize from the authoritative configuration source. Eliminated conditional file existence checks that could result in missing or inconsistent configurations, ensuring all service deployments reliably begin with current, validated configuration state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->