### PR TITLE
fix(hubble-ui): images v0.13.0 (compat Cilium 1.18.x)

### DIFF
--- a/apps/02-monitoring/hubble-ui/base/deployment.yaml
+++ b/apps/02-monitoring/hubble-ui/base/deployment.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       k8s-app: hubble-ui
@@ -21,6 +23,7 @@ spec:
         vixens.io/sizing.hubble-ui-frontend: V-nano
         vixens.io/sizing.hubble-ui-backend: V-nano
       annotations:
+        vixens.io/fast-start: "true"
         vixens.io/no-long-connections: "true"
         vixens.io/backup-profile: ephemeral
     spec:

--- a/apps/02-monitoring/hubble-ui/base/deployment.yaml
+++ b/apps/02-monitoring/hubble-ui/base/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - name: frontend
           image: quay.io/cilium/hubble-ui:v0.13.1
           ports:
-            - containerPort: 8081
+            - containerPort: 8080
               name: http
           livenessProbe:
             httpGet:

--- a/apps/02-monitoring/hubble-ui/base/deployment.yaml
+++ b/apps/02-monitoring/hubble-ui/base/deployment.yaml
@@ -20,8 +20,8 @@ spec:
       labels:
         k8s-app: hubble-ui
         vixens.io/sizing-v2: "true"
-        vixens.io/sizing.hubble-ui-frontend: V-nano
-        vixens.io/sizing.hubble-ui-backend: V-nano
+        vixens.io/sizing.frontend: V-nano
+        vixens.io/sizing.backend: V-nano
       annotations:
         vixens.io/fast-start: "true"
         vixens.io/no-long-connections: "true"

--- a/apps/02-monitoring/hubble-ui/base/deployment.yaml
+++ b/apps/02-monitoring/hubble-ui/base/deployment.yaml
@@ -45,13 +45,13 @@ spec:
               name: http
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /
               port: http
             initialDelaySeconds: 5
             periodSeconds: 30
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/apps/02-monitoring/hubble-ui/base/deployment.yaml
+++ b/apps/02-monitoring/hubble-ui/base/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: frontend
-          image: quay.io/cilium/hubble-ui:v0.13.1
+          image: quay.io/cilium/hubble-ui:v0.13.0
           ports:
             - containerPort: 8080
               name: http
@@ -60,7 +60,7 @@ spec:
             capabilities:
               drop: ["ALL"]
         - name: backend
-          image: quay.io/cilium/hubble-ui-backend:v0.13.1
+          image: quay.io/cilium/hubble-ui-backend:v0.13.0
           env:
             - name: EVENTS_SERVER_PORT
               value: "8090"

--- a/apps/02-monitoring/hubble-ui/overlays/prod/ingress.yaml
+++ b/apps/02-monitoring/hubble-ui/overlays/prod/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
-    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd, auth-authentik-forward-auth@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
     gethomepage.dev/enabled: "true"
     gethomepage.dev/group: Monitoring
     gethomepage.dev/name: Hubble


### PR DESCRIPTION
v0.13.1 n'a pas la UI buildée (nginx stock). v0.13.0 est la version correcte pour Cilium 1.18.x.