### PR TITLE
fix(openclaw): pip install works as uid 1000 (PIP_USER + PYTHONUSERBASE)

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -483,6 +483,10 @@ spec:
               value: /data/node_modules
             - name: NPM_CONFIG_PREFIX
               value: /data/tools
+            - name: PIP_USER
+              value: "1"
+            - name: PYTHONUSERBASE
+              value: /data/tools
             - name: NODE_EXTRA_CA_CERTS
               value: /data/workspace/truxonline-ca.pem
             - name: REQUESTS_CA_BUNDLE


### PR DESCRIPTION
## Summary

`pip install` without flags failed as uid 1000 (system site-packages = root-only).

- `PIP_USER=1` — makes `pip install` behave like `pip install --user` by default
- `PYTHONUSERBASE=/data/tools` — user installs go to `/data/tools` (persistent PVC, already in PATH)

Completes the package manager fix alongside `NPM_CONFIG_PREFIX` (npm) from the previous PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)