### PR TITLE
fix(sakapuss): local-path-delete storage for dev instead of iSCSI

### DIFF
--- a/apps/60-services/sakapuss/base/pvc.yaml
+++ b/apps/60-services/sakapuss/base/pvc.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: synelia-iscsi-delete
+  storageClassName: local-path-delete
   resources:
     requests:
       storage: 1Gi
@@ -22,7 +22,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: synelia-iscsi-delete
+  storageClassName: local-path-delete
   resources:
     requests:
       storage: 5Gi


### PR DESCRIPTION
## Summary
- iSCSI is shared between dev and prod clusters on the same Synology NAS
- Using `synelia-iscsi-delete` in dev impacted the shared NAS and caused issues
- `local-path-delete` is appropriate for a single-node dev cluster with ephemeral workloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)