### PR TITLE
fix(openclaw): add --break-system-packages to pip install mempalace

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -338,7 +338,7 @@ spec:
               else
                 echo "Installing mempalace v$MEMPALACE_VERSION (no venv — pip --target)..."
                 curl -sSL https://bootstrap.pypa.io/get-pip.py | python3 - --quiet
-                python3 -m pip install --target="$MEMPALACE_PACKAGES" --no-cache-dir "mempalace==$MEMPALACE_VERSION" -q
+                python3 -m pip install --target="$MEMPALACE_PACKAGES" --no-cache-dir --break-system-packages "mempalace==$MEMPALACE_VERSION" -q
                 echo "$MEMPALACE_VERSION" > "$VERSION_FILE"
                 echo "mempalace installed successfully"
               fi


### PR DESCRIPTION
PEP 668 externally-managed-environment blocks pip on bookworm nodes. Since we install to --target (isolated directory, not system packages), --break-system-packages is safe here.