### PR TITLE
feat(snmp-exporter): inject device IPs dynamically via Infisical

### DIFF
--- a/apps/02-monitoring/snmp-exporter/base/configmap-vmscrape-tpl.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/configmap-vmscrape-tpl.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: snmp-exporter-vmscrape-tpl
+data:
+  vmscrape.yaml: |
+    ---
+    apiVersion: operator.victoriametrics.com/v1beta1
+    kind: VMStaticScrape
+    metadata:
+      name: snmp-unifi
+      namespace: monitoring
+    spec:
+      jobName: snmp-unifi
+      targetEndpoints:
+        - targets:
+            - ${SNMP_TARGET_UDM}
+          labels:
+            device_type: udm
+            device_name: udm-pro-se
+          scrapeTimeout: 30s
+          interval: 60s
+          path: /snmp
+          params:
+            module: [if_mib]
+            auth: [unifi_v2c]
+          relabelConfigs:
+            - sourceLabels: [__address__]
+              targetLabel: __param_target
+            - sourceLabels: [__param_target]
+              targetLabel: instance
+            - targetLabel: __address__
+              replacement: snmp-exporter.monitoring.svc.cluster.local:9116
+
+        - targets:
+            - ${SNMP_TARGET_SW_BAIE}
+            - ${SNMP_TARGET_SW_ATELIER}
+          labels:
+            device_type: switch
+          scrapeTimeout: 30s
+          interval: 60s
+          path: /snmp
+          params:
+            module: [if_mib]
+            auth: [unifi_v2c]
+          relabelConfigs:
+            - sourceLabels: [__address__]
+              targetLabel: __param_target
+            - sourceLabels: [__param_target]
+              targetLabel: instance
+            - targetLabel: __address__
+              replacement: snmp-exporter.monitoring.svc.cluster.local:9116
+            - sourceLabels: [instance]
+              regex: ${SNMP_TARGET_SW_BAIE}
+              targetLabel: device_name
+              replacement: switch-baie
+            - sourceLabels: [instance]
+              regex: ${SNMP_TARGET_SW_ATELIER}
+              targetLabel: device_name
+              replacement: switch-atelier
+
+        - targets:
+            - ${SNMP_TARGET_AP_COULOIR}
+            - ${SNMP_TARGET_AP_CUISINE}
+            - ${SNMP_TARGET_AP_SALON}
+            - ${SNMP_TARGET_AP_ATELIER}
+          labels:
+            device_type: ap
+          scrapeTimeout: 30s
+          interval: 60s
+          path: /snmp
+          params:
+            module: [if_mib]
+            auth: [unifi_v2c]
+          relabelConfigs:
+            - sourceLabels: [__address__]
+              targetLabel: __param_target
+            - sourceLabels: [__param_target]
+              targetLabel: instance
+            - targetLabel: __address__
+              replacement: snmp-exporter.monitoring.svc.cluster.local:9116
+            - sourceLabels: [instance]
+              regex: ${SNMP_TARGET_AP_COULOIR}
+              targetLabel: device_name
+              replacement: ap-couloir
+            - sourceLabels: [instance]
+              regex: ${SNMP_TARGET_AP_CUISINE}
+              targetLabel: device_name
+              replacement: ap-cuisine
+            - sourceLabels: [instance]
+              regex: ${SNMP_TARGET_AP_SALON}
+              targetLabel: device_name
+              replacement: ap-salon
+            - sourceLabels: [instance]
+              regex: ${SNMP_TARGET_AP_ATELIER}
+              targetLabel: device_name
+              replacement: ap-atelier

--- a/apps/02-monitoring/snmp-exporter/base/deployment.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         vixens.io/sizing-v2: "true"
         vixens.io/sizing.snmp-exporter: V-nano
         vixens.io/sizing.init-config: G-nano
+        vixens.io/sizing.init-vmscrape: G-nano
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9116"
@@ -30,6 +31,7 @@ spec:
         vixens.io/no-long-connections: "true"
         vixens.io/backup-profile: ephemeral
     spec:
+      serviceAccountName: snmp-exporter
       priorityClassName: vixens-low
       tolerations:
         - key: node-role.kubernetes.io/control-plane
@@ -53,6 +55,60 @@ spec:
               mountPath: /config-tpl
             - name: config-out
               mountPath: /config-out
