### PR TITLE
fix(sakapuss): external-dns annotations pour DNS Gandi

### DIFF
--- a/apps/60-services/sakapuss/overlays/prod/ingress.yaml
+++ b/apps/60-services/sakapuss/overlays/prod/ingress.yaml
@@ -7,6 +7,8 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
     traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    external-dns.alpha.kubernetes.io/target: truxonline.com
+    external-dns.alpha.kubernetes.io/public: "true"
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: Sakapuss
     gethomepage.dev/icon: mdi-paw


### PR DESCRIPTION
## Summary

- Annotations `external-dns.alpha.kubernetes.io/target` et `public` manquantes sur l'ingress prod
- Sans elles, external-dns-gandi ne crée pas l'entrée DNS → seul le split DNS interne résolvait

🤖 Generated with [Claude Code](https://claude.com/claude-code)