### PR TITLE
fix(cilium): enableDefaultDeny:false sur CCNPs globaux (Traefik cassé → HA/Frigate KO)

### DIFF
--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-coredns.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-coredns.yaml
@@ -1,12 +1,15 @@
 ---
 # Autorise tous les pods à résoudre le DNS via CoreDNS (kube-system)
-# Nécessaire avant d'activer le default-deny (issue #2935)
+# enableDefaultDeny: false = additif seulement, ne bloque pas le reste de l'egress
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
   name: allow-coredns-egress
 spec:
   endpointSelector: {}
+  enableDefaultDeny:
+    ingress: false
+    egress: false
   egress:
     - toEndpoints:
         - matchLabels:

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-prometheus.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-prometheus.yaml
@@ -1,12 +1,15 @@
 ---
 # Autorise vmagent (monitoring) à scraper les métriques de tous les pods
-# Nécessaire avant d'activer le default-deny (issue #2935)
+# enableDefaultDeny: false = additif seulement, ne bloque pas le reste de l'ingress
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
   name: allow-prometheus-scrape
 spec:
   endpointSelector: {}
+  enableDefaultDeny:
+    ingress: false
+    egress: false
   ingress:
     - fromEndpoints:
         - matchLabels:

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-traefik.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-traefik.yaml
@@ -1,12 +1,15 @@
 ---
 # Autorise Traefik à accéder à tous les pods applicatifs (ingress)
-# Nécessaire avant d'activer le default-deny (issue #2935)
+# enableDefaultDeny: false = additif seulement, ne bloque pas le reste de l'ingress
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
   name: allow-traefik-ingress
 spec:
   endpointSelector: {}
+  enableDefaultDeny:
+    ingress: false
+    egress: false
   ingress:
     - fromEndpoints:
         - matchLabels:


### PR DESCRIPTION
## Problème

Les CCNPs déployés dans #2977 avaient `endpointSelector: {}` avec des règles ingress/egress mais **sans** `enableDefaultDeny: false`.

En Cilium, quand une CCNP ajoute une règle egress/ingress à un pod qui n'avait **aucune politique** (ex: Traefik), Cilium active automatiquement le deny par défaut pour cette direction. Résultat : Traefik ne pouvait plus atteindre `kube-apiserver:443` → perte de découverte des routes → HA et Frigate inaccessibles.

## Fix

Ajout de `enableDefaultDeny: ingress: false / egress: false` sur les 3 CCNPs — les règles deviennent **additives** et ne bloquent pas le trafic existant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated production network policy configurations to explicitly configure default-deny behavior settings for both ingress and egress traffic.
* All existing traffic allow rules are preserved unchanged.
* No impact to current network connectivity or traffic patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->