### PR TITLE
fix(openclaw): retirer streaming — clé non reconnue (crash)

### DIFF
--- a/apps/60-services/openclaw/base/configmap.yaml
+++ b/apps/60-services/openclaw/base/configmap.yaml
@@ -25,7 +25,6 @@ data:
                 "id": "qwen3:14b-q4_K_M",
                 "name": "Qwen3 14B Local",
                 "reasoning": false,
-                "streaming": false,
                 "contextWindow": 40960,
                 "maxTokens": 4096,
                 "input": ["text"],

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         vixens.io/fast-start: "true"
         vixens.io/nometrics: "true"
         # Bump this when openclaw-config ConfigMap changes to force pod restart
-        vixens.io/config-version: "5"
+        vixens.io/config-version: "6"
 
     spec:
       securityContext:


### PR DESCRIPTION
OpenClaw crashait au démarrage : `Unrecognized key: "streaming"`. Le champ n'existe pas dans le schéma OpenClaw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated model configuration settings for the local AI provider
  * Refreshed service deployment to apply configuration changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->