### PR TITLE
feat(sakapuss): déploiement initial dans le cluster dev

### DIFF
--- a/apps/60-services/sakapuss/base/deployment.yaml
+++ b/apps/60-services/sakapuss/base/deployment.yaml
@@ -1,0 +1,128 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sakapuss-backend
+  labels:
+    app: sakapuss
+    component: backend
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: sakapuss
+      component: backend
+  template:
+    metadata:
+      labels:
+        app: sakapuss
+        component: backend
+        vixens.io/sizing.sakapuss-backend: V-nano
+        vixens.io/backup-profile: important
+      annotations:
+        reloader.stakater.com/auto: "true"
+    spec:
+      priorityClassName: vixens-medium
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: backend
+          image: ghcr.io/charchess/sakapuss-backend:latest
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            - name: SAKAPUSS_DB_PATH
+              value: /data/sakapuss.db
+            - name: SAKAPUSS_MEDIA_PATH
+              value: /media
+          envFrom:
+            - secretRef:
+                name: sakapuss-secrets
+                optional: true
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: media
+              mountPath: /media
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: sakapuss-data
+        - name: media
+          persistentVolumeClaim:
+            claimName: sakapuss-media
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sakapuss-frontend
+  labels:
+    app: sakapuss
+    component: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sakapuss
+      component: frontend
+  template:
+    metadata:
+      labels:
+        app: sakapuss
+        component: frontend
+        vixens.io/sizing.sakapuss-frontend: V-nano
+    spec:
+      priorityClassName: vixens-medium
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: frontend
+          image: ghcr.io/charchess/sakapuss-frontend:latest
+          ports:
+            - containerPort: 80
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi

--- a/apps/60-services/sakapuss/base/kustomization.yaml
+++ b/apps/60-services/sakapuss/base/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: services
+resources:
+  - deployment.yaml
+  - service.yaml
+  - pvc.yaml

--- a/apps/60-services/sakapuss/base/pvc.yaml
+++ b/apps/60-services/sakapuss/base/pvc.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sakapuss-data
+  labels:
+    app: sakapuss
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: synelia-iscsi-delete
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sakapuss-media
+  labels:
+    app: sakapuss
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: synelia-iscsi-delete
+  resources:
+    requests:
+      storage: 5Gi

--- a/apps/60-services/sakapuss/base/service.yaml
+++ b/apps/60-services/sakapuss/base/service.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sakapuss-backend
+  labels:
+    app: sakapuss
+    component: backend
+spec:
+  selector:
+    app: sakapuss
+    component: backend
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8000
+      targetPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sakapuss-frontend
+  labels:
+    app: sakapuss
+    component: frontend
+spec:
+  selector:
+    app: sakapuss
+    component: frontend
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80

--- a/apps/60-services/sakapuss/overlays/dev/ingress.yaml
+++ b/apps/60-services/sakapuss/overlays/dev/ingress.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sakapuss-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+    traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    traefik.ingress.kubernetes.io/router.middlewares-requestbodysize: "10485760"
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Sakapuss
+    gethomepage.dev/icon: mdi-paw
+    gethomepage.dev/group: Services
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: sakapuss.dev.truxonline.com
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: sakapuss-backend
+                port:
+                  number: 8000
+          - path: /media
+            pathType: Prefix
+            backend:
+              service:
+                name: sakapuss-backend
+                port:
+                  number: 8000
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: sakapuss-frontend
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - sakapuss.dev.truxonline.com
+      secretName: sakapuss-tls

--- a/apps/60-services/sakapuss/overlays/dev/kustomization.yaml
+++ b/apps/60-services/sakapuss/overlays/dev/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - ingress.yaml

--- a/argocd/overlays/dev/apps/sakapuss.yaml
+++ b/argocd/overlays/dev/apps/sakapuss.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sakapuss
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: main
+    path: apps/60-services/sakapuss/overlays/dev
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/overlays/dev/kustomization.yaml
+++ b/argocd/overlays/dev/kustomization.yaml
@@ -61,6 +61,7 @@ resources:
   # Services (commented)
   # - apps/vaultwarden.yaml
   - apps/openclaw.yaml
+  - apps/sakapuss.yaml
   # - apps/cloudnative-pg-crds.yaml
   # - apps/cloudnative-pg.yaml
   # - apps/redis-shared.yaml


### PR DESCRIPTION
## Summary
- Backend FastAPI (SQLite + media) avec PVCs iSCSI Synology (1Gi data + 5Gi media)
- Frontend SvelteKit (nginx statique)
- Ingress Traefik → `sakapuss.dev.truxonline.com` (letsencrypt-staging)
- Images depuis `ghcr.io/charchess/sakapuss-{backend,frontend}:latest` (CI déjà en place)
- ArgoCD Application enregistrée dans le cluster dev

## Test plan
- [ ] Images buildées et poussées sur ghcr.io
- [ ] PVCs créés sur Synology
- [ ] Pods backend + frontend démarrent
- [ ] `https://sakapuss.dev.truxonline.com` accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)