### PR TITLE
fix(openclaw): revert api ollama — provider non reconnu, openai-completions + compat

### DIFF
--- a/apps/60-services/openclaw/base/configmap.yaml
+++ b/apps/60-services/openclaw/base/configmap.yaml
@@ -18,8 +18,8 @@ data:
       "models": {
         "providers": {
           "ollama-local": {
-            "baseUrl": "http://192.168.199.119:11434",
-            "api": "ollama",
+            "baseUrl": "http://192.168.199.119:11434/v1",
+            "api": "openai-completions",
             "models": [
               {
                 "id": "qwen3:14b-q4_K_M",

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         vixens.io/fast-start: "true"
         vixens.io/nometrics: "true"
         # Bump this when openclaw-config ConfigMap changes to force pod restart
-        vixens.io/config-version: "6"
+        vixens.io/config-version: "7"
 
     spec:
       securityContext:


### PR DESCRIPTION
OpenClaw ne reconnaît pas `api: "ollama"`. Retour à `openai-completions` avec `compat.supportsDeveloperRole: false` pour empêcher l'envoi de `role: developer` (droppé silencieusement par Ollama → persona perdu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the model provider configuration for the openclaw service
  * Incremented deployment configuration version to apply new settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->