### PR TITLE
fix(snmp-exporter): remplace alpine/k8s par bitnami/kubectl (OOMKilled)

### DIFF
--- a/apps/02-monitoring/snmp-exporter/base/deployment.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: config-out
               mountPath: /config-out
         - name: init-vmscrape
-          image: alpine/k8s:1.32.3
+          image: bitnami/kubectl:1.32
           command:
             - sh
             - -c
@@ -69,7 +69,7 @@ spec:
                 -e "s|\${SNMP_TARGET_AP_CUISINE}|${SNMP_TARGET_AP_CUISINE}|g" \
                 -e "s|\${SNMP_TARGET_AP_SALON}|${SNMP_TARGET_AP_SALON}|g" \
                 -e "s|\${SNMP_TARGET_AP_ATELIER}|${SNMP_TARGET_AP_ATELIER}|g" \
-                /tpl/vmscrape.yaml | kubectl apply -f - && echo "VMStaticScrape applied"
+                /tpl/vmscrape.yaml | kubectl apply --timeout=30s -f - && echo "VMStaticScrape applied"
           env:
             - name: SNMP_TARGET_UDM
               valueFrom:


### PR DESCRIPTION
## Summary
- `alpine/k8s:1.32.3` (322MB) OOMKilled avec sizing G-nano dans init-vmscrape
- Remplacé par `bitnami/kubectl:1.32` (~50MB) qui a kubectl + sed et est adapté au sizing G-nano

## Root cause
Le sizing G-nano (très peu de mémoire) est insuffisant pour l'image alpine/k8s. bitnami/kubectl est une image minimaliste conçue exactement pour ce cas d'usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)