### PR TITLE
fix(openclaw): API Ollama native + streaming:false — fix persona et tool calls

### DIFF
--- a/apps/60-services/openclaw/base/configmap.yaml
+++ b/apps/60-services/openclaw/base/configmap.yaml
@@ -18,17 +18,22 @@ data:
       "models": {
         "providers": {
           "ollama-local": {
-            "baseUrl": "http://192.168.199.119:11434/v1",
-            "api": "openai-completions",
+            "baseUrl": "http://192.168.199.119:11434",
+            "api": "ollama",
             "models": [
               {
                 "id": "qwen3:14b-q4_K_M",
-                "name": "Qwen3 14B (local)",
+                "name": "Qwen3 14B Local",
                 "reasoning": false,
+                "streaming": false,
+                "contextWindow": 40960,
+                "maxTokens": 4096,
                 "input": ["text"],
                 "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
-                "contextWindow": 32768,
-                "maxTokens": 4096
+                "compat": {
+                  "supportsDeveloperRole": false,
+                  "supportsReasoningEffort": false
+                }
               }
             ]
           }

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -26,6 +26,8 @@ spec:
       annotations:
         vixens.io/fast-start: "true"
         vixens.io/nometrics: "true"
+        # Bump this when openclaw-config ConfigMap changes to force pod restart
+        vixens.io/config-version: "4"
 
     spec:
       securityContext:

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         vixens.io/fast-start: "true"
         vixens.io/nometrics: "true"
         # Bump this when openclaw-config ConfigMap changes to force pod restart
-        vixens.io/config-version: "4"
+        vixens.io/config-version: "5"
 
     spec:
       securityContext:


### PR DESCRIPTION
## Root cause

Le persona de Lisa était ignoré par Qwen3 local à cause de deux problèmes :

1. **`api: "openai-completions"`** → utilise `/v1` qui tronque les tool definitions envoyées par OpenClaw
2. **`streaming: true` (défaut)** → Ollama ne gère pas les `tool_calls` delta chunks en streaming → le modèle décrit les tools en texte au lieu de les exécuter
3. **`reasoning` absent + OpenAI API** → system prompt envoyé en `role: developer` que Ollama drop silencieusement → persona/SOUL.md/IDENTITY.md perdu

## Fix

- `api: "ollama"` (API native `/api/chat`)
- `streaming: false`
- `reasoning: false` explicite
- `compat: {supportsDeveloperRole: false, supportsReasoningEffort: false}`
- `contextWindow: 40960` (max Qwen3 14B)
- `baseUrl` sans `/v1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Ollama model provider configuration and API integration.
  * Increased Qwen3 14B model context window from 32,768 to 40,960 tokens.
  * Adjusted model display name and compatibility settings.

* **Chores**
  * Improved deployment update mechanism to properly handle configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->