### PR TITLE
fix(snmp-exporter): sizing labels pour scheduling sur cluster saturé

### DIFF
--- a/apps/02-monitoring/snmp-exporter/base/deployment.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/deployment.yaml
@@ -5,9 +5,8 @@ metadata:
   name: snmp-exporter
   annotations:
     argocd.argoproj.io/sync-wave: "8"
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9116"
-    prometheus.io/path: "/metrics"
+    goldilocks.fairwinds.com/enabled: "true"
+    vpa.kubernetes.io/updateMode: "Off"
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -20,11 +19,18 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: snmp-exporter
+        vixens.io/sizing-v2: "true"
+        vixens.io/sizing.snmp-exporter: V-nano
+        vixens.io/sizing.init-config: G-nano
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9116"
         prometheus.io/path: "/metrics"
+        vixens.io/fast-start: "true"
+        vixens.io/no-long-connections: "true"
+        vixens.io/backup-profile: ephemeral
     spec:
+      priorityClassName: vixens-low
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
@@ -35,7 +41,7 @@ spec:
           command:
             - sh
             - -c
-            - 'sed "s|\${SNMP_COMMUNITY}|${SNMP_COMMUNITY}|g" /config-tpl/snmp.yml > /config-out/snmp.yml && echo "Config generated successfully"'
+            - 'sed "s|\${SNMP_COMMUNITY}|${SNMP_COMMUNITY}|g" /config-tpl/snmp.yml > /config-out/snmp.yml && echo "Config generated"'
           env:
             - name: SNMP_COMMUNITY
               valueFrom:
@@ -47,13 +53,6 @@ spec:
               mountPath: /config-tpl
             - name: config-out
               mountPath: /config-out
-          resources:
-            requests:
-              cpu: 5m
-              memory: 8Mi
-            limits:
-              cpu: 50m
-              memory: 32Mi
       containers:
         - name: snmp-exporter
           image: prom/snmp-exporter:v0.26.0
@@ -79,13 +78,6 @@ spec:
           volumeMounts:
             - name: config-out
               mountPath: /config
-          resources:
-            requests:
-              cpu: 10m
-              memory: 32Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
       volumes:
         - name: config-tpl
           configMap:


### PR DESCRIPTION
Cluster mémoire à 99% — ajout sizing labels V-nano + priorityClass vixens-low pour permettre le scheduling.