### PR TITLE
feat(monitoring): SNMP exporter pour équipements UniFi

### DIFF
--- a/apps/02-monitoring/grafana/base/dashboards/unifi-snmp.yaml
+++ b/apps/02-monitoring/grafana/base/dashboards/unifi-snmp.yaml
@@ -1,0 +1,428 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-unifi-snmp
+  labels:
+    grafana_dashboard: "1"
+immutable: false
+data:
+  unifi-snmp.json: |
+    {
+      "title": "UniFi Network \u2014 SNMP",
+      "uid": "unifi-snmp-vixens",
+      "description": "Trafic, \u00e9tat des interfaces et erreurs sur les \u00e9quipements UniFi (UDM, switches, APs) via SNMP exporter",
+      "schemaVersion": 38,
+      "version": 1,
+      "refresh": "1m",
+      "time": { "from": "now-3h", "to": "now" },
+      "timezone": "browser",
+      "graphTooltip": 1,
+      "tags": ["snmp", "unifi", "network"],
+      "links": [],
+      "annotations": { "list": [] },
+      "templating": {
+        "list": [
+          {
+            "name": "device_name",
+            "label": "Device",
+            "type": "query",
+            "datasource": null,
+            "definition": "label_values(ifOperStatus{job=\"snmp-unifi\"}, device_name)",
+            "query": "label_values(ifOperStatus{job=\"snmp-unifi\"}, device_name)",
+            "includeAll": true,
+            "multi": true,
+            "allValue": ".*",
+            "refresh": 2,
+            "sort": 1,
+            "hide": 0,
+            "current": {}
+          },
+          {
+            "name": "interface",
+            "label": "Interface",
+            "type": "query",
+            "datasource": null,
+            "definition": "label_values(ifOperStatus{job=\"snmp-unifi\", device_name=~\"$device_name\"}, ifName)",
+            "query": "label_values(ifOperStatus{job=\"snmp-unifi\", device_name=~\"$device_name\"}, ifName)",
+            "includeAll": true,
+            "multi": true,
+            "allValue": ".*",
+            "refresh": 2,
+            "sort": 1,
+            "hide": 0,
+            "current": {}
+          }
+        ]
+      },
+      "panels": [
+        {
+          "id": 1,
+          "type": "stat",
+          "title": "Devices monitor\u00e9s",
+          "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
+          "datasource": null,
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "background",
+            "graphMode": "none",
+            "textMode": "value"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "value": null, "color": "blue" }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "count(sysUpTime{job=\"snmp-unifi\"} > 0)",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "type": "stat",
+          "title": "Interfaces UP",
+          "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 },
+          "datasource": null,
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "background",
+            "graphMode": "none"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "value": null, "color": "green" }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "count(ifOperStatus{job=\"snmp-unifi\"} == 1)",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "type": "stat",
+          "title": "Interfaces DOWN",
+          "gridPos": { "x": 12, "y": 0, "w": 6, "h": 4 },
+          "datasource": null,
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "background",
+            "graphMode": "none"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "value": null, "color": "green" },
+                  { "value": 1, "color": "red" }
+                ]
+              },
+              "unit": "short",
+              "noValue": "0"
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "count(ifOperStatus{job=\"snmp-unifi\"} == 2) or vector(0)",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "type": "stat",
+          "title": "Uptime minimum",
+          "description": "Device avec le plus petit uptime (red\u00e9marrage r\u00e9cent ?)",
+          "gridPos": { "x": 18, "y": 0, "w": 6, "h": 4 },
+          "datasource": null,
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "colorMode": "background",
+            "graphMode": "none"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "value": null, "color": "red" },
+                  { "value": 3600, "color": "orange" },
+                  { "value": 86400, "color": "green" }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "min(sysUpTime{job=\"snmp-unifi\"} / 100)",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 5,
+          "type": "timeseries",
+          "title": "Trafic par device (agr\u00e9g\u00e9)",
+          "description": "Somme du trafic entrant et sortant de toutes les interfaces par device",
+          "gridPos": { "x": 0, "y": 4, "w": 24, "h": 9 },
+          "datasource": null,
+          "options": {
+            "tooltip": { "mode": "multi", "sort": "desc" },
+            "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max", "lastNotNull"] }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bps",
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "showPoints": "never"
+              }
+            },
+            "overrides": [
+              {
+                "matcher": { "id": "byNamePattern", "options": ".*out.*" },
+                "properties": [
+                  { "id": "custom.transform", "value": "negative-Y" }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "expr": "sum by (device_name) (rate(ifHCInOctets{job=\"snmp-unifi\", device_name=~\"$device_name\"}[$__rate_interval])) * 8",
+              "legendFormat": "{{device_name}} in",
+              "refId": "A"
+            },
+            {
+              "expr": "sum by (device_name) (rate(ifHCOutOctets{job=\"snmp-unifi\", device_name=~\"$device_name\"}[$__rate_interval])) * 8",
+              "legendFormat": "{{device_name}} out",
+              "refId": "B"
+            }
+          ]
+        },
+        {
+          "id": 6,
+          "type": "timeseries",
+          "title": "Trafic par interface — $device_name",
+          "description": "D\u00e9tail du trafic par interface (filtre sur device et interface s\u00e9lectionn\u00e9s)",
+          "gridPos": { "x": 0, "y": 13, "w": 24, "h": 9 },
+          "datasource": null,
+          "options": {
+            "tooltip": { "mode": "multi", "sort": "desc" },
+            "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max", "lastNotNull"] }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bps",
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "lineWidth": 1,
+                "fillOpacity": 8,
+                "showPoints": "never"
+              }
+            },
+            "overrides": [
+              {
+                "matcher": { "id": "byNamePattern", "options": ".*out.*" },
+                "properties": [
+                  { "id": "custom.transform", "value": "negative-Y" }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "expr": "rate(ifHCInOctets{job=\"snmp-unifi\", device_name=~\"$device_name\", ifName=~\"$interface\"}[$__rate_interval]) * 8",
+              "legendFormat": "{{device_name}} / {{ifName}} in",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(ifHCOutOctets{job=\"snmp-unifi\", device_name=~\"$device_name\", ifName=~\"$interface\"}[$__rate_interval]) * 8",
+              "legendFormat": "{{device_name}} / {{ifName}} out",
+              "refId": "B"
+            }
+          ]
+        },
+        {
+          "id": 7,
+          "type": "table",
+          "title": "\u00c9tat des interfaces",
+          "gridPos": { "x": 0, "y": 22, "w": 24, "h": 10 },
+          "datasource": null,
+          "options": {
+            "sortBy": [{ "displayName": "device_name" }],
+            "footer": { "show": false }
+          },
+          "fieldConfig": {
+            "defaults": { "custom": { "filterable": true } },
+            "overrides": [
+              {
+                "matcher": { "id": "byName", "options": "Value #status" },
+                "properties": [
+                  { "id": "displayName", "value": "Status" },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      { "type": "value", "value": "1", "result": { "text": "UP", "color": "green", "index": 0 } },
+                      { "type": "value", "value": "2", "result": { "text": "DOWN", "color": "red", "index": 1 } },
+                      { "type": "value", "value": "3", "result": { "text": "TESTING", "color": "yellow", "index": 2 } }
+                    ]
+                  },
+                  { "id": "custom.displayMode", "value": "color-background" },
+                  { "id": "custom.width", "value": 100 }
+                ]
+              },
+              {
+                "matcher": { "id": "byName", "options": "Value #speed" },
+                "properties": [
+                  { "id": "displayName", "value": "Speed" },
+                  { "id": "unit", "value": "Mbps" },
+                  { "id": "custom.width", "value": 80 }
+                ]
+              },
+              {
+                "matcher": { "id": "byName", "options": "Value #errors_in" },
+                "properties": [
+                  { "id": "displayName", "value": "Err IN/s" },
+                  { "id": "unit", "value": "short" },
+                  { "id": "decimals", "value": 2 },
+                  { "id": "custom.width", "value": 90 }
+                ]
+              },
+              {
+                "matcher": { "id": "byName", "options": "Value #errors_out" },
+                "properties": [
+                  { "id": "displayName", "value": "Err OUT/s" },
+                  { "id": "unit", "value": "short" },
+                  { "id": "decimals", "value": 2 },
+                  { "id": "custom.width", "value": 90 }
+                ]
+              }
+            ]
+          },
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "names": ["device_name", "device_type", "ifName", "ifAlias", "ifDescr", "Value #status", "Value #speed", "Value #errors_in", "Value #errors_out"]
+                }
+              }
+            }
+          ],
+          "targets": [
+            {
+              "expr": "ifOperStatus{job=\"snmp-unifi\", device_name=~\"$device_name\", ifName=~\"$interface\"}",
+              "legendFormat": "",
+              "refId": "status",
+              "instant": true,
+              "format": "table"
+            },
+            {
+              "expr": "ifHighSpeed{job=\"snmp-unifi\", device_name=~\"$device_name\", ifName=~\"$interface\"}",
+              "legendFormat": "",
+              "refId": "speed",
+              "instant": true,
+              "format": "table"
+            },
+            {
+              "expr": "rate(ifInErrors{job=\"snmp-unifi\", device_name=~\"$device_name\", ifName=~\"$interface\"}[$__rate_interval])",
+              "legendFormat": "",
+              "refId": "errors_in",
+              "instant": true,
+              "format": "table"
+            },
+            {
+              "expr": "rate(ifOutErrors{job=\"snmp-unifi\", device_name=~\"$device_name\", ifName=~\"$interface\"}[$__rate_interval])",
+              "legendFormat": "",
+              "refId": "errors_out",
+              "instant": true,
+              "format": "table"
+            }
+          ]
+        },
+        {
+          "id": 8,
+          "type": "timeseries",
+          "title": "Erreurs et discards",
+          "gridPos": { "x": 0, "y": 32, "w": 24, "h": 7 },
+          "datasource": null,
+          "options": {
+            "tooltip": { "mode": "multi", "sort": "desc" },
+            "legend": { "displayMode": "list", "placement": "bottom" }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "pps",
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "lineWidth": 1,
+                "fillOpacity": 5,
+                "showPoints": "never"
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "sum by (device_name) (rate(ifInErrors{job=\"snmp-unifi\", device_name=~\"$device_name\"}[$__rate_interval]))",
+              "legendFormat": "{{device_name}} err-in",
+              "refId": "A"
+            },
+            {
+              "expr": "sum by (device_name) (rate(ifOutErrors{job=\"snmp-unifi\", device_name=~\"$device_name\"}[$__rate_interval]))",
+              "legendFormat": "{{device_name}} err-out",
+              "refId": "B"
+            },
+            {
+              "expr": "sum by (device_name) (rate(ifInDiscards{job=\"snmp-unifi\", device_name=~\"$device_name\"}[$__rate_interval]))",
+              "legendFormat": "{{device_name}} drop-in",
+              "refId": "C"
+            },
+            {
+              "expr": "sum by (device_name) (rate(ifOutDiscards{job=\"snmp-unifi\", device_name=~\"$device_name\"}[$__rate_interval]))",
+              "legendFormat": "{{device_name}} drop-out",
+              "refId": "D"
+            }
+          ]
+        }
+      ]
+    }

