### PR TITLE
fix(openclaw): install python3-venv before mempalace venv (CrashLoopBackOff)

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -337,6 +337,7 @@ spec:
                 echo "mempalace v$MEMPALACE_VERSION already installed, skipping"
               else
                 echo "Installing mempalace v$MEMPALACE_VERSION..."
+                apt-get install -y --no-install-recommends python3-venv -qq
                 python3 -m venv "$VENV_PATH"
                 "$VENV_PATH/bin/pip" install --no-cache-dir "mempalace==$MEMPALACE_VERSION"
                 echo "$MEMPALACE_VERSION" > "$VERSION_FILE"


### PR DESCRIPTION
node:24-bookworm has Python 3.11 but without python3-venv package — ensurepip unavailable → CrashLoopBackOff. Add apt-get install python3-venv before venv creation (inside the version-cached block, so only on first install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of service deployment initialization by ensuring required system dependencies are properly installed during the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->