### PR TITLE
fix: resolve ArgoCD sync errors (whoami container name, frigate PVC storage class)

### DIFF
--- a/apps/20-media/frigate/overlays/dev/kustomization.yaml
+++ b/apps/20-media/frigate/overlays/dev/kustomization.yaml
@@ -9,6 +9,7 @@ components:
   - ../../../../_shared/components/dataangel
   - ../../../../_shared/components/revision-history-limit
 patches:
+  - path: pvc-patch.yaml
   - path: dataangel.yaml
   - target:
       kind: Deployment

--- a/apps/20-media/frigate/overlays/dev/pvc-patch.yaml
+++ b/apps/20-media/frigate/overlays/dev/pvc-patch.yaml
@@ -1,0 +1,17 @@
+---
+# Dev cluster PVC was created with synelia-iscsi-retain (iSCSI).
+# PVC specs are immutable once bound — this patch ensures Git matches
+# the existing cluster PVC to prevent ArgoCD sync errors.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: frigate-config-pvc
+spec:
+  storageClassName: synelia-iscsi-retain
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: frigate-cache-pvc
+spec:
+  storageClassName: synelia-iscsi-retain

--- a/apps/99-test/whoami/overlays/dev/kustomization.yaml
+++ b/apps/99-test/whoami/overlays/dev/kustomization.yaml
@@ -7,4 +7,3 @@ resources:
 - ingress.yaml
 components:
 - ../../../../_shared/components/dev-hibernate
-- ../../../../_shared/components/probes/basic


### PR DESCRIPTION
## Problems

### whoami: invalid container name
The `probes/basic` component uses `name: "*"` (kustomize wildcard) to patch all containers. However, kustomize renders this as a literal container named `"*"` when the merge doesn't find an exact match — causing Kubernetes to reject the Deployment:
```
spec.template.spec.containers[0].name: Invalid value: "*"
spec.template.spec.containers[0].image: Required value
```

### frigate: immutable PVC spec
The frigate dev cluster PVC was created with `storageClassName: synelia-iscsi-retain` (iSCSI), but the Git base has `local-path-delete`. PVC specs are immutable once bound:
```
PersistentVolumeClaim "frigate-config-pvc" is invalid:
  spec: Forbidden: spec is immutable after creation
```

## Fixes

- **whoami**: Remove the redundant `probes/basic` component from the dev overlay. The base deployment already defines proper liveness/readiness probes. With `dev-hibernate` setting replicas=0, probes are unused anyway.

- **frigate**: Add `pvc-patch.yaml` to the dev overlay that sets both PVCs to `synelia-iscsi-retain` to match the existing cluster PVCs.

## Test plan

- [ ] `whoami` ArgoCD app goes Synced (was OutOfSync/Missing)
- [ ] `frigate` ArgoCD app goes Synced (was OutOfSync/Progressing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)