### PR TITLE
fix(sakapuss): route all traffic via nginx frontend to strip /api prefix

### DIFF
--- a/apps/60-services/sakapuss/overlays/dev/ingress.yaml
+++ b/apps/60-services/sakapuss/overlays/dev/ingress.yaml
@@ -19,20 +19,6 @@ spec:
     - host: sakapuss.dev.truxonline.com
       http:
         paths:
-          - path: /api
-            pathType: Prefix
-            backend:
-              service:
-                name: sakapuss-backend
-                port:
-                  number: 8000
-          - path: /media
-            pathType: Prefix
-            backend:
-              service:
-                name: sakapuss-backend
-                port:
-                  number: 8000
           - path: /
             pathType: Prefix
             backend:

--- a/apps/60-services/sakapuss/overlays/prod/ingress.yaml
+++ b/apps/60-services/sakapuss/overlays/prod/ingress.yaml
@@ -19,20 +19,6 @@ spec:
     - host: sakapuss.truxonline.com
       http:
         paths:
-          - path: /api
-            pathType: Prefix
-            backend:
-              service:
-                name: sakapuss-backend
-                port:
-                  number: 8000
-          - path: /media
-            pathType: Prefix
-            backend:
-              service:
-                name: sakapuss-backend
-                port:
-                  number: 8000
           - path: /
             pathType: Prefix
             backend:


### PR DESCRIPTION
## Summary

- Remove direct `/api` and `/media` backend routes from Ingress (dev + prod)
- All traffic now goes through `sakapuss-frontend:80` (nginx)
- nginx's `location /api/` already does `proxy_pass http://sakapuss-backend:8000/;` (trailing slash strips the prefix)

## Root cause

Backend routes are defined without the `/api` prefix (`/auth/register`, not `/api/auth/register`). The Ingress was bypassing nginx by routing `/api` directly to the backend → 404 on all API calls.

## Test plan

- [ ] `POST /api/auth/register` → backend receives `POST /auth/register` → 201
- [ ] `GET /api/...` routes work correctly
- [ ] `/media/` files still served via nginx proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated routing configuration in both development and production environments to streamline traffic handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->