### PR TITLE
fix(openclaw): reduce memory request 2Gi→512Mi to unblock Kyverno on dev cluster

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -410,10 +410,10 @@ spec:
           resources:
             requests:
               cpu: 200m
-              memory: 2Gi
+              memory: 512Mi
             limits:
               cpu: 2000m
-              memory: 8Gi
+              memory: 4Gi
           image: ghcr.io/openclaw/openclaw:2026.4.14
           imagePullPolicy: Always
           command:


### PR DESCRIPTION
## Summary
- The dev cluster has a single node (~7.2GiB allocatable memory)
- openclaw was requesting 2Gi which, combined with other apps, left no room for Kyverno (4 pods × ~128Mi = 512Mi needed)
- Kyverno being down blocked PVC binding via `validate.kyverno.svc-fail` webhook
- This cascaded: CSI provisioned volumes but controller-manager couldn't bind PVCs → sakapuss stuck

## Fix
Reduce openclaw memory request from 2Gi to 512Mi (limit from 8Gi to 4Gi). The app calls the Cerebras API and doesn't hold models in memory, so actual usage is well under 512Mi.

## Test plan
- [ ] Kyverno admission controller schedules and starts
- [ ] sakapuss-data and sakapuss-media PVCs bind
- [ ] sakapuss-backend pod starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)