--- a/apps/02-monitoring/grafana/base/kustomization.yaml
+++ b/apps/02-monitoring/grafana/base/kustomization.yaml
@@ -12,4 +12,5 @@ resources:
   - dashboards/argocd.yaml
   - dashboards/velero.yaml
   - dashboards/cert-manager.yaml
+  - dashboards/unifi-snmp.yaml
 # Helm chart managed by ArgoCD

--- a/apps/02-monitoring/snmp-exporter/base/configmap-snmp.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/configmap-snmp.yaml
@@ -1,0 +1,192 @@
+---
+# snmp.yml template — ${SNMP_COMMUNITY} is substituted by the init container
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: snmp-exporter-config
+data:
+  snmp.yml: |
+    auths:
+      unifi_v2c:
+        community: ${SNMP_COMMUNITY}
+        version: 2
+
+    modules:
+      if_mib:
+        walk:
+          - 1.3.6.1.2.1.1.3      # sysUpTime
+          - 1.3.6.1.2.1.2        # interfaces table
+          - 1.3.6.1.2.1.31.1.1   # ifXTable (64-bit counters + ifName/ifAlias)
+        metrics:
+          - name: sysUpTime
+            oid: 1.3.6.1.2.1.1.3.0
+            type: gauge
+            help: Time since last reinit (centiseconds)
+
+          - name: ifOperStatus
+            oid: 1.3.6.1.2.1.2.2.1.8
+            type: gauge
+            help: Operational state of the interface (1=up, 2=down, 3=testing)
+            indexes:
+              - labelname: ifIndex
+                type: gauge
+            lookups:
+              - labels: [ifIndex]
+                labelname: ifDescr
+                oid: 1.3.6.1.2.1.2.2.1.2
+                type: DisplayString
+              - labels: [ifIndex]
+                labelname: ifName
+                oid: 1.3.6.1.2.1.31.1.1.1.1
+                type: DisplayString
+              - labels: [ifIndex]
+                labelname: ifAlias
+                oid: 1.3.6.1.2.1.31.1.1.1.18
+                type: DisplayString
+
+          - name: ifHighSpeed
+            oid: 1.3.6.1.2.1.31.1.1.1.15
+            type: gauge
+            help: Current bandwidth estimate in Mbps
+            indexes:
+              - labelname: ifIndex
+                type: gauge
+            lookups:
+              - labels: [ifIndex]
+                labelname: ifDescr
+                oid: 1.3.6.1.2.1.2.2.1.2
+                type: DisplayString
+              - labels: [ifIndex]
+                labelname: ifName
+                oid: 1.3.6.1.2.1.31.1.1.1.1
+                type: DisplayString
+              - labels: [ifIndex]
+                labelname: ifAlias
+                oid: 1.3.6.1.2.1.31.1.1.1.18
+                type: DisplayString
+
+          - name: ifHCInOctets
+            oid: 1.3.6.1.2.1.31.1.1.1.6
+            type: counter
+            help: Total octets received on the interface (64-bit)
+            indexes:
+              - labelname: ifIndex
+                type: gauge
+            lookups:
+              - labels: [ifIndex]
+                labelname: ifDescr
+                oid: 1.3.6.1.2.1.2.2.1.2
+                type: DisplayString
+              - labels: [ifIndex]
+                labelname: ifName
+                oid: 1.3.6.1.2.1.31.1.1.1.1
+                type: DisplayString
+              - labels: [ifIndex]
+                labelname: ifAlias
+                oid: 1.3.6.1.2.1.31.1.1.1.18
+                type: DisplayString
+
+          - name: ifHCOutOctets
+            oid: 1.3.6.1.2.1.31.1.1.1.10
+            type: counter
+            help: Total octets transmitted on the interface (64-bit)
+            indexes:
+              - labelname: ifIndex
+                type: gauge
+            lookups:
+              - labels: [ifIndex]
+                labelname: ifDescr
+                oid: 1.3.6.1.2.1.2.2.1.2
+                type: DisplayString
+              - labels: [ifIndex]
+                labelname: ifName
+                oid: 1.3.6.1.2.1.31.1.1.1.1
+                type: DisplayString
+              - labels: [ifIndex]
+                labelname: ifAlias
+                oid: 1.3.6.1.2.1.31.1.1.1.18
+                type: DisplayString
+
+          - name: ifInErrors
+            oid: 1.3.6.1.2.1.2.2.1.14
+            type: counter
+            help: Inbound packets with errors
+            indexes:
+              - labelname: ifIndex
+                type: gauge
+            lookups:
+              - labels: [ifIndex]
+                labelname: ifDescr
+                oid: 1.3.6.1.2.1.2.2.1.2
+                type: DisplayString
+              - labels: [ifIndex]
+                labelname: ifName
+                oid: 1.3.6.1.2.1.31.1.1.1.1
+                type: DisplayString
+              - labels: [ifIndex]
+                labelname: ifAlias
+                oid: 1.3.6.1.2.1.31.1.1.1.18
+                type: DisplayString
+
+          - name: ifOutErrors
+            oid: 1.3.6.1.2.1.2.2.1.20
+            type: counter
+            help: Outbound packets that could not be transmitted due to errors
+            indexes:
+              - labelname: ifIndex
+                type: gauge
+            lookups:
+              - labels: [ifIndex]
+                labelname: ifDescr
+                oid: 1.3.6.1.2.1.2.2.1.2
+                type: DisplayString
+              - labels: [ifIndex]
+                labelname: ifName
+                oid: 1.3.6.1.2.1.31.1.1.1.1
+                type: DisplayString
+              - labels: [ifIndex]
+                labelname: ifAlias
+                oid: 1.3.6.1.2.1.31.1.1.1.18
+                type: DisplayString
+
+          - name: ifInDiscards
+            oid: 1.3.6.1.2.1.2.2.1.13
+            type: counter
+            help: Inbound packets discarded even though no errors detected
+            indexes:
+              - labelname: ifIndex
+                type: gauge
+            lookups:
+              - labels: [ifIndex]
+                labelname: ifDescr
+                oid: 1.3.6.1.2.1.2.2.1.2
+                type: DisplayString
+              - labels: [ifIndex]
+                labelname: ifName
+                oid: 1.3.6.1.2.1.31.1.1.1.1
+                type: DisplayString
+              - labels: [ifIndex]
+                labelname: ifAlias
+                oid: 1.3.6.1.2.1.31.1.1.1.18
+                type: DisplayString
+
+          - name: ifOutDiscards
+            oid: 1.3.6.1.2.1.2.2.1.19
+            type: counter
+            help: Outbound packets discarded even though no errors detected
+            indexes:
+              - labelname: ifIndex
+                type: gauge
+            lookups:
+              - labels: [ifIndex]
+                labelname: ifDescr
+                oid: 1.3.6.1.2.1.2.2.1.2
+                type: DisplayString
+              - labels: [ifIndex]
+                labelname: ifName
+                oid: 1.3.6.1.2.1.31.1.1.1.1
+                type: DisplayString
+              - labels: [ifIndex]
+                labelname: ifAlias
+                oid: 1.3.6.1.2.1.31.1.1.1.18
+                type: DisplayString

