### PR TITLE
fix(openclaw): symlink /home/node/.gemini to /data/.gemini on postStart

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -354,6 +354,10 @@ spec:
       containers:
         - name: openclaw
           lifecycle:
+            postStart:
+              exec:
+                # Symlink /home/node/.gemini → /data/.gemini so gemini-cli finds OAuth creds
+                command: ["/bin/sh", "-c", "rm -rf /home/node/.gemini && ln -sfn /data/.gemini /home/node/.gemini"]
             preStop:
               exec:
                 command: ["sleep", "5"]


### PR DESCRIPTION
gemini-cli reads auth from `HOME/.gemini` but setup-config writes credentials to `/data/.gemini`. The symlink bridges this gap.