+        - name: init-vmscrape
+          image: alpine/k8s:1.32.3
+          command:
+            - sh
+            - -c
+            - |
+              sed \
+                -e "s|\${SNMP_TARGET_UDM}|${SNMP_TARGET_UDM}|g" \
+                -e "s|\${SNMP_TARGET_SW_BAIE}|${SNMP_TARGET_SW_BAIE}|g" \
+                -e "s|\${SNMP_TARGET_SW_ATELIER}|${SNMP_TARGET_SW_ATELIER}|g" \
+                -e "s|\${SNMP_TARGET_AP_COULOIR}|${SNMP_TARGET_AP_COULOIR}|g" \
+                -e "s|\${SNMP_TARGET_AP_CUISINE}|${SNMP_TARGET_AP_CUISINE}|g" \
+                -e "s|\${SNMP_TARGET_AP_SALON}|${SNMP_TARGET_AP_SALON}|g" \
+                -e "s|\${SNMP_TARGET_AP_ATELIER}|${SNMP_TARGET_AP_ATELIER}|g" \
+                /tpl/vmscrape.yaml | kubectl apply -f - && echo "VMStaticScrape applied"
+          env:
+            - name: SNMP_TARGET_UDM
+              valueFrom:
+                secretKeyRef:
+                  name: snmp-exporter-secrets
+                  key: SNMP_TARGET_UDM
+            - name: SNMP_TARGET_SW_BAIE
+              valueFrom:
+                secretKeyRef:
+                  name: snmp-exporter-secrets
+                  key: SNMP_TARGET_SW_BAIE
+            - name: SNMP_TARGET_SW_ATELIER
+              valueFrom:
+                secretKeyRef:
+                  name: snmp-exporter-secrets
+                  key: SNMP_TARGET_SW_ATELIER
+            - name: SNMP_TARGET_AP_COULOIR
+              valueFrom:
+                secretKeyRef:
+                  name: snmp-exporter-secrets
+                  key: SNMP_TARGET_AP_COULOIR
+            - name: SNMP_TARGET_AP_CUISINE
+              valueFrom:
+                secretKeyRef:
+                  name: snmp-exporter-secrets
+                  key: SNMP_TARGET_AP_CUISINE
+            - name: SNMP_TARGET_AP_SALON
+              valueFrom:
+                secretKeyRef:
+                  name: snmp-exporter-secrets
+                  key: SNMP_TARGET_AP_SALON
+            - name: SNMP_TARGET_AP_ATELIER
+              valueFrom:
+                secretKeyRef:
+                  name: snmp-exporter-secrets
+                  key: SNMP_TARGET_AP_ATELIER
+          volumeMounts:
+            - name: vmscrape-tpl
+              mountPath: /tpl
       containers:
         - name: snmp-exporter
           image: prom/snmp-exporter:v0.26.0
@@ -84,3 +140,6 @@ spec:
             name: snmp-exporter-config
         - name: config-out
           emptyDir: {}
+        - name: vmscrape-tpl
+          configMap:
+            name: snmp-exporter-vmscrape-tpl

--- a/apps/02-monitoring/snmp-exporter/base/kustomization.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/kustomization.yaml
@@ -3,7 +3,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-snmp.yaml
+  - configmap-vmscrape-tpl.yaml
   - deployment.yaml
   - service.yaml
   - infisical-secret.yaml
+  - rbac.yaml
   - vmscrape.yaml

