### PR TITLE
fix(mylar): timeoutSeconds:5 sur probes liveness/readiness (crash loop)

### DIFF
--- a/apps/02-monitoring/grafana/base/dashboards/unifi-snmp.yaml
+++ b/apps/02-monitoring/grafana/base/dashboards/unifi-snmp.yaml
@@ -284,7 +284,7 @@ data:
           "gridPos": { "x": 0, "y": 22, "w": 24, "h": 10 },
           "datasource": null,
           "options": {
-            "sortBy": [{ "displayName": "device_name" }],
+            "sortBy": [{ "displayName": "device_name", "desc": false }],
             "footer": { "show": false }
           },
           "fieldConfig": {

--- a/apps/20-media/mylar/base/deployment.yaml
+++ b/apps/20-media/mylar/base/deployment.yaml
@@ -58,12 +58,14 @@ spec:
               port: http
             initialDelaySeconds: 120
             periodSeconds: 30
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /
               port: http
             initialDelaySeconds: 60
             periodSeconds: 20
+            timeoutSeconds: 5
           startupProbe:
             httpGet:
               path: /


### PR DESCRIPTION
## Cause

La liveness probe et readiness probe n'avaient pas de `timeoutSeconds` (default: 1s). Mylar (Python + iSCSI) met parfois plus d'1s à répondre → probe failure → SIGKILL après 3 échecs → 180+ restarts.

La startup probe avait déjà `timeoutSeconds: 5`, les deux autres probes non.

## Fix

Ajout de `timeoutSeconds: 5` sur liveness et readiness probe, aligné avec la startup probe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated monitoring dashboard table sorting configuration for explicit ascending order.
  * Added explicit 5-second timeout limits to deployment health check probes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->