### PR TITLE
feat(cilium): CCNPs globaux allow-traefik + allow-prometheus + allow-coredns

### DIFF
--- a/apps/00-infra/cilium-lb/base/ccnp-allow-coredns.yaml
+++ b/apps/00-infra/cilium-lb/base/ccnp-allow-coredns.yaml
@@ -1,0 +1,20 @@
+---
+# Autorise tous les pods à résoudre le DNS via CoreDNS (kube-system)
+# Nécessaire avant d'activer le default-deny (issue #2935)
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-coredns-egress
+spec:
+  endpointSelector: {}
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/apps/00-infra/cilium-lb/base/ccnp-allow-prometheus.yaml
+++ b/apps/00-infra/cilium-lb/base/ccnp-allow-prometheus.yaml
@@ -1,0 +1,14 @@
+---
+# Autorise vmagent (monitoring) à scraper les métriques de tous les pods
+# Nécessaire avant d'activer le default-deny (issue #2935)
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-prometheus-scrape
+spec:
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: vmagent

--- a/apps/00-infra/cilium-lb/base/ccnp-allow-traefik.yaml
+++ b/apps/00-infra/cilium-lb/base/ccnp-allow-traefik.yaml
@@ -1,0 +1,14 @@
+---
+# Autorise Traefik à accéder à tous les pods applicatifs (ingress)
+# Nécessaire avant d'activer le default-deny (issue #2935)
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-traefik-ingress
+spec:
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+            app.kubernetes.io/name: traefik

--- a/apps/00-infra/cilium-lb/base/kustomization.yaml
+++ b/apps/00-infra/cilium-lb/base/kustomization.yaml
@@ -11,5 +11,8 @@ resources:
   - ippool.yaml
   - l2policy.yaml
   - ccnp-default-deny.yaml
+  - ccnp-allow-traefik.yaml
+  - ccnp-allow-prometheus.yaml
+  - ccnp-allow-coredns.yaml
 components:
   - ../../../_shared/components/revision-history-limit


### PR DESCRIPTION
## Contexte

Prérequis pour l'activation du default-deny (#2935).
Policies basées sur l'analyse des flux Hubble (2093 flux observés en prod).

## Policies créées

| CCNP | Flux observés | Description |
|------|--------------|-------------|
| `allow-traefik-ingress` | 54 traefik→monitoring + autres | Traefik → tous pods |
| `allow-prometheus-scrape` | 28 monitoring→kube-system + autres | vmagent → tous pods (métriques) |
| `allow-coredns-egress` | DNS implicite dans tous les flux | Tous pods → CoreDNS UDP+TCP/53 |

## Impact

Ces CCNPs sont **additifs** — aucun trafic n'est bloqué aujourd'hui (default-deny toujours disabled). Ils préparent le terrain pour #2935.

🤖 Generated with [Claude Code](https://claude.com/claude-code)