--- a/apps/02-monitoring/snmp-exporter/base/rbac.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/rbac.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: snmp-exporter
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: snmp-exporter-vmscrape
+rules:
+  - apiGroups: ["operator.victoriametrics.com"]
+    resources: ["vmstaticscrapes"]
+    verbs: ["get", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: snmp-exporter-vmscrape
+subjects:
+  - kind: ServiceAccount
+    name: snmp-exporter
+    namespace: monitoring
+roleRef:
+  kind: Role
+  name: snmp-exporter-vmscrape
+  apiGroup: rbac.authorization.k8s.io

--- a/apps/02-monitoring/snmp-exporter/base/vmscrape.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/vmscrape.yaml
@@ -1,95 +1,11 @@
 ---
-# VMStaticScrape — scrape UniFi devices via SNMP exporter
-# The SNMP exporter acts as a proxy: vmagent calls it with ?target=<device_ip>&module=if_mib&auth=unifi_v2c
+# VMStaticScrape — coquille gérée par ArgoCD, contenu injecté dynamiquement par init-vmscrape
+# Les IPs des équipements sont stockées dans Infisical et substituées au démarrage du pod.
+# ignoreDifferences sur /spec/targetEndpoints dans l'ArgoCD Application empêche le revert.
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMStaticScrape
 metadata:
   name: snmp-unifi
 spec:
   jobName: snmp-unifi
-  targetEndpoints:
-    # UDM Pro SE
-    - targets:
-        - 192.168.0.1
-      labels:
-        device_type: udm
-        device_name: udm-pro-se
-      scrapeTimeout: 30s
-      interval: 60s
-      path: /snmp
-      params:
-        module: [if_mib]
-        auth: [unifi_v2c]
-      relabelConfigs:
-        - sourceLabels: [__address__]
-          targetLabel: __param_target
-        - sourceLabels: [__param_target]
-          targetLabel: instance
-        - targetLabel: __address__
-          replacement: snmp-exporter.monitoring.svc.cluster.local:9116
-
-    # Switches
-    - targets:
-        - 192.168.0.246
-        - 192.168.0.240
-      labels:
-        device_type: switch
-      scrapeTimeout: 30s
-      interval: 60s
-      path: /snmp
-      params:
-        module: [if_mib]
-        auth: [unifi_v2c]
-      relabelConfigs:
-        - sourceLabels: [__address__]
-          targetLabel: __param_target
-        - sourceLabels: [__param_target]
-          targetLabel: instance
-        - targetLabel: __address__
-          replacement: snmp-exporter.monitoring.svc.cluster.local:9116
-        - sourceLabels: [instance]
-          regex: 192\.168\.0\.246
-          targetLabel: device_name
-          replacement: switch-baie
-        - sourceLabels: [instance]
-          regex: 192\.168\.0\.240
-          targetLabel: device_name
-          replacement: switch-atelier
-
-    # Access Points
-    - targets:
-        - 192.168.0.10
-        - 192.168.0.11
-        - 192.168.0.12
-        - 192.168.0.13
-      labels:
-        device_type: ap
-      scrapeTimeout: 30s
-      interval: 60s
-      path: /snmp
-      params:
-        module: [if_mib]
-        auth: [unifi_v2c]
-      relabelConfigs:
-        - sourceLabels: [__address__]
-          targetLabel: __param_target
-        - sourceLabels: [__param_target]
-          targetLabel: instance
-        - targetLabel: __address__
-          replacement: snmp-exporter.monitoring.svc.cluster.local:9116
-        - sourceLabels: [instance]
-          regex: 192\.168\.0\.10
-          targetLabel: device_name
-          replacement: ap-couloir
-        - sourceLabels: [instance]
-          regex: 192\.168\.0\.11
-          targetLabel: device_name
-          replacement: ap-cuisine
-        - sourceLabels: [instance]
-          regex: 192\.168\.0\.12
-          targetLabel: device_name
-          replacement: ap-salon
-        - sourceLabels: [instance]
-          regex: 192\.168\.0\.13
-          targetLabel: device_name
-          replacement: ap-atelier
+  targetEndpoints: []

--- a/argocd/overlays/dev/apps/snmp-exporter.yaml
+++ b/argocd/overlays/dev/apps/snmp-exporter.yaml
@@ -25,3 +25,10 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=false
+  ignoreDifferences:
+    - group: operator.victoriametrics.com
+      kind: VMStaticScrape
+      name: snmp-unifi
+      namespace: monitoring
+      jsonPointers:
+        - /spec/targetEndpoints

--- a/argocd/overlays/prod/apps/snmp-exporter.yaml
+++ b/argocd/overlays/prod/apps/snmp-exporter.yaml
@@ -25,3 +25,10 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=false
+  ignoreDifferences:
+    - group: operator.victoriametrics.com
+      kind: VMStaticScrape
+      name: snmp-unifi
+      namespace: monitoring
+      jsonPointers:
+        - /spec/targetEndpoints


### PR DESCRIPTION
## Summary
- IPs des équipements UniFi retirées du git — stockées dans Infisical sous \`/snmp-exporter\`
- Init-container \`init-vmscrape\` (alpine/k8s) substitue les placeholders et applique le VMStaticScrape via kubectl
- \`vmscrape.yaml\` en git = coquille vide (\`targetEndpoints: []\`), aucune IP visible
- ArgoCD \`ignoreDifferences\` sur \`/spec/targetEndpoints\` empêche le revert du selfHeal
- RBAC minimal : ServiceAccount \`snmp-exporter\` + Role limité aux VMStaticScrapes du namespace

## Secrets Infisical ajoutés (\`/snmp-exporter\`, prod + dev)
\`SNMP_TARGET_UDM\`, \`SNMP_TARGET_SW_BAIE\`, \`SNMP_TARGET_SW_ATELIER\`, \`SNMP_TARGET_AP_COULOIR\`, \`SNMP_TARGET_AP_CUISINE\`, \`SNMP_TARGET_AP_SALON\`, \`SNMP_TARGET_AP_ATELIER\`

## Test plan
- [ ] Pod démarre, init-vmscrape applique le VMStaticScrape avec les vraies IPs
- [ ] ArgoCD reste Synced (ignoreDifferences actif)
- [ ] Métriques visibles dans Grafana pour les 7 équipements

🤖 Generated with [Claude Code](https://claude.com/claude-code)