### PR TITLE
fix(openclaw): mark Gemma models supportsTools=false for mempalace compat

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -357,6 +357,10 @@ spec:
                 echo "$MEMPALACE_VERSION" > "$VERSION_FILE"
                 echo "mempalace installed successfully"
               fi
+              # Fix venv symlinks: init container uses /usr/local/bin/python3 but openclaw has /usr/bin/python3
+              ln -sf /usr/bin/python3 "$VENV_PATH/bin/python3"
+              ln -sf /usr/bin/python3 "$VENV_PATH/bin/python"
+              ln -sf /usr/bin/python3 "$VENV_PATH/bin/python3.11"
               chown -R 1000:1000 "$VENV_PATH" 2>/dev/null || true
           volumeMounts:
             - name: data

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -170,6 +170,13 @@ spec:
                           'args': ['-m', 'mempalace.mcp_server'],
                       }
                       print('mempalace MCP server injected')
+                  # Fix Gemma compat: mark as not supporting tools so openclaw skips tool injection
+                  # (mempalace MCP adds tools to every request; Gemma rejects tool-bearing requests)
+                  providers = d.get('models', {}).get('providers', {})
+                  ollama = providers.get('ollama-local', {})
+                  for model in ollama.get('models', []):
+                      if 'gemma' in model.get('id', '').lower():
+                          model.setdefault('compat', {})['supportsTools'] = False
                   json.dump(d, open(p, 'w'))
                   print('Config keys checked')
 


### PR DESCRIPTION
## Problem

After adding the MemPalace MCP server (#2899), every LLM request includes tool definitions. Gemma (via Ollama) doesn't support tool calling and returns a 400 error. This caused the entire `ollama-local` auth profile to enter cooldown, breaking the fallback chain — Lisa stopped responding.

## Fix

In `setup-config`, auto-patch all Gemma models with `compat.supportsTools = false` so OpenClaw skips tool injection when routing to those models. They remain available for tool-free usage via `/model`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration Updates**
  * Gemma models are now explicitly configured to not support tool operations in Openclaw. This prevents compatibility issues and ensures correct behavior for tool-related requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->