### PR TITLE
fix(external-dns-unifi): convert webhook to native K8s sidecar — eliminate startup race

### DIFF
--- a/apps/40-network/external-dns-unifi/values/common.yaml
+++ b/apps/40-network/external-dns-unifi/values/common.yaml
@@ -17,10 +17,13 @@ rbac:
       resources: ["endpointslices"]
       verbs: ["get", "watch", "list"]
 
-# Sidecar Webhook
-sidecars:
+# Native K8s sidecar (1.28+): starts before external-dns and its readiness
+# probe must pass before external-dns starts — eliminates startup race condition
+# where external-dns would exit if the webhook wasn't ready within 3 seconds.
+initContainers:
   - name: unifi-webhook
     image: ghcr.io/kashalls/external-dns-unifi-webhook:v0.8.2
+    restartPolicy: Always
     args: ["--host", "0.0.0.0"]
     ports:
       - containerPort: 8888


### PR DESCRIPTION
## Problem

On every new pod start, `external-dns` connects to `http://127.0.0.1:8888` (the `unifi-webhook` sidecar) immediately and exits after 3 seconds if the webhook isn't ready. The webhook takes 25+ seconds to start, so every new pod crashes — the rolling update has been stuck for days.

Root cause: `unifi-webhook` was defined as a regular container in `spec.containers`. Both containers start concurrently with no ordering guarantee.

## Fix

Convert `unifi-webhook` to a **native Kubernetes sidecar** using `initContainers` with `restartPolicy: Always` (GA since K8s 1.29, cluster is on 1.34).

When an initContainer has `restartPolicy: Always`, Kubernetes:
1. Starts the sidecar **before** all regular containers
2. Waits for its `readinessProbe` to pass before starting regular containers
3. Keeps the sidecar running alongside regular containers

The existing `readinessProbe` (`tcpSocket: port webhook, initialDelaySeconds: 5`) already provides the right signal — Kubernetes just wasn't waiting for it before starting `external-dns`.

## Test plan

- [ ] ArgoCD applies the new Deployment — verify `unifi-webhook` appears in `initContainers` section
- [ ] New pod starts successfully: `unifi-webhook` reaches Ready, then `external-dns` starts
- [ ] External DNS continues resolving LAN records via UniFi
- [ ] Rolling update completes — old stuck RS scales to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)