### PR TITLE
feat(hubble-ui): Hubble UI avec Authentik SSO

### DIFF
--- a/apps/02-monitoring/hubble-ui/base/deployment.yaml
+++ b/apps/02-monitoring/hubble-ui/base/deployment.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hubble-ui
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    goldilocks.fairwinds.com/enabled: "true"
+    vpa.kubernetes.io/updateMode: "Off"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      k8s-app: hubble-ui
+  template:
+    metadata:
+      labels:
+        k8s-app: hubble-ui
+        vixens.io/sizing-v2: "true"
+        vixens.io/sizing.hubble-ui-frontend: V-nano
+        vixens.io/sizing.hubble-ui-backend: V-nano
+      annotations:
+        vixens.io/no-long-connections: "true"
+        vixens.io/backup-profile: ephemeral
+    spec:
+      serviceAccountName: hubble-ui
+      priorityClassName: vixens-low
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: frontend
+          image: quay.io/cilium/hubble-ui:v0.13.1
+          ports:
+            - containerPort: 8081
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+        - name: backend
+          image: quay.io/cilium/hubble-ui-backend:v0.13.1
+          env:
+            - name: EVENTS_SERVER_PORT
+              value: "8090"
+            - name: FLOWS_API_ADDR
+              value: "hubble-relay.kube-system.svc.cluster.local:80"
+          ports:
+            - containerPort: 8090
+              name: grpc
+          livenessProbe:
+            tcpSocket:
+              port: grpc
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: grpc
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]

--- a/apps/02-monitoring/hubble-ui/base/kustomization.yaml
+++ b/apps/02-monitoring/hubble-ui/base/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - rbac.yaml
+  - deployment.yaml
+  - service.yaml
+  - vpa.yaml

--- a/apps/02-monitoring/hubble-ui/base/rbac.yaml
+++ b/apps/02-monitoring/hubble-ui/base/rbac.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hubble-ui
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hubble-ui
+rules:
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["componentstatuses", "endpoints", "namespaces", "nodes", "pods", "services"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["cilium.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hubble-ui
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hubble-ui
+subjects:
+  - kind: ServiceAccount
+    name: hubble-ui
+    namespace: monitoring

--- a/apps/02-monitoring/hubble-ui/base/service.yaml
+++ b/apps/02-monitoring/hubble-ui/base/service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hubble-ui
+spec:
+  selector:
+    k8s-app: hubble-ui
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP

--- a/apps/02-monitoring/hubble-ui/overlays/prod/ingress.yaml
+++ b/apps/02-monitoring/hubble-ui/overlays/prod/ingress.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hubble-ui
+  namespace: monitoring
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd, auth-authentik-forward-auth@kubernetescrd
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Monitoring
+    gethomepage.dev/name: Hubble
+    gethomepage.dev/icon: hubble.png
+    gethomepage.dev/description: Flux réseau Cilium
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: hubble.truxonline.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: hubble-ui
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - hubble.truxonline.com
+      secretName: hubble-ui-tls

--- a/apps/02-monitoring/hubble-ui/overlays/prod/kustomization.yaml
+++ b/apps/02-monitoring/hubble-ui/overlays/prod/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - ingress.yaml
+  - ../../base

--- a/argocd/overlays/prod/apps/hubble-ui.yaml
+++ b/argocd/overlays/prod/apps/hubble-ui.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hubble-ui
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: prod-stable
+    path: apps/02-monitoring/hubble-ui/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -47,6 +47,7 @@ resources:
   # - apps/prometheus-ingress.yaml  # replaced by victoria-metrics (issue #2354)
   - apps/grafana.yaml
   - apps/grafana-ingress.yaml
+  - apps/hubble-ui.yaml
   - apps/homepage.yaml
   - apps/linkwarden.yaml
   - apps/gluetun.yaml


### PR DESCRIPTION
## Contexte

Closes #2936. Prérequis de #2935 (default-deny).

## Ce qui est déployé

- Deployment avec 2 containers : `frontend` (nginx, port 8081) + `backend` (gRPC proxy vers hubble-relay, port 8090)
- Backend connecté à `hubble-relay.kube-system.svc.cluster.local:80`
- RBAC ClusterRole : lecture des namespaces, pods, services, networkpolicies, CRDs Cilium
- Service ClusterIP port 80 → 8081
- Ingress `hubble.truxonline.com` protégé par Authentik SSO + HTTPS

## Images

- `quay.io/cilium/hubble-ui:v0.13.1`
- `quay.io/cilium/hubble-ui-backend:v0.13.1`

Compatibles Cilium v1.18.3 (déployé en prod).

## DNS

À créer chez Gandi : `hubble.truxonline.com` → IP LoadBalancer Traefik prod.