### PR TITLE
fix(openclaw): install python3-pip via apt for mempalace

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -340,8 +340,8 @@ spec:
               if [ -f "$VERSION_FILE" ] && [ "$(cat $VERSION_FILE)" = "$MEMPALACE_VERSION" ] && [ -d "$MEMPALACE_PACKAGES" ]; then
                 echo "mempalace v$MEMPALACE_VERSION already installed, skipping"
               else
-                echo "Installing mempalace v$MEMPALACE_VERSION (no venv — pip --target)..."
-                (curl -sSL https://bootstrap.pypa.io/get-pip.py | python3 - --quiet) || true
+                echo "Installing mempalace v$MEMPALACE_VERSION..."
+                apt-get update -qq && apt-get install -y --no-install-recommends python3-pip -qq
                 python3 -m pip install --target="$MEMPALACE_PACKAGES" --no-cache-dir --break-system-packages "mempalace==$MEMPALACE_VERSION" -q
                 echo "$MEMPALACE_VERSION" > "$VERSION_FILE"
                 echo "mempalace installed successfully"


### PR DESCRIPTION
node:24-bookworm has no pip module and get-pip.py fails with PEP 668 externally-managed-environment. Fix: use `apt-get install python3-pip` inside the version-check block. Runs once on first install, skipped on future restarts when VERSION_FILE exists.