### PR TITLE
fix(synology-csi): scale up controller in dev to provision PVCs

### DIFF
--- a/apps/01-storage/synology-csi/overlays/dev/kustomization.yaml
+++ b/apps/01-storage/synology-csi/overlays/dev/kustomization.yaml
@@ -10,6 +10,17 @@ namespace: synology-csi
 components:
   - ../../../../_shared/components/dev-hibernate
 patches:
+  # CSI controller must run to provision PVCs — override dev-hibernate for infrastructure
+  - patch: |-
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: synology-csi-controller
+      spec:
+        replicas: 1
+    target:
+      kind: StatefulSet
+      name: synology-csi-controller
   - patch: |-
       - op: replace
         path: /parameters/igroup


### PR DESCRIPTION
## Summary
- The `dev-hibernate` component sets all StatefulSets to 0 replicas
- The synology-csi-controller is infrastructure, not an app — it must run to provision iSCSI PVCs
- Without it, any new PVC using `synelia-iscsi-delete`/`synelia-iscsi-retain` stays Pending forever
- sakapuss PVCs (`sakapuss-data`, `sakapuss-media`) are blocked by this

## Fix
Override dev-hibernate for the controller StatefulSet specifically: `replicas: 1`

## Test plan
- [ ] synology-csi-controller pod starts in dev
- [ ] sakapuss-data and sakapuss-media PVCs bind
- [ ] sakapuss-backend pod starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)