### PR TITLE
fix: kyverno PriorityClass RBAC + revert external-dns-unifi v0.21.0

### DIFF
--- a/apps/00-infra/kyverno/base/policies/kustomization.yaml
+++ b/apps/00-infra/kyverno/base/policies/kustomization.yaml
@@ -48,6 +48,7 @@ resources:
   - policy-exception-csi-probes.yaml
   - policy-exception-mixed-sizing.yaml
   - policy-exception-nometrics.yaml
+  - rbac-priorityclasses.yaml
   - rbac-secrets.yaml
   - rbac-servicemonitors.yaml
   - require-goldilocks.yaml

--- a/apps/00-infra/kyverno/base/policies/rbac-priorityclasses.yaml
+++ b/apps/00-infra/kyverno/base/policies/rbac-priorityclasses.yaml
@@ -1,0 +1,26 @@
+---
+# Grant Kyverno admission controller read access to PriorityClasses
+# Required for mutate-priority-class policy APICall evaluation
+# (rule inject-priority-class-from-label fetches the numeric value
+#  from /apis/scheduling.k8s.io/v1/priorityclasses/<name>)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:admission-controller:priorityclasses
+rules:
+  - apiGroups: ["scheduling.k8s.io"]
+    resources: ["priorityclasses"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kyverno:admission-controller:priorityclasses
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kyverno:admission-controller:priorityclasses
+subjects:
+  - kind: ServiceAccount
+    name: kyverno-admission-controller
+    namespace: kyverno

--- a/apps/40-network/external-dns-unifi/values/common.yaml
+++ b/apps/40-network/external-dns-unifi/values/common.yaml
@@ -6,7 +6,7 @@ logLevel: debug
 image:
   registry: registry.k8s.io
   repository: external-dns/external-dns
-  tag: v0.21.0
+  tag: v0.20.0
 extraArgs:
   webhook-provider-url: http://127.0.0.1:8888
 # RBAC permissions for EndpointSlices (required for some sources)


### PR DESCRIPTION
## Summary

- **fix(kyverno)**: Add `ClusterRole/ClusterRoleBinding` granting `kyverno-admission-controller` GET access to `scheduling.k8s.io/priorityclasses`. The `mutate-priority-class` policy makes an APICall to fetch the numeric priority value from the PriorityClass object, but the SA lacked permission → `victoria-metrics-operator` and other pods with `vixens.io/priority-class` labels were blocked from creation.

- **fix(external-dns-unifi)**: Revert image from `v0.21.0` → `v0.20.0`. The v0.21.0 upgrade fails because external-dns now exits after 3s if the sidecar webhook isn't ready (the sidecar needs ~5s to start). This has been crashing for 6 days, consuming 768Mi in memory requests on the single-node dev cluster.

## Test plan

- [x] RBAC applied manually — `kubectl auth can-i get priorityclasses --as=system:serviceaccount:kyverno:kyverno-admission-controller` returns `yes`
- [x] `kubectl run test-priority --image=nginx:alpine --labels="vixens.io/priority-class=vixens-low" -n monitoring --dry-run=server` succeeds
- [ ] victoria-metrics-operator pod created and running after PR merge
- [ ] external-dns-unifi rolling update cleans up broken v0.21.0 pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)