### PR TITLE
fix(sakapuss): frontend nginx CrashLoopBackOff — bypass Kyverno CAP_CHOWN drop

### DIFF
--- a/apps/60-services/sakapuss/base/deployment.yaml
+++ b/apps/60-services/sakapuss/base/deployment.yaml
@@ -96,6 +96,8 @@ spec:
         app: sakapuss
         component: frontend
         vixens.io/sizing.sakapuss-frontend: V-nano
+      annotations:
+        vixens.io/explicitly-allow-root: "true"
     spec:
       priorityClassName: vixens-medium
       tolerations:


### PR DESCRIPTION
## Summary

- Kyverno `mutate-security-context` injecte `drop: ALL` caps sur les nouveaux pods
- nginx init script a besoin de `CAP_CHOWN` pour setup `/var/cache/nginx/client_temp`
- Résultat : CrashLoopBackOff au prochain restart du pod frontend
- Fix : annotation `vixens.io/explicitly-allow-root: "true"` sur le pod template frontend (bypass prévu par la policy)

## Test plan

- [ ] PR merge → main → ArgoCD sync dev → frontend pod redémarre sans crash
- [ ] Promouvoir prod-stable → frontend prod stable au prochain restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)