### PR TITLE
fix(argocd): correct repo-server container name (v3.x rename)

### DIFF
--- a/apps/00-infra/argocd/overlays/dev/patches/repo-server-resources.yaml
+++ b/apps/00-infra/argocd/overlays/dev/patches/repo-server-resources.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     spec:
       containers:
-        - name: repo-server
+        - name: argocd-repo-server
           resources:
             limits:
               memory: 2Gi


### PR DESCRIPTION
## Problem

ArgoCD v3.x renamed the main container in `argocd-repo-server` Deployment from `repo-server` to `argocd-repo-server`. The `repo-server-resources.yaml` patch was still targeting the old name, causing kustomize to add a **phantom container with no image** to the Deployment spec.

This caused the ArgoCD self-sync to fail repeatedly:
```
Deployment.apps "argocd-repo-server" is invalid:
  spec.template.spec.containers[0].image: Required value (retried 5 times)
```

## Fix

Update the patch to target `argocd-repo-server` (the current container name).

## Test plan

- [ ] ArgoCD app goes from OutOfSync→Synced after merge
- [ ] `argocd-repo-server` Deployment has exactly 1 container with a valid image

🤖 Generated with [Claude Code](https://claude.com/claude-code)