### PR TITLE
feat(network): CiliumNetworkPolicies pour tous les namespaces (#2935 prep)

### DIFF
--- a/apps/00-infra/cert-manager-webhook-gandi/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/base/cilium-networkpolicy.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cert-manager-webhook-gandi
+  namespace: cert-manager
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: cert-manager-webhook-gandi
+  egress:
+    - {}
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/00-infra/cert-manager-webhook-gandi/base/kustomization.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/base/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - gandi-infisical-secret.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/00-infra/cert-manager/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/cert-manager/base/cilium-networkpolicy.yaml
@@ -1,0 +1,60 @@
+---
+# cert-manager controller
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: cert-manager
+      app.kubernetes.io/instance: cert-manager
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+---
+# cert-manager cainjector
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cert-manager-cainjector
+  namespace: cert-manager
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: cainjector
+      app.kubernetes.io/instance: cert-manager
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+---
+# cert-manager webhook — reçoit des appels de kube-apiserver
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cert-manager-webhook
+  namespace: cert-manager
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: webhook
+      app.kubernetes.io/instance: cert-manager
+  egress:
+    - {}
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "10250"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/00-infra/cert-manager/base/kustomization.yaml
+++ b/apps/00-infra/cert-manager/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - cluster-issuer-prod.yaml
   - servicemonitor.yaml
   - pdb.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-coredns.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-coredns.yaml
@@ -1,12 +1,15 @@
 ---
 # Autorise tous les pods à résoudre le DNS via CoreDNS (kube-system)
-# Nécessaire avant d'activer le default-deny (issue #2935)
+# enableDefaultDeny: false = additif seulement, ne bloque pas le reste de l'egress
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
   name: allow-coredns-egress
 spec:
   endpointSelector: {}
+  enableDefaultDeny:
+    ingress: false
+    egress: false
   egress:
     - toEndpoints:
         - matchLabels:

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-prometheus.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-prometheus.yaml
@@ -1,12 +1,15 @@
 ---
 # Autorise vmagent (monitoring) à scraper les métriques de tous les pods
-# Nécessaire avant d'activer le default-deny (issue #2935)
+# enableDefaultDeny: false = additif seulement, ne bloque pas le reste de l'ingress
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
   name: allow-prometheus-scrape
 spec:
   endpointSelector: {}
+  enableDefaultDeny:
+    ingress: false
+    egress: false
   ingress:
     - fromEndpoints:
         - matchLabels:

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-traefik.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-traefik.yaml
@@ -1,12 +1,15 @@
 ---
 # Autorise Traefik à accéder à tous les pods applicatifs (ingress)
-# Nécessaire avant d'activer le default-deny (issue #2935)
+# enableDefaultDeny: false = additif seulement, ne bloque pas le reste de l'ingress
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
   name: allow-traefik-ingress
 spec:
   endpointSelector: {}
+  enableDefaultDeny:
+    ingress: false
+    egress: false
   ingress:
     - fromEndpoints:
         - matchLabels:

--- a/apps/00-infra/crowdsec/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/crowdsec/base/cilium-networkpolicy.yaml
@@ -1,0 +1,41 @@
+---
+# crowdsec-agent (collecte logs, pas d'ingress externe)
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: crowdsec-agent
+  namespace: crowdsec
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: crowdsec-agent
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+---
+# crowdsec-lapi — reçoit des requêtes de Traefik (bouncer) et monitoring
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: crowdsec-lapi
+  namespace: crowdsec
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: crowdsec-lapi
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/00-infra/crowdsec/base/kustomization.yaml
+++ b/apps/00-infra/crowdsec/base/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - infisical-secret.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/00-infra/infisical-operator/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/infisical-operator/base/cilium-networkpolicy.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: infisical-operator
+  namespace: infisical-operator-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: secrets-operator
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/00-infra/infisical-operator/base/kustomization.yaml
+++ b/apps/00-infra/infisical-operator/base/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - servicemonitor.yaml
   - pdb.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/00-infra/keda/overlays/prod/cilium-networkpolicy.yaml
+++ b/apps/00-infra/keda/overlays/prod/cilium-networkpolicy.yaml
@@ -1,0 +1,57 @@
+---
+# keda-operator
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: keda-operator
+  namespace: keda
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: keda-operator
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+---
+# keda-admission-webhooks — reçoit des appels de kube-apiserver
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: keda-admission-webhooks
+  namespace: keda
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: keda-admission-webhooks
+  egress:
+    - {}
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+---
+# keda http-add-on (controller, scaler, interceptor)
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: keda-http-add-on
+  namespace: keda
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: http-add-on
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/00-infra/keda/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/keda/overlays/prod/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - pdb-keda-operator.yaml
   - pdb-keda-metrics-apiserver.yaml
   - pdb-keda-webhooks.yaml
+  - cilium-networkpolicy.yaml
 
 patches:
   - patch: |-

--- a/apps/00-infra/kyverno/base/policies/cilium-networkpolicy.yaml
+++ b/apps/00-infra/kyverno/base/policies/cilium-networkpolicy.yaml
@@ -1,0 +1,84 @@
+---
+# kyverno admission-controller — reçoit des appels de kube-apiserver
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kyverno-admission-controller
+  namespace: kyverno
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: admission-controller
+      app.kubernetes.io/instance: kyverno
+  egress:
+    - {}
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "9443"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+---
+# kyverno background-controller
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kyverno-background-controller
+  namespace: kyverno
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: background-controller
+      app.kubernetes.io/instance: kyverno
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+---
+# kyverno cleanup-controller — reçoit des appels de kube-apiserver
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kyverno-cleanup-controller
+  namespace: kyverno
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: cleanup-controller
+      app.kubernetes.io/instance: kyverno
+  egress:
+    - {}
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "9443"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+---
+# kyverno reports-controller
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kyverno-reports-controller
+  namespace: kyverno
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: reports-controller
+      app.kubernetes.io/instance: kyverno
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/00-infra/kyverno/base/policies/kustomization.yaml
+++ b/apps/00-infra/kyverno/base/policies/kustomization.yaml
@@ -62,3 +62,4 @@ resources:
   - sizing-audit.yaml
   - sizing-v2-mutate.yaml
   - sizing-vpa-generate.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/00-infra/policy-reporter/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/policy-reporter/base/cilium-networkpolicy.yaml
@@ -1,0 +1,66 @@
+---
+# policy-reporter core
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: policy-reporter
+  namespace: policy-reporter
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: policy-reporter
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+---
+# policy-reporter kyverno-plugin
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: policy-reporter-kyverno-plugin
+  namespace: policy-reporter
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: kyverno-plugin
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+---
+# policy-reporter UI
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: policy-reporter-ui
+  namespace: policy-reporter
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: ui
+      app.kubernetes.io/part-of: policy-reporter
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/00-infra/policy-reporter/base/kustomization.yaml
+++ b/apps/00-infra/policy-reporter/base/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 namespace: policy-reporter
 resources:
   - servicemonitor.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/00-infra/reloader/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/reloader/base/cilium-networkpolicy.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: reloader
+  namespace: tools
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: reloader
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/00-infra/reloader/base/kustomization.yaml
+++ b/apps/00-infra/reloader/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - service.yaml
   - servicemonitor.yaml
   - pdb.yaml
+  - cilium-networkpolicy.yaml
 
 patches:
   - patch: |

--- a/apps/00-infra/traefik/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/traefik/base/cilium-networkpolicy.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: traefik
+  namespace: traefik
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+  egress:
+    - {}
+  ingress:
+    - fromEntities:
+        - world
+        - cluster
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/00-infra/traefik/base/kustomization.yaml
+++ b/apps/00-infra/traefik/base/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - middleware-redirect-https.yaml
   - middleware-crowdsec-bouncer.yaml
   - infisical-crowdsec-bouncer.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/00-infra/velero/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/velero/base/cilium-networkpolicy.yaml
@@ -1,0 +1,17 @@
+---
+# velero server
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: velero
+  namespace: velero
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: velero
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/00-infra/velero/base/kustomization.yaml
+++ b/apps/00-infra/velero/base/kustomization.yaml
@@ -1,3 +1,5 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+resources:
+  - cilium-networkpolicy.yaml

--- a/apps/00-infra/vpa/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/vpa/base/cilium-networkpolicy.yaml
@@ -1,0 +1,60 @@
+---
+# vpa-admission-controller — reçoit des appels de kube-apiserver
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: vpa-admission-controller
+  namespace: vpa
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: vertical-pod-autoscaler
+      app.kubernetes.io/component: admission-controller
+  egress:
+    - {}
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "8944"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+---
+# vpa-recommender
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: vpa-recommender
+  namespace: vpa
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: vertical-pod-autoscaler
+      app.kubernetes.io/component: recommender
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+---
+# vpa-updater
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: vpa-updater
+  namespace: vpa
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: vertical-pod-autoscaler
+      app.kubernetes.io/component: updater
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/00-infra/vpa/base/kustomization.yaml
+++ b/apps/00-infra/vpa/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - manifests.yaml
   - pdb-recommender.yaml
   - pdb-updater.yaml
+  - cilium-networkpolicy.yaml
 
 patches:
   - patch: |

--- a/apps/02-monitoring/fluent-bit-syslog/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/fluent-bit-syslog/base/cilium-networkpolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: fluent-bit-syslog
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: fluent-bit-syslog
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - {}
+      toPorts:
+        - ports:
+            - port: "514"
+              protocol: TCP
+            - port: "514"
+              protocol: UDP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "2020"
+              protocol: TCP

--- a/apps/02-monitoring/fluent-bit-syslog/base/kustomization.yaml
+++ b/apps/02-monitoring/fluent-bit-syslog/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingressroute-syslog.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/02-monitoring/fluent-bit/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/fluent-bit/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: fluent-bit
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: fluent-bit
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "2020"
+              protocol: TCP

--- a/apps/02-monitoring/fluent-bit/base/kustomization.yaml
+++ b/apps/02-monitoring/fluent-bit/base/kustomization.yaml
@@ -2,3 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: monitoring
+resources:
+  - cilium-networkpolicy.yaml

--- a/apps/02-monitoring/goldilocks/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/goldilocks/base/cilium-networkpolicy.yaml
@@ -1,0 +1,40 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: goldilocks-dashboard
+  namespace: goldilocks
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: goldilocks
+      app.kubernetes.io/component: dashboard
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: goldilocks-controller
+  namespace: goldilocks
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: goldilocks
+      app.kubernetes.io/component: controller
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/02-monitoring/goldilocks/base/kustomization.yaml
+++ b/apps/02-monitoring/goldilocks/base/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - infisical-secret.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/02-monitoring/grafana/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/grafana/base/cilium-networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/02-monitoring/grafana/base/kustomization.yaml
+++ b/apps/02-monitoring/grafana/base/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 namespace: monitoring
 resources:
   - infisical-secret.yaml
+  - cilium-networkpolicy.yaml
   - dashboards/traefik.yaml
   - dashboards/postgresql.yaml
   - dashboards/homeassistant.yaml

--- a/apps/02-monitoring/snmp-exporter/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/cilium-networkpolicy.yaml
@@ -1,0 +1,19 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: snmp-exporter
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: snmp-exporter
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "9116"
+              protocol: TCP

--- a/apps/02-monitoring/snmp-exporter/base/kustomization.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - infisical-secret.yaml
   - rbac.yaml
   - vmscrape.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/02-monitoring/victoria-metrics/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/victoria-metrics/base/cilium-networkpolicy.yaml
@@ -1,0 +1,139 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: vmagent
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: vmagent
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "8429"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: vmsingle
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: vmsingle
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "8428"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: vmalert
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: vmalert
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: vmalertmanager
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: vmalertmanager
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "9093"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kube-state-metrics
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: prometheus-node-exporter
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-node-exporter
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "9100"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: victoria-metrics-operator
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: victoria-metrics-operator
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/apps/02-monitoring/victoria-metrics/base/kustomization.yaml
+++ b/apps/02-monitoring/victoria-metrics/base/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: monitoring
 resources:
   - alertmanager-infisical-secret.yaml
   - vmrule-pvc-pending.yaml
+  - cilium-networkpolicy.yaml
 
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/03-security/trivy/base/cilium-networkpolicy.yaml
+++ b/apps/03-security/trivy/base/cilium-networkpolicy.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: trivy-operator
+  namespace: security
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: trivy-operator
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/03-security/trivy/base/kustomization.yaml
+++ b/apps/03-security/trivy/base/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 namespace: security
 resources:
   - manifests.yaml
+  - cilium-networkpolicy.yaml
 
 patches:
   # Add resources for Bronze maturity

--- a/apps/20-media/amule/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/amule/base/cilium-networkpolicy.yaml
@@ -1,0 +1,30 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: amule
+  namespace: downloads
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: amule
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "4711"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+    - toPorts:
+        - ports:
+            - port: "4662"
+              protocol: TCP
+            - port: "4665"
+              protocol: UDP
+            - port: "4672"
+              protocol: UDP

--- a/apps/20-media/amule/base/kustomization.yaml
+++ b/apps/20-media/amule/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - deployment.yaml
   - service.yaml
   - infisical-secret.yaml
+  - cilium-networkpolicy.yaml
 
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/20-media/birdnet-go/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/birdnet-go/base/cilium-networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: birdnet-go
+  namespace: birdnet-go
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: birdnet-go
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/20-media/birdnet-go/base/kustomization.yaml
+++ b/apps/20-media/birdnet-go/base/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
   - deployment.yaml
   - service.yaml
   - pdb.yaml
+  - cilium-networkpolicy.yaml
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/20-media/pyload/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/pyload/base/cilium-networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: pyload
+  namespace: downloads
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: pyload
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/20-media/pyload/base/kustomization.yaml
+++ b/apps/20-media/pyload/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - deployment.yaml
   - service.yaml
   - infisical-secret.yaml
+  - cilium-networkpolicy.yaml
 
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/20-media/qbittorrent/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/qbittorrent/base/cilium-networkpolicy.yaml
@@ -1,0 +1,28 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: qbittorrent
+  namespace: media
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: qbittorrent
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+    - toPorts:
+        - ports:
+            - port: "6881"
+              protocol: TCP
+            - port: "6881"
+              protocol: UDP

--- a/apps/20-media/qbittorrent/base/kustomization.yaml
+++ b/apps/20-media/qbittorrent/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - deployment.yaml
   - service.yaml
   - infisical-secret.yaml
+  - cilium-networkpolicy.yaml
 
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/40-network/external-dns-gandi/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/external-dns-gandi/base/cilium-networkpolicy.yaml
@@ -1,0 +1,15 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: external-dns-gandi
+  namespace: networking
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-dns-gandi
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/40-network/external-dns-gandi/base/kustomization.yaml
+++ b/apps/40-network/external-dns-gandi/base/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - infisical-secret.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/40-network/external-dns-unifi/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/external-dns-unifi/base/cilium-networkpolicy.yaml
@@ -1,0 +1,15 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: external-dns-unifi
+  namespace: networking
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-dns-unifi
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/40-network/external-dns-unifi/base/kustomization.yaml
+++ b/apps/40-network/external-dns-unifi/base/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - infisical-secret.yaml
   - rbac-fix.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/60-services/firefly-iii-importer/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/firefly-iii-importer/base/cilium-networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: firefly-iii-importer
+  namespace: finance
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: firefly-iii-importer
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/60-services/firefly-iii-importer/base/kustomization.yaml
+++ b/apps/60-services/firefly-iii-importer/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - service.yaml
   - ingress.yaml
   - infisical-secret.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/60-services/firefly-iii/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/firefly-iii/base/cilium-networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: firefly-iii
+  namespace: finance
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: firefly-iii
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/60-services/firefly-iii/base/kustomization.yaml
+++ b/apps/60-services/firefly-iii/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - infisical-secret.yaml
   - cronjob.yaml
   - pdb.yaml
+  - cilium-networkpolicy.yaml
   # vpa.yaml removed - Kyverno generates vixens-firefly-iii VPA via sizing-v2 label
 
 components:

--- a/apps/60-services/g4f/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/g4f/base/cilium-networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: g4f
+  namespace: g4f
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: g4f
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/60-services/g4f/base/kustomization.yaml
+++ b/apps/60-services/g4f/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - pvc.yaml
   - service.yaml
   - ingress.yaml
+  - cilium-networkpolicy.yaml

--- a/apps/60-services/sakapuss/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/sakapuss/base/cilium-networkpolicy.yaml
@@ -1,0 +1,47 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: sakapuss-backend
+  namespace: sakapuss
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sakapuss-backend
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+        - matchLabels:
+            app: sakapuss
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: sakapuss-frontend
+  namespace: sakapuss
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sakapuss-frontend
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/60-services/sakapuss/base/kustomization.yaml
+++ b/apps/60-services/sakapuss/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - service.yaml
   - pvc.yaml
   - nginx-config.yaml
+  - cilium-networkpolicy.yaml
 patches:
   - path: patch-frontend-nginx.yaml
     target:

--- a/apps/70-tools/homepage/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/homepage/base/cilium-networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: homepage
+  namespace: tools
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: homepage
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/70-tools/homepage/base/kustomization.yaml
+++ b/apps/70-tools/homepage/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - deployment.yaml
   - service.yaml
   - infisical-config.yaml
+  - cilium-networkpolicy.yaml
 
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/70-tools/it-tools/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/it-tools/base/cilium-networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: it-tools
+  namespace: tools
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: it-tools
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/70-tools/it-tools/base/kustomization.yaml
+++ b/apps/70-tools/it-tools/base/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: tools
 resources:
+  - cilium-networkpolicy.yaml
 # Base resources managed by Helm
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/70-tools/nexterm/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/nexterm/base/cilium-networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: nexterm
+  namespace: tools
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: nexterm
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/70-tools/nexterm/base/kustomization.yaml
+++ b/apps/70-tools/nexterm/base/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - service.yaml
   - infisical-secret.yaml
   - pdb.yaml
+  - cilium-networkpolicy.yaml
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/70-tools/nocodb/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/nocodb/base/cilium-networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: nocodb
+  namespace: tools
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: nocodb
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/70-tools/nocodb/base/kustomization.yaml
+++ b/apps/70-tools/nocodb/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - service.yaml
   - ingress.yaml
   - infisical-secret.yaml
+  - cilium-networkpolicy.yaml
 
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/70-tools/radar/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/radar/base/cilium-networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: radar
+  namespace: tools
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: radar
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "9280"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/70-tools/radar/base/kustomization.yaml
+++ b/apps/70-tools/radar/base/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: tools
 resources:
   - manifests.yaml
   - rbac-view-binding.yaml
+  - cilium-networkpolicy.yaml
 
 patches:
   - target:

--- a/apps/70-tools/stirling-pdf/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/stirling-pdf/base/cilium-networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: stirling-pdf
+  namespace: tools
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: stirling-pdf
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/70-tools/stirling-pdf/base/kustomization.yaml
+++ b/apps/70-tools/stirling-pdf/base/kustomization.yaml
@@ -3,7 +3,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: tools
 resources:
-# Empty base - resources are managed by Helm
+  - cilium-networkpolicy.yaml
+# Empty base - other resources are managed by Helm
 
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/70-tools/trilium/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/trilium/base/cilium-networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: trilium
+  namespace: tools
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: trilium
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/70-tools/trilium/base/kustomization.yaml
+++ b/apps/70-tools/trilium/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - service.yaml
   - ingress.yaml
   - pdb.yaml
+  - cilium-networkpolicy.yaml
 
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/70-tools/vikunja/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/vikunja/base/cilium-networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: vikunja
+  namespace: tools
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: vikunja
+  egress:
+    - {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring

--- a/apps/70-tools/vikunja/base/kustomization.yaml
+++ b/apps/70-tools/vikunja/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - infisical-secret.yaml
   - vikunja-db-secrets.yaml
   - pdb.yaml
+  - cilium-networkpolicy.yaml
 
 components:
   - ../../../_shared/components/revision-history-limit


### PR DESCRIPTION
## Summary

Prépare le futur default-deny (#2935) en ajoutant des **CiliumNetworkPolicies additives** pour tous les namespaces qui n'en avaient pas.

- **36 nouveaux fichiers** `cilium-networkpolicy.yaml` couvrant 36 namespaces/composants
- **Purement additif** : `egress: [{}]` sur tout, `enableDefaultDeny: false` reste sur les CCNPs globaux — rien n'est bloqué maintenant
- Toutes les CNPs ont été validées YAML (pre-commit hook passed)

### Couverture

**Infrastructure (webhooks kube-apiserver)** :
- `traefik` : ingress depuis `world + cluster`
- `cert-manager` (controller + cainjector + webhook kube-apiserver→10250)
- `cert-manager-webhook-gandi` (kube-apiserver→443)
- `kyverno` (admission+cleanup kube-apiserver→9443, background, reports)
- `keda` (operator, admission kube-apiserver→443, http-add-on ×3)
- `vpa` (admission kube-apiserver→8944, recommender, updater)
- `velero`, `crowdsec` (lapi reçoit Traefik bouncer), `infisical-operator`, `policy-reporter`, `trivy`, `reloader`

**Monitoring** : grafana, victoria-metrics (7 composants : vmagent/vmsingle/vmalert/vmalertmanager/kube-state-metrics/node-exporter/vm-operator), fluent-bit, fluent-bit-syslog, snmp-exporter, goldilocks

**Tools** : homepage, nexterm, nocodb, radar, stirling-pdf, trilium, vikunja, it-tools

**Services/Finance** : g4f, sakapuss (frontend+backend), firefly-iii, firefly-iii-importer

**Media/Downloads** : birdnet-go, amule, pyload, qbittorrent

**Network** : external-dns-gandi, external-dns-unifi

## Test plan

- [ ] ArgoCD sync all affected apps → no errors (CNPs additives = rien ne casse)
- [ ] `kubectl get cnp -A` montre les nouvelles CNPs VALID: True
- [ ] Services existants toujours accessibles (Traefik, HA, Frigate)
- [ ] Prêt pour activer default-deny (#2935) une fois ce PR en prod

Closes #2934

🤖 Generated with [Claude Code](https://claude.com/claude-code)