### PR TITLE
fix(mosquitto): allow Traefik in CiliumNetworkPolicy for MQTT ingress

### DIFF
--- a/apps/10-home/mosquitto/base/cilium-networkpolicy.yaml
+++ b/apps/10-home/mosquitto/base/cilium-networkpolicy.yaml
@@ -11,6 +11,8 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: homeassistant
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
       toPorts:
         - ports:
             - port: "1883"


### PR DESCRIPTION
## Root cause

`CiliumNetworkPolicy` only allowed port 1883 from namespace `homeassistant`. Traefik pods (namespace `traefik`) were silently dropped by Cilium, causing:

```
Error while dialing backend: dial tcp 10.244.1.38:1883: connect: connection timed out
```

The `IngressRouteTCP`, service, and mosquitto pod were all fine.

## Fix

Add `traefik` namespace to the allowed ingress sources on port 1883.

## Test plan

- [ ] MQTT connections via `192.168.201.70:1883` succeed
- [ ] Home Assistant still connects (homeassistant namespace still whitelisted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)