--- a/apps/02-monitoring/snmp-exporter/base/deployment.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/deployment.yaml
@@ -1,0 +1,94 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: snmp-exporter
+  annotations:
+    argocd.argoproj.io/sync-wave: "8"
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9116"
+    prometheus.io/path: "/metrics"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: snmp-exporter
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: snmp-exporter
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9116"
+        prometheus.io/path: "/metrics"
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      initContainers:
+        - name: init-config
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - 'sed "s|\${SNMP_COMMUNITY}|${SNMP_COMMUNITY}|g" /config-tpl/snmp.yml > /config-out/snmp.yml && echo "Config generated successfully"'
+          env:
+            - name: SNMP_COMMUNITY
+              valueFrom:
+                secretKeyRef:
+                  name: snmp-exporter-secrets
+                  key: SNMP_COMMUNITY
+          volumeMounts:
+            - name: config-tpl
+              mountPath: /config-tpl
+            - name: config-out
+              mountPath: /config-out
+          resources:
+            requests:
+              cpu: 5m
+              memory: 8Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi
+      containers:
+        - name: snmp-exporter
+          image: prom/snmp-exporter:v0.26.0
+          args:
+            - --config.file=/config/snmp.yml
+            - --log.level=info
+          ports:
+            - name: http
+              containerPort: 9116
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - name: config-out
+              mountPath: /config
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+      volumes:
+        - name: config-tpl
+          configMap:
+            name: snmp-exporter-config
+        - name: config-out
+          emptyDir: {}

