### PR TITLE
fix(openclaw): qwen3 officiel — abliterated ignorait les personas

### DIFF
--- a/apps/60-services/openclaw/base/configmap.yaml
+++ b/apps/60-services/openclaw/base/configmap.yaml
@@ -22,7 +22,7 @@ data:
             "api": "openai-completions",
             "models": [
               {
-                "id": "huihui_ai/qwen3-abliterated:14b-q4_K_M",
+                "id": "qwen3:14b-q4_K_M",
                 "name": "Qwen3 14B (local)",
                 "reasoning": false,
                 "input": ["text"],
@@ -39,7 +39,7 @@ data:
           "model": {
             "primary": "cerebras/qwen-3-235b-a22b-instruct-2507",
             "fallbacks": [
-              "ollama-local/huihui_ai/qwen3-abliterated:14b-q4_K_M",
+              "ollama-local/qwen3:14b-q4_K_M",
               "google-gemini-cli/gemini-2.5-flash",
               "moonshot/kimi-k2.5"
             ]


### PR DESCRIPTION
## Problem

`huihui_ai/qwen3-abliterated:14b-q4_K_M` :
- Répondait en chinois en ignorant la langue de l'utilisateur
- Ignorait la persona de l'agent (system prompt)
- Appelait des outils aléatoirement sans discriminer

## Fix

Switch vers `qwen3:14b-q4_K_M` (officiel Ollama) — meilleur alignment, suivi d'instructions et tool use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AI model identifier references in service configuration to reflect current model versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->