### PR TITLE
fix(openclaw): install clawhub CLI in init container

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -118,6 +118,12 @@ spec:
                 apt-get clean && rm -rf /var/lib/apt/lists/*
                 echo "Tools installed successfully"
               fi
+              # Always ensure clawhub CLI is installed (idempotent)
+              if [ ! -f /data/tools/bin/clawhub ]; then
+                echo "Installing clawhub CLI..."
+                npm install -g --prefix /data/tools clawhub
+                echo "clawhub installed"
+              fi
               # Always install/update truxonline CA cert (fast, idempotent)
               if [ -f /data/workspace/truxonline-ca.pem ]; then
                 mkdir -p /usr/local/share/ca-certificates
@@ -448,6 +454,8 @@ spec:
               value: discord,github,telegram,@clawdbot/google-gemini-cli-auth
             - name: NODE_PATH
               value: /data/node_modules
+            - name: NPM_CONFIG_PREFIX
+              value: /data/tools
             - name: NODE_EXTRA_CA_CERTS
               value: /data/workspace/truxonline-ca.pem
             - name: REQUESTS_CA_BUNDLE


### PR DESCRIPTION
## Summary

- `clawhub` binary was absent — skill defined at `/app/skills/clawhub/SKILL.md` but npm package never installed
- Main container runs as uid 1000, `npm install -g` requires root → use `--prefix /data/tools` instead
- Added idempotent install step in `install-tools` init container (outside the version block — no TOOLS_VERSION bump needed)
- Manually installed clawsec skill in the running pod (`clawhub install clawsec`) — will persist across restarts via `/data/workspace`

## Test plan

- [ ] Pod restarts cleanly (init container installs clawhub)
- [ ] `clawhub list` works in openclaw pod
- [ ] Lisa can use the `clawhub` skill to install/search skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced clawhub CLI availability during deployment initialization by implementing an idempotent installation check, ensuring the tool is accessible earlier in the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->