### PR TITLE
fix(sakapuss): backup-profile important→standard (valid kyverno enum value)

### DIFF
--- a/apps/60-services/sakapuss/base/deployment.yaml
+++ b/apps/60-services/sakapuss/base/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app: sakapuss
         component: backend
         vixens.io/sizing.sakapuss-backend: V-nano
-        vixens.io/backup-profile: important
+        vixens.io/backup-profile: standard
       annotations:
         reloader.stakater.com/auto: "true"
         vixens.io/fast-start: "true"


### PR DESCRIPTION
## Summary
- `vixens.io/backup-profile: important` triggers a Kyverno validation error
- Valid values are: `critical, standard, relaxed, ephemeral`
- Changed to `standard` (sakapuss has persistent SQLite DB + media files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend service deployment configuration to adjust backup profile settings for improved resource optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->