--- a/apps/02-monitoring/snmp-exporter/base/infisical-secret.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/infisical-secret.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: snmp-exporter-secrets-sync
+spec:
+  authentication:
+    universalAuth:
+      credentialsRef:
+        secretName: infisical-universal-auth
+        secretNamespace: argocd
+      secretsScope:
+        projectSlug: vixens
+        envSlug: dev
+        secretsPath: /snmp-exporter
+  hostAPI: http://192.168.111.69:8085
+  managedSecretReference:
+    creationPolicy: Owner
+    secretName: snmp-exporter-secrets
+    secretNamespace: monitoring
+    secretType: Opaque
+  resyncInterval: 60

--- a/apps/02-monitoring/snmp-exporter/base/kustomization.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap-snmp.yaml
+  - deployment.yaml
+  - service.yaml
+  - infisical-secret.yaml
+  - vmscrape.yaml

--- a/apps/02-monitoring/snmp-exporter/base/service.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: snmp-exporter
+  labels:
+    app.kubernetes.io/name: snmp-exporter
+spec:
+  selector:
+    app.kubernetes.io/name: snmp-exporter
+  ports:
+    - name: http
+      port: 9116
+      targetPort: http
+      protocol: TCP

--- a/apps/02-monitoring/snmp-exporter/base/vmscrape.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/vmscrape.yaml
@@ -1,0 +1,95 @@
+---
+# VMStaticScrape — scrape UniFi devices via SNMP exporter
+# The SNMP exporter acts as a proxy: vmagent calls it with ?target=<device_ip>&module=if_mib&auth=unifi_v2c
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMStaticScrape
+metadata:
+  name: snmp-unifi
+spec:
+  jobName: snmp-unifi
+  targetEndpoints:
+    # UDM Pro SE
+    - targets:
+        - 192.168.200.1
+      labels:
+        device_type: udm
+        device_name: udm-pro-se
+      scrapeTimeout: 30s
+      interval: 60s
+      path: /snmp
+      params:
+        module: [if_mib]
+        auth: [unifi_v2c]
+      relabelConfigs:
+        - sourceLabels: [__address__]
+          targetLabel: __param_target
+        - sourceLabels: [__param_target]
+          targetLabel: instance
+        - targetLabel: __address__
+          replacement: snmp-exporter.monitoring.svc.cluster.local:9116
+
+    # Switches
+    - targets:
+        - 192.168.200.246
+        - 192.168.200.240
+      labels:
+        device_type: switch
+      scrapeTimeout: 30s
+      interval: 60s
+      path: /snmp
+      params:
+        module: [if_mib]
+        auth: [unifi_v2c]
+      relabelConfigs:
+        - sourceLabels: [__address__]
+          targetLabel: __param_target
+        - sourceLabels: [__param_target]
+          targetLabel: instance
+        - targetLabel: __address__
+          replacement: snmp-exporter.monitoring.svc.cluster.local:9116
+        - sourceLabels: [instance]
+          regex: 192\.168\.200\.246
+          targetLabel: device_name
+          replacement: switch-baie
+        - sourceLabels: [instance]
+          regex: 192\.168\.200\.240
+          targetLabel: device_name
+          replacement: switch-atelier
+
+    # Access Points
+    - targets:
+        - 192.168.200.10
+        - 192.168.200.11
+        - 192.168.200.12
+        - 192.168.200.13
+      labels:
+        device_type: ap
+      scrapeTimeout: 30s
+      interval: 60s
+      path: /snmp
+      params:
+        module: [if_mib]
+        auth: [unifi_v2c]
+      relabelConfigs:
+        - sourceLabels: [__address__]
+          targetLabel: __param_target
+        - sourceLabels: [__param_target]
+          targetLabel: instance
+        - targetLabel: __address__
+          replacement: snmp-exporter.monitoring.svc.cluster.local:9116
+        - sourceLabels: [instance]
+          regex: 192\.168\.200\.10
+          targetLabel: device_name
+          replacement: ap-couloir
+        - sourceLabels: [instance]
+          regex: 192\.168\.200\.11
+          targetLabel: device_name
+          replacement: ap-cuisine
+        - sourceLabels: [instance]
+          regex: 192\.168\.200\.12
+          targetLabel: device_name
+          replacement: ap-salon
+        - sourceLabels: [instance]
+          regex: 192\.168\.200\.13
+          targetLabel: device_name
+          replacement: ap-atelier

