### PR TITLE
fix(hubble-ui): supprimer middleware Authentik (accès interne seulement)

### DIFF
--- a/apps/02-monitoring/hubble-ui/overlays/prod/ingress.yaml
+++ b/apps/02-monitoring/hubble-ui/overlays/prod/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
-    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd, auth-authentik-forward-auth@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
     gethomepage.dev/enabled: "true"
     gethomepage.dev/group: Monitoring
     gethomepage.dev/name: Hubble


### PR DESCRIPTION
Hubble UI n'est accessible qu'en interne (pas de DNS public). Le middleware Authentik est inutile, le réseau est la protection suffisante.