### PR TITLE
fix(snmp-exporter): dual community strings pour USW-Lite (truncature à 20 chars)

### DIFF
--- a/apps/02-monitoring/snmp-exporter/base/configmap-snmp.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/configmap-snmp.yaml
@@ -1,5 +1,7 @@
 ---
-# snmp.yml template — ${SNMP_COMMUNITY} is substituted by the init container
+# snmp.yml template — ${SNMP_COMMUNITY} et ${SNMP_COMMUNITY_FULL} substitués par l'init container
+# unifi_v2c      : 20 chars → switches (USW-Lite firmware truncate à 20)
+# unifi_v2c_full : 21 chars → UDM + APs (pas de troncature)
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,6 +11,9 @@ data:
     auths:
       unifi_v2c:
         community: ${SNMP_COMMUNITY}
+        version: 2
+      unifi_v2c_full:
+        community: ${SNMP_COMMUNITY_FULL}
         version: 2
 
     modules:

--- a/apps/02-monitoring/snmp-exporter/base/deployment.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/deployment.yaml
@@ -43,13 +43,18 @@ spec:
           command:
             - sh
             - -c
-            - 'sed "s|\${SNMP_COMMUNITY}|${SNMP_COMMUNITY}|g" /config-tpl/snmp.yml > /config-out/snmp.yml && echo "Config generated"'
+            - 'sed -e "s|\${SNMP_COMMUNITY}|${SNMP_COMMUNITY}|g" -e "s|\${SNMP_COMMUNITY_FULL}|${SNMP_COMMUNITY_FULL}|g" /config-tpl/snmp.yml > /config-out/snmp.yml && echo "Config generated"'
           env:
             - name: SNMP_COMMUNITY
               valueFrom:
                 secretKeyRef:
                   name: snmp-exporter-secrets
                   key: SNMP_COMMUNITY
+            - name: SNMP_COMMUNITY_FULL
+              valueFrom:
+                secretKeyRef:
+                  name: snmp-exporter-secrets
+                  key: SNMP_COMMUNITY_FULL
           volumeMounts:
             - name: config-tpl
               mountPath: /config-tpl
@@ -72,7 +77,7 @@ spec:
                       "targets": ["%s"],
                       "labels": {"device_type": "udm", "device_name": "udm-pro-se"},
                       "scrapeTimeout": "30s", "interval": "60s", "path": "/snmp",
-                      "params": {"module": ["if_mib"], "auth": ["unifi_v2c"]},
+                      "params": {"module": ["if_mib"], "auth": ["unifi_v2c_full"]},
                       "relabelConfigs": [
                         {"sourceLabels": ["__address__"], "targetLabel": "__param_target"},
                         {"sourceLabels": ["__param_target"], "targetLabel": "instance"},
@@ -96,7 +101,7 @@ spec:
                       "targets": ["%s", "%s", "%s", "%s"],
                       "labels": {"device_type": "ap"},
                       "scrapeTimeout": "30s", "interval": "60s", "path": "/snmp",
-                      "params": {"module": ["if_mib"], "auth": ["unifi_v2c"]},
+                      "params": {"module": ["if_mib"], "auth": ["unifi_v2c_full"]},
                       "relabelConfigs": [
                         {"sourceLabels": ["__address__"], "targetLabel": "__param_target"},
                         {"sourceLabels": ["__param_target"], "targetLabel": "instance"},


### PR DESCRIPTION
## Problème
Les USW-Lite-8-PoE et USW-Lite-16-PoE tronquent les community SNMP à **20 caractères** dans leur firmware. Notre community `public_wvOZjZG0twgU5I` (21 chars) est reçue comme `public_wvOZjZG0twgU5` (20 chars) sur les switches, mais l'UDM et les APs gardent la version complète.

## Solution
Deux entrées auth dans `snmp.yml` :
- `unifi_v2c` (20 chars) → switches
- `unifi_v2c_full` (21 chars) → UDM + APs

Secrets Infisical : `SNMP_COMMUNITY` (20 chars) + `SNMP_COMMUNITY_FULL` (21 chars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)