### PR TITLE
fix(openclaw): fix mempalace venv python symlinks

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -350,6 +350,10 @@ spec:
                 echo "$MEMPALACE_VERSION" > "$VERSION_FILE"
                 echo "mempalace installed successfully"
               fi
+              # Fix venv symlinks: init container uses /usr/local/bin/python3 but openclaw has /usr/bin/python3
+              ln -sf /usr/bin/python3 "$VENV_PATH/bin/python3"
+              ln -sf /usr/bin/python3 "$VENV_PATH/bin/python"
+              ln -sf /usr/bin/python3 "$VENV_PATH/bin/python3.11"
               chown -R 1000:1000 "$VENV_PATH" 2>/dev/null || true
           volumeMounts:
             - name: data


### PR DESCRIPTION
## Problem

`python:3.11-slim` creates the venv with symlinks pointing to `/usr/local/bin/python3`. The openclaw container has Python at `/usr/bin/python3`. Result: broken symlinks, CLI and MCP server unusable.

## Fix

After venv creation/install, patch the 3 symlinks to `/usr/bin/python3` (idempotent, runs on every pod start regardless of version cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)