### PR TITLE
fix(openclaw): init containers B-xlarge→B-medium to fix dev cluster OOM

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -18,8 +18,8 @@ spec:
     metadata:
       labels:
         app: openclaw
-        vixens.io/sizing.install-tools: B-xlarge
-        vixens.io/sizing.install-gemini: B-xlarge
+        vixens.io/sizing.install-tools: B-medium
+        vixens.io/sizing.install-gemini: B-medium
         vixens.io/sizing.openclaw: V-xlarge
         vixens.io/backup-profile: "relaxed"
       annotations:


### PR DESCRIPTION
## Summary
- Init containers `install-tools` and `install-gemini` had `B-xlarge` sizing label
- The sizing webhook injects **2Gi memory request per B-xlarge container**
- With 2 init containers × 2Gi = 4Gi just for setup, the single-node dev cluster (~7.2Gi allocatable) can't fit kyverno (512Mi) and other infra
- This caused a cascade: kyverno can't schedule → webhook fails → pod creation loops

## Fix
Change init container sizing from `B-xlarge` (2Gi) to `B-medium` (512Mi). These containers run `npm install` and Python config scripts — they don't need 2Gi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)