### PR TITLE
fix(sakapuss): SkipHealthCheck sur PVCs WaitForFirstConsumer

### DIFF
--- a/apps/60-services/sakapuss/base/pvc.yaml
+++ b/apps/60-services/sakapuss/base/pvc.yaml
@@ -5,6 +5,8 @@ metadata:
   name: sakapuss-data
   labels:
     app: sakapuss
+  annotations:
+    argocd.argoproj.io/sync-options: SkipHealthCheck=true
 spec:
   accessModes:
     - ReadWriteOnce
@@ -19,6 +21,8 @@ metadata:
   name: sakapuss-media
   labels:
     app: sakapuss
+  annotations:
+    argocd.argoproj.io/sync-options: SkipHealthCheck=true
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
## Summary

- `synelia-iscsi-retain` utilise `WaitForFirstConsumer` : les PVCs ne se bindent qu'une fois qu'un pod les consomme
- ArgoCD attendait la santé des PVCs avant de créer les Deployments → deadlock
- Fix : annotation `argocd.argoproj.io/sync-options: SkipHealthCheck=true` sur les deux PVCs

## Test plan

- [ ] Merge → main → auto-tag → promote prod-stable → ArgoCD sync sakapuss sans deadlock

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SNMP interfaces monitoring dashboard to Grafana for tracking network interface metrics.
  * Deployed SNMP exporter to collect interface traffic and uptime data.
  * Integrated SNMP metrics collection with Prometheus monitoring pipeline.

* **Improvements**
  * Simplified application configuration initialization.
  * Enhanced persistent volume health check handling.

* **Infrastructure**
  * Configured automated deployment management for SNMP monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->