### PR TITLE
fix(grafana): desc:false au sortBy + byRegexp (compat Grafana 12)

### DIFF
--- a/apps/02-monitoring/grafana/base/dashboards/unifi-snmp.yaml
+++ b/apps/02-monitoring/grafana/base/dashboards/unifi-snmp.yaml
@@ -284,7 +284,7 @@ data:
           "gridPos": { "x": 0, "y": 22, "w": 24, "h": 10 },
           "datasource": null,
           "options": {
-            "sortBy": [{ "displayName": "device_name" }],
+            "sortBy": [{ "displayName": "device_name", "desc": false }],
             "footer": { "show": false }
           },
           "fieldConfig": {


### PR DESCRIPTION
## Fix

- `sortBy` dans le table panel nécessite `desc: false` explicite dans Grafana 12 (sinon TypeError sur `u.options[1]`)
- `byNamePattern` → `byRegexp` (matcher supprimé dans Grafana 12)