### PR TITLE
fix(openclaw): get-pip.py non-fatal + fix MCP server python path

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -165,8 +165,12 @@ spec:
                   if 'mempalace' not in servers:
                       servers['mempalace'] = {
                           'type': 'stdio',
-                          'command': '/data/tools/mempalace-venv/bin/python3',
+                          'command': 'python3',
                           'args': ['-m', 'mempalace.mcp_server'],
+                          'env': {
+                              'PYTHONPATH': '/data/tools/mempalace-packages',
+                              'MEMPALACE_PALACE_PATH': '/data/.mempalace',
+                          },
                       }
                       print('mempalace MCP server injected')
                   # Fix Gemma compat: mark as not supporting tools so openclaw skips tool injection
@@ -337,7 +341,7 @@ spec:
                 echo "mempalace v$MEMPALACE_VERSION already installed, skipping"
               else
                 echo "Installing mempalace v$MEMPALACE_VERSION (no venv — pip --target)..."
-                curl -sSL https://bootstrap.pypa.io/get-pip.py | python3 - --quiet
+                (curl -sSL https://bootstrap.pypa.io/get-pip.py | python3 - --quiet) || true
                 python3 -m pip install --target="$MEMPALACE_PACKAGES" --no-cache-dir --break-system-packages "mempalace==$MEMPALACE_VERSION" -q
                 echo "$MEMPALACE_VERSION" > "$VERSION_FILE"
                 echo "mempalace installed successfully"


### PR DESCRIPTION
Two fixes for mempalace installation CrashLoopBackOff:

1. **set -e + get-pip.py**: install-gemini has `set -e`. The `get-pip.py` bootstrap fails with PEP 668 `externally-managed-environment` (exit 1), which aborts the script before `pip install --break-system-packages` runs. Fix: wrap get-pip.py in a subshell with `|| true`.

2. **Wrong MCP path**: setup-config was still injecting the old venv path `/data/tools/mempalace-venv/bin/python3` for the mempalace MCP server. Fix: use `python3` command with `PYTHONPATH=/data/tools/mempalace-packages` env var.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined openclaw deployment configuration with streamlined mempalace service initialization, improved Python environment setup, and enhanced installation robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->