--- a/apps/02-monitoring/snmp-exporter/overlays/dev/kustomization.yaml
+++ b/apps/02-monitoring/snmp-exporter/overlays/dev/kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - ../../base
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 0
+    target:
+      kind: Deployment
+      name: snmp-exporter
+  - patch: |-
+      - op: add
+        path: /spec/template/metadata/labels/environment
+        value: dev
+    target:
+      kind: Deployment
+      name: snmp-exporter

--- a/apps/02-monitoring/snmp-exporter/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/snmp-exporter/overlays/prod/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - ../../base
+patches:
+  - path: patch-infisical-env.yaml
+  - patch: |-
+      - op: add
+        path: /spec/template/metadata/labels/environment
+        value: prod
+    target:
+      kind: Deployment
+      name: snmp-exporter

--- a/apps/02-monitoring/snmp-exporter/overlays/prod/patch-infisical-env.yaml
+++ b/apps/02-monitoring/snmp-exporter/overlays/prod/patch-infisical-env.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: snmp-exporter-secrets-sync
+spec:
+  authentication:
+    universalAuth:
+      secretsScope:
+        envSlug: prod

--- a/argocd/overlays/dev/apps/snmp-exporter.yaml
+++ b/argocd/overlays/dev/apps/snmp-exporter.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: snmp-exporter
+  namespace: argocd
+  labels:
+    vixens.lab/environment: dev
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "8"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: main
+    path: apps/02-monitoring/snmp-exporter/overlays/dev
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false

