### PR TITLE
fix(hubble-ui): port frontend 8080 (nginx réel, pas 8081)

### DIFF
--- a/apps/02-monitoring/hubble-ui/base/deployment.yaml
+++ b/apps/02-monitoring/hubble-ui/base/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - name: frontend
           image: quay.io/cilium/hubble-ui:v0.13.1
           ports:
-            - containerPort: 8081
+            - containerPort: 8080
               name: http
           livenessProbe:
             httpGet:

--- a/apps/02-monitoring/hubble-ui/overlays/prod/ingress.yaml
+++ b/apps/02-monitoring/hubble-ui/overlays/prod/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
-    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd, auth-authentik-forward-auth@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
     gethomepage.dev/enabled: "true"
     gethomepage.dev/group: Monitoring
     gethomepage.dev/name: Hubble


### PR DESCRIPTION
nginx dans quay.io/cilium/hubble-ui:v0.13.1 écoute sur 8080, pas 8081 — readiness/liveness probe échouaient.