### PR TITLE
chore(openclaw): annotation config-version pour forcer restart sur changement ConfigMap

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -26,6 +26,8 @@ spec:
       annotations:
         vixens.io/fast-start: "true"
         vixens.io/nometrics: "true"
+        # Bump this when openclaw-config ConfigMap changes to force pod restart
+        vixens.io/config-version: "4"
 
     spec:
       securityContext:


### PR DESCRIPTION
ArgoCD ne redémarre pas le pod quand seul le ConfigMap change. Ajout d'une annotation `vixens.io/config-version` à bumper manuellement à chaque modif du ConfigMap `openclaw-config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to automatically restart services when configuration updates are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->