--- a/argocd/overlays/dev/kustomization.yaml
+++ b/argocd/overlays/dev/kustomization.yaml
@@ -79,6 +79,7 @@ resources:
   # - apps/firefly-iii.yaml
   - apps/mealie.yaml
   - apps/victoria-metrics.yaml
+  - apps/snmp-exporter.yaml
   # - apps/nocodb.yaml
   # - apps/vikunja.yaml
   # - apps/mariadb-shared.yaml

--- a/argocd/overlays/prod/apps/snmp-exporter.yaml
+++ b/argocd/overlays/prod/apps/snmp-exporter.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: snmp-exporter
+  namespace: argocd
+  labels:
+    vixens.lab/environment: prod
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "8"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: prod-stable
+    path: apps/02-monitoring/snmp-exporter/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -86,6 +86,7 @@ resources:
   - apps/loki.yaml
   - apps/fluent-bit.yaml
   - apps/fluent-bit-syslog.yaml
+  - apps/snmp-exporter.yaml
   # - apps/promtail.yaml  # replaced by fluent-bit (issue #2354)
   - apps/renovate.yaml
   - apps/stirling-pdf.yaml


### PR DESCRIPTION
## Summary

- Déploie **prometheus/snmp-exporter v0.26.0** dans le namespace `monitoring`
- Monitore 7 équipements UniFi via SNMP v2c : UDM Pro SE, 2 switches, 4 APs
- **VMStaticScrape** avec 3 groupes de targets (udm / switch / ap) et labels `device_type` + `device_name`
- **Prod** : replicas=1 — **Dev** : replicas=0 (déployé mais dormant)
- Community string injectée depuis Infisical `/snmp-exporter` via init container (sed)

## Métriques collectées (module if_mib)

- `ifHCInOctets` / `ifHCOutOctets` — trafic 64-bit par interface
- `ifOperStatus` — état des liens (up/down)
- `ifHighSpeed` — vitesse des liens (Mbps)
- `ifInErrors` / `ifOutErrors` — erreurs
- `ifInDiscards` / `ifOutDiscards` — drops
- `sysUpTime` — uptime

## Test plan

- [ ] CI passe
- [ ] Merger → promouvoir en prod-stable
- [ ] Vérifier pod `snmp-exporter` Running dans `monitoring`
- [ ] Tester manuellement : `curl "http://snmp-exporter:9116/snmp?target=192.168.200.1&module=if_mib&auth=unifi_v2c"`
- [ ] Vérifier métriques dans VictoriaMetrics / Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SNMP exporter service for monitoring network devices including Unifi UDM, switches, and access points
  * Configured multi-environment support with dedicated development and production deployment overlays
  * Integrated secret management and automatic configuration rendering for secure credential handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->