### PR TITLE
fix(openclaw): gateway.controlUi fallback for 2026.4.14

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -180,6 +180,12 @@ spec:
                   for model in ollama.get('models', []):
                       if 'gemma' in model.get('id', '').lower():
                           model.setdefault('compat', {})['supportsTools'] = False
+                  # Fix gateway.controlUi for 2026.4.14+ (requires allowedOrigins or fallback)
+                  gateway_cfg = d.setdefault('gateway', {})
+                  control_ui = gateway_cfg.setdefault('controlUi', {})
+                  if not control_ui.get('allowedOrigins') and not control_ui.get('dangerouslyAllowHostHeaderOriginFallback'):
+                      control_ui['dangerouslyAllowHostHeaderOriginFallback'] = True
+                      print('gateway.controlUi fallback enabled')
                   json.dump(d, open(p, 'w'))
                   print('Config keys checked')
 


### PR DESCRIPTION
## Summary
- 2026.4.14 exige `gateway.controlUi.allowedOrigins` ou `dangerouslyAllowHostHeaderOriginFallback=true`
- Injection dans setup-config (openclaw.json) si pas déjà configuré

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced configuration initialization to ensure proper gateway and controlUi defaults for openclaw 2026.4.14 and later versions. Automatically sets necessary fallback parameters when not explicitly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->