### PR TITLE
fix(sakapuss): nginx upstream K8s + fast-start

### DIFF
--- a/apps/60-services/sakapuss/base/deployment.yaml
+++ b/apps/60-services/sakapuss/base/deployment.yaml
@@ -23,6 +23,7 @@ spec:
         vixens.io/backup-profile: important
       annotations:
         reloader.stakater.com/auto: "true"
+        vixens.io/fast-start: "true"
     spec:
       priorityClassName: vixens-medium
       tolerations:

--- a/apps/60-services/sakapuss/overlays/dev/kustomization.yaml
+++ b/apps/60-services/sakapuss/overlays/dev/kustomization.yaml
@@ -4,3 +4,9 @@ kind: Kustomization
 resources:
   - ../../base
   - ingress.yaml
+  - nginx-config.yaml
+patches:
+  - path: patch-frontend-nginx.yaml
+    target:
+      kind: Deployment
+      name: sakapuss-frontend

--- a/apps/60-services/sakapuss/overlays/dev/nginx-config.yaml
+++ b/apps/60-services/sakapuss/overlays/dev/nginx-config.yaml
@@ -1,0 +1,36 @@
+---
+# Override nginx.conf pour K8s: le proxy passe par le service sakapuss-backend
+# (vs "backend" en docker-compose)
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sakapuss-nginx-config
+  labels:
+    app: sakapuss
+    component: frontend
+data:
+  default.conf: |
+    server {
+        listen 80;
+        server_name _;
+
+        root /usr/share/nginx/html;
+        index index.html;
+
+        location /api/ {
+            proxy_pass http://sakapuss-backend:8000/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /media/ {
+            proxy_pass http://sakapuss-backend:8000/media/;
+            proxy_set_header Host $host;
+        }
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }

--- a/apps/60-services/sakapuss/overlays/dev/patch-frontend-nginx.yaml
+++ b/apps/60-services/sakapuss/overlays/dev/patch-frontend-nginx.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sakapuss-frontend
+spec:
+  template:
+    metadata:
+      annotations:
+        vixens.io/fast-start: "true"
+    spec:
+      containers:
+        - name: frontend
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: sakapuss-nginx-config


### PR DESCRIPTION
## Summary
- Frontend nginx cherchait `backend:8000` (docker-compose) → crash en K8s
- ConfigMap avec `sakapuss-backend:8000` + patch deployment pour le monter
- `vixens.io/fast-start: true` sur les deux déploiements (bypass Kyverno startupProbe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)