### PR TITLE
fix(openclaw): cerebras comme modèle par défaut

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -186,8 +186,20 @@ spec:
                   if not control_ui.get('allowedOrigins') and not control_ui.get('dangerouslyAllowHostHeaderOriginFallback'):
                       control_ui['dangerouslyAllowHostHeaderOriginFallback'] = True
                       print('gateway.controlUi fallback enabled')
-                  # Remove any invalid agentModel key (not recognized by OpenClaw)
                   gateway_cfg.pop('agentModel', None)
+                  # Configure default model (cerebras) + fallbacks if not set
+                  agent_defaults = d.setdefault('agents', {}).setdefault('defaults', {})
+                  if not agent_defaults.get('model', {}).get('primary'):
+                      agent_defaults['model'] = {
+                          'primary': 'cerebras/qwen-3-235b-a22b-instruct-2507',
+                          'fallbacks': ['cerebras/gpt-oss-120b', 'cerebras/llama3.1-8b'],
+                      }
+                      agent_defaults.setdefault('models', {}).update({
+                          'cerebras/qwen-3-235b-a22b-instruct-2507': {},
+                          'cerebras/gpt-oss-120b': {},
+                          'cerebras/llama3.1-8b': {},
+                      })
+                      print('Default model set: cerebras/qwen-3-235b-a22b-instruct-2507')
                   json.dump(d, open(p, 'w'))
                   print('Config keys checked')
 


### PR DESCRIPTION
## Summary
- Injecte `agents.defaults.model` dans openclaw.json au démarrage
- Primary: `cerebras/qwen-3-235b-a22b-instruct-2507`
- Fallbacks: `cerebras/gpt-oss-120b`, `cerebras/llama3.1-8b`
- Évite le défaut `openai/gpt-5.4` qui crash (pas de clé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed default agent model configuration initialization to ensure proper setup during service deployment.

* **Chores**
  * Updated service deployment configuration to streamline model initialization and fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->