### PR TITLE
fix(hubble-ui): ConfigMap nginx + port 8081 (React app manquante)

### DIFF
--- a/apps/02-monitoring/hubble-ui/base/configmap.yaml
+++ b/apps/02-monitoring/hubble-ui/base/configmap.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hubble-ui-nginx
+data:
+  nginx.conf: |
+    server {
+        listen       8081;
+        server_name  localhost;
+        root /app;
+        index index.html;
+        client_max_body_size 1G;
+
+        location / {
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+
+            location /api {
+                proxy_http_version 1.1;
+                proxy_pass_request_headers on;
+                proxy_pass http://127.0.0.1:8090;
+            }
+
+            location / {
+                if ($http_user_agent ~* "kube-probe") { access_log off; }
+                try_files $uri $uri/ /index.html /index.html;
+            }
+
+            location /healthz {
+                access_log off;
+                add_header Content-Type text/plain;
+                return 200 'ok';
+            }
+        }
+    }

--- a/apps/02-monitoring/hubble-ui/base/deployment.yaml
+++ b/apps/02-monitoring/hubble-ui/base/deployment.yaml
@@ -41,11 +41,11 @@ spec:
         - name: frontend
           image: quay.io/cilium/hubble-ui:v0.13.3@sha256:661d5de7050182d495c6497ff0b007a7a1e379648e60830dd68c4d78ae21761d
           ports:
-            - containerPort: 8080
+            - containerPort: 8081
               name: http
           livenessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
             initialDelaySeconds: 5
             periodSeconds: 30
@@ -55,6 +55,12 @@ spec:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
+          volumeMounts:
+            - name: hubble-ui-nginx-conf
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: nginx.conf
+            - name: tmp-dir
+              mountPath: /tmp
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -83,3 +89,9 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+      volumes:
+        - name: hubble-ui-nginx-conf
+          configMap:
+            name: hubble-ui-nginx
+        - name: tmp-dir
+          emptyDir: {}

--- a/apps/02-monitoring/hubble-ui/base/kustomization.yaml
+++ b/apps/02-monitoring/hubble-ui/base/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 namespace: monitoring
 resources:
   - rbac.yaml
+  - configmap.yaml
   - deployment.yaml
   - service.yaml
   - vpa.yaml


### PR DESCRIPTION
## Problème

hubble.truxonline.com affichait la page nginx welcome au lieu de la vraie UI Hubble.

## Cause racine

Le Helm chart Cilium 1.18.3 monte un **ConfigMap** `hubble-ui-nginx` comme nginx config :
- `root /app` (pas `/usr/share/nginx/html`)
- Port `8081` (pas `8080`)
- `/healthz` endpoint pour liveness
- Proxy `/api` → backend port 8090

Sans ce ConfigMap, nginx utilise sa config par défaut → page welcome.

## Fix

- Ajoute `configmap.yaml` avec la config nginx du Helm chart Cilium
- Corrige `deployment.yaml` : port `8081`, volumeMounts nginx + tmp
- Ajoute `configmap.yaml` à `kustomization.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated monitoring UI infrastructure with improved health check endpoints and port configuration for enhanced reliability.
  * Configured API proxy layer to enable seamless backend service communication.
  * Enhanced single-page application routing for improved user navigation experience.
  * Added support for temporary runtime storage and optimized request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->