### PR TITLE
fix(openclaw): scale up replica to 1

### DIFF
--- a/apps/60-services/openclaw/overlays/dev/kustomization.yaml
+++ b/apps/60-services/openclaw/overlays/dev/kustomization.yaml
@@ -12,4 +12,4 @@ patches:
     patch: |
       - op: replace
         path: /spec/replicas
-        value: 0
+        value: 1


### PR DESCRIPTION
## Summary
- Remettre replicas à 1 (était à 0 depuis la session précédente)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deployment configuration in the development environment to ensure the service is properly scaled and operational.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->