### PR TITLE
fix(sakapuss): pin backend to peach node to fix recurring iSCSI mount failures

### DIFF
--- a/apps/60-services/sakapuss/overlays/prod/backend-node-affinity.yaml
+++ b/apps/60-services/sakapuss/overlays/prod/backend-node-affinity.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sakapuss-backend
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - pearl

--- a/apps/60-services/sakapuss/overlays/prod/backend-node-affinity.yaml
+++ b/apps/60-services/sakapuss/overlays/prod/backend-node-affinity.yaml
@@ -14,4 +14,4 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - pearl
+                      - peach

--- a/apps/60-services/sakapuss/overlays/prod/kustomization.yaml
+++ b/apps/60-services/sakapuss/overlays/prod/kustomization.yaml
@@ -10,3 +10,4 @@ components:
   - ../../../../_shared/components/poddisruptionbudget/0
 patches:
   - path: pvc-storageclass.yaml
+  - path: backend-node-affinity.yaml


### PR DESCRIPTION
## Problem

On every sakapuss backend restart (image update, etc.), the pod bounces between nodes (peach, pearl, phoebe, poison, powder) due to Recreate strategy + RWO PVCs. This causes a cascade of failures:

1. **Stale iSCSI sessions** — the old node holds iSCSI sessions open, blocking the new node from logging in → `Multi-Attach error` then `DeadlineExceeded`
2. **ext-iscsid stuck state** — after sessions are released, ext-iscsid on any node enters a state where it accepts TCP on port 3260 but doesn't respond to iSCSI PDUs. Requires `talosctl service ext-iscsid restart` on the target node.

Each restart required manual intervention: find stale sessions across 5 nodes, logout them, restart ext-iscsid, restart CSI node pod, delete the stuck backend pod — repeat 3-5 times as the pod bounces between nodes.

## Fix

Add `nodeAffinity` to pin the backend to `pearl` (stable worker node). Benefits:
- iSCSI sessions always on pearl → no cross-node stale sessions
- ext-iscsid on pearl stays warm (active sessions prevent stuck state)
- Future restarts: at most one ext-iscsid restart needed on pearl

## Scope

Prod overlay only — prod uses Synology iSCSI (synelia-iscsi-retain). Dev uses a different storage class and doesn't have this issue.

## Test plan
- [ ] After merge + prod-stable promotion, backend pod comes up on pearl
- [ ] iSCSI sessions stable on pearl CSI node
- [ ] Next image update restart completes without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated production deployment configuration to constrain the backend service to a specific host node for scheduling.
  * Updated production overlay composition to include the new deployment scheduling rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->