### PR TITLE
fix(hubble-ui): v0.13.3 pinned avec digest (Cilium 1.18.3)

### DIFF
--- a/apps/02-monitoring/hubble-ui/base/deployment.yaml
+++ b/apps/02-monitoring/hubble-ui/base/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: frontend
-          image: quay.io/cilium/hubble-ui:v0.13.5
+          image: quay.io/cilium/hubble-ui:v0.13.3@sha256:661d5de7050182d495c6497ff0b007a7a1e379648e60830dd68c4d78ae21761d
           ports:
             - containerPort: 8080
               name: http
@@ -60,7 +60,7 @@ spec:
             capabilities:
               drop: ["ALL"]
         - name: backend
-          image: quay.io/cilium/hubble-ui-backend:v0.13.5
+          image: quay.io/cilium/hubble-ui-backend:v0.13.3@sha256:db1454e45dc39ca41fbf7cad31eec95d99e5b9949c39daaad0fa81ef29d56953
           env:
             - name: EVENTS_SERVER_PORT
               value: "8090"


### PR DESCRIPTION
## Problème

`quay.io/cilium/hubble-ui:v0.13.1` et `v0.13.5` sont du **nginx stock** sans React app (page bienvenue nginx).

## Cause

Le Helm chart Cilium 1.18.3 spécifie exactement `v0.13.3` avec digest :
- frontend: `sha256:661d5de7050182d495c6497ff0b007a7a1e379648e60830dd68c4d78ae21761d`
- backend: `sha256:db1454e45dc39ca41fbf7cad31eec95d99e5b9949c39daaad0fa81ef29d56953`

## Fix

Pin `v0.13.3@sha256:...` (images vérifiées depuis `values.yaml` Cilium v1.18.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)