### PR TITLE
fix(cnp): restore egress allow-all + add missing CNPs (prep for deny)

### DIFF
--- a/apps/00-infra/cert-manager/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/cert-manager/base/cilium-networkpolicy.yaml
@@ -14,6 +14,8 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}
 ---
 # cert-manager cainjector
 apiVersion: cilium.io/v2
@@ -30,6 +32,8 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}
 ---
 # cert-manager webhook — reçoit des appels de kube-apiserver
 apiVersion: cilium.io/v2
@@ -52,3 +56,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/00-infra/crowdsec/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/crowdsec/base/cilium-networkpolicy.yaml
@@ -13,6 +13,8 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}
 ---
 # crowdsec-lapi — reçoit des requêtes de Traefik (bouncer) et monitoring
 apiVersion: cilium.io/v2
@@ -35,3 +37,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/00-infra/infisical-operator/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/infisical-operator/base/cilium-networkpolicy.yaml
@@ -12,3 +12,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/00-infra/kyverno/base/policies/cilium-networkpolicy.yaml
+++ b/apps/00-infra/kyverno/base/policies/cilium-networkpolicy.yaml
@@ -22,6 +22,8 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}
 ---
 # kyverno background-controller
 apiVersion: cilium.io/v2
@@ -38,6 +40,8 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}
 ---
 # kyverno cleanup-controller — reçoit des appels de kube-apiserver
 apiVersion: cilium.io/v2
@@ -62,6 +66,8 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}
 ---
 # kyverno reports-controller
 apiVersion: cilium.io/v2
@@ -78,3 +84,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/00-infra/policy-reporter/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/policy-reporter/base/cilium-networkpolicy.yaml
@@ -20,6 +20,8 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}
 ---
 # policy-reporter kyverno-plugin
 apiVersion: cilium.io/v2
@@ -35,6 +37,8 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}
 ---
 # policy-reporter UI
 apiVersion: cilium.io/v2
@@ -58,3 +62,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/00-infra/reloader/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/reloader/base/cilium-networkpolicy.yaml
@@ -12,3 +12,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/00-infra/traefik/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/traefik/base/cilium-networkpolicy.yaml
@@ -21,3 +21,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/00-infra/velero/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/velero/base/cilium-networkpolicy.yaml
@@ -13,3 +13,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/00-infra/vpa/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/vpa/base/cilium-networkpolicy.yaml
@@ -20,6 +20,8 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}
 ---
 # vpa-recommender
 apiVersion: cilium.io/v2
@@ -36,6 +38,8 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}
 ---
 # vpa-updater
 apiVersion: cilium.io/v2
@@ -52,3 +56,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/01-storage/local-path-provisioner/base/cilium-networkpolicy.yaml
+++ b/apps/01-storage/local-path-provisioner/base/cilium-networkpolicy.yaml
@@ -2,18 +2,15 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: gluetun
+  name: local-path-provisioner
+  namespace: local-path-storage
 spec:
   endpointSelector:
     matchLabels:
-      app: gluetun
+      app: local-path-provisioner
   ingress:
     - fromEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: traefik
-      toPorts:
-        - ports:
-            - port: "8888"
-              protocol: TCP
+            io.kubernetes.pod.namespace: monitoring
   egress:
     - {}

--- a/apps/01-storage/local-path-provisioner/base/kustomization.yaml
+++ b/apps/01-storage/local-path-provisioner/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - deployment.yaml
   - configmap.yaml
   - storage-class.yaml
+  - cilium-networkpolicy.yaml
 labels:
   - pairs:
       app.kubernetes.io/name: local-path-provisioner

--- a/apps/01-storage/synology-csi/base/cilium-networkpolicy.yaml
+++ b/apps/01-storage/synology-csi/base/cilium-networkpolicy.yaml
@@ -1,14 +1,14 @@
 ---
-# keda-operator
+# synology-csi-controller — provisioner/attacher/resizer/snapshotter
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: keda-operator
-  namespace: keda
+  name: synology-csi-controller
+  namespace: synology-csi
 spec:
   endpointSelector:
     matchLabels:
-      app.kubernetes.io/name: keda-operator
+      app: synology-csi-controller
   ingress:
     - fromEndpoints:
         - matchLabels:
@@ -16,39 +16,33 @@ spec:
   egress:
     - {}
 ---
-# keda-admission-webhooks — reçoit des appels de kube-apiserver
+# synology-csi-node — node driver (iSCSI mount)
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: keda-admission-webhooks
-  namespace: keda
+  name: synology-csi-node
+  namespace: synology-csi
 spec:
   endpointSelector:
     matchLabels:
-      app.kubernetes.io/name: keda-admission-webhooks
+      app: synology-csi-node
   ingress:
-    - fromEntities:
-        - kube-apiserver
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
   egress:
     - {}
 ---
-# keda http-add-on (controller, scaler, interceptor)
+# iscsi-lock-cleanup — DaemonSet lock management
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: keda-http-add-on
-  namespace: keda
+  name: iscsi-lock-cleanup
+  namespace: synology-csi
 spec:
   endpointSelector:
     matchLabels:
-      app.kubernetes.io/name: http-add-on
+      app: iscsi-lock-cleanup
   ingress:
     - fromEndpoints:
         - matchLabels:

--- a/apps/01-storage/synology-csi/base/kustomization.yaml
+++ b/apps/01-storage/synology-csi/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - node.yaml
   - storage-class.yaml
   - iscsi-lock-cleanup-daemonset.yaml
+  - cilium-networkpolicy.yaml
 
 patches:
 

--- a/apps/02-monitoring/fluent-bit-syslog/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/fluent-bit-syslog/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -23,3 +24,5 @@ spec:
         - ports:
             - port: "2020"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/02-monitoring/fluent-bit/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/fluent-bit/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -15,3 +16,5 @@ spec:
         - ports:
             - port: "2020"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/02-monitoring/goldilocks/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/goldilocks/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -34,3 +35,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/02-monitoring/grafana/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/grafana/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -18,3 +19,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/02-monitoring/loki/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/loki/base/cilium-networkpolicy.yaml
@@ -17,3 +17,5 @@ spec:
         - ports:
             - port: "3100"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/02-monitoring/snmp-exporter/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -15,3 +16,5 @@ spec:
         - ports:
             - port: "9116"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/02-monitoring/victoria-metrics/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/victoria-metrics/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -33,6 +34,8 @@ spec:
         - ports:
             - port: "8428"
               protocol: TCP
+  egress:
+    - {}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -51,6 +54,8 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
+  egress:
+    - {}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -69,6 +74,8 @@ spec:
         - ports:
             - port: "9093"
               protocol: TCP
+  egress:
+    - {}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -87,6 +94,8 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
+  egress:
+    - {}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -105,6 +114,8 @@ spec:
         - ports:
             - port: "9100"
               protocol: TCP
+  egress:
+    - {}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -123,3 +134,5 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/03-security/authentik/base/cilium-networkpolicy.yaml
+++ b/apps/03-security/authentik/base/cilium-networkpolicy.yaml
@@ -18,3 +18,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/03-security/trivy/base/cilium-networkpolicy.yaml
+++ b/apps/03-security/trivy/base/cilium-networkpolicy.yaml
@@ -12,3 +12,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/04-databases/cloudnative-pg/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/cloudnative-pg/base/cilium-networkpolicy.yaml
@@ -1,19 +1,20 @@
 ---
+# cloudnative-pg operator — reçoit des appels webhook de kube-apiserver
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: cert-manager-webhook-gandi
-  namespace: cert-manager
+  name: cloudnative-pg
+  namespace: cnpg-system
 spec:
   endpointSelector:
     matchLabels:
-      app.kubernetes.io/name: cert-manager-webhook-gandi
+      app.kubernetes.io/name: cloudnative-pg
   ingress:
     - fromEntities:
         - kube-apiserver
       toPorts:
         - ports:
-            - port: "443"
+            - port: "9443"
               protocol: TCP
     - fromEndpoints:
         - matchLabels:

--- a/apps/04-databases/cloudnative-pg/base/kustomization.yaml
+++ b/apps/04-databases/cloudnative-pg/base/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cnpg-system
+resources:
+  - cilium-networkpolicy.yaml
 helmCharts:
   - name: cloudnative-pg
     releaseName: cloudnative-pg

--- a/apps/04-databases/mariadb-shared/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/mariadb-shared/base/cilium-networkpolicy.yaml
@@ -14,3 +14,5 @@ spec:
         - ports:
             - port: "3306"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/04-databases/redis-shared/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/redis-shared/base/cilium-networkpolicy.yaml
@@ -21,3 +21,5 @@ spec:
         - ports:
             - port: "6379"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/10-home/homeassistant/base/cilium-networkpolicy.yaml
+++ b/apps/10-home/homeassistant/base/cilium-networkpolicy.yaml
@@ -18,3 +18,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/10-home/mealie/base/cilium-networkpolicy.yaml
+++ b/apps/10-home/mealie/base/cilium-networkpolicy.yaml
@@ -18,3 +18,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/10-home/mosquitto/base/cilium-networkpolicy.yaml
+++ b/apps/10-home/mosquitto/base/cilium-networkpolicy.yaml
@@ -17,3 +17,5 @@ spec:
         - ports:
             - port: "1883"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/amule/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/amule/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -26,3 +27,5 @@ spec:
               protocol: UDP
             - port: "4672"
               protocol: UDP
+  egress:
+    - {}

--- a/apps/20-media/birdnet-go/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/birdnet-go/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -18,3 +19,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/20-media/booklore/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/booklore/base/cilium-networkpolicy.yaml
@@ -15,3 +15,5 @@ spec:
         - ports:
             - port: "6060"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/bookshelf/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/bookshelf/base/cilium-networkpolicy.yaml
@@ -15,3 +15,5 @@ spec:
         - ports:
             - port: "8787"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/frigate/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/frigate/base/cilium-networkpolicy.yaml
@@ -18,3 +18,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/20-media/hydrus-client/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/hydrus-client/base/cilium-networkpolicy.yaml
@@ -20,3 +20,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/20-media/jellyfin/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/jellyfin/base/cilium-networkpolicy.yaml
@@ -15,3 +15,5 @@ spec:
         - ports:
             - port: "8096"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/jellyseerr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/jellyseerr/base/cilium-networkpolicy.yaml
@@ -17,3 +17,5 @@ spec:
         - ports:
             - port: "5055"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/lidarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/lidarr/base/cilium-networkpolicy.yaml
@@ -18,3 +18,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/20-media/music-assistant/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/music-assistant/base/cilium-networkpolicy.yaml
@@ -15,3 +15,5 @@ spec:
         - ports:
             - port: "8095"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/20-media/mylar/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/mylar/base/cilium-networkpolicy.yaml
@@ -18,3 +18,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/20-media/prowlarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/prowlarr/base/cilium-networkpolicy.yaml
@@ -18,3 +18,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/20-media/pyload/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/pyload/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -18,3 +19,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/20-media/qbittorrent/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/qbittorrent/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -24,3 +25,5 @@ spec:
               protocol: TCP
             - port: "6881"
               protocol: UDP
+  egress:
+    - {}

--- a/apps/20-media/radarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/radarr/base/cilium-networkpolicy.yaml
@@ -18,3 +18,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/20-media/sabnzbd/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/sabnzbd/base/cilium-networkpolicy.yaml
@@ -20,3 +20,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/20-media/sonarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/sonarr/base/cilium-networkpolicy.yaml
@@ -18,3 +18,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/20-media/whisparr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/whisparr/base/cilium-networkpolicy.yaml
@@ -18,3 +18,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/40-network/adguard-home/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/adguard-home/base/cilium-networkpolicy.yaml
@@ -28,3 +28,5 @@ spec:
               protocol: TCP
             - port: "53"
               protocol: UDP
+  egress:
+    - {}

--- a/apps/40-network/external-dns-gandi/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/external-dns-gandi/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -11,3 +12,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/40-network/external-dns-unifi/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/external-dns-unifi/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -11,3 +12,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/40-network/netbird/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/netbird/base/cilium-networkpolicy.yaml
@@ -15,3 +15,5 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/40-network/netvisor/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/netvisor/base/cilium-networkpolicy.yaml
@@ -17,3 +17,5 @@ spec:
         - ports:
             - port: "60072"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/60-services/docspell/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/docspell/base/cilium-networkpolicy.yaml
@@ -17,3 +17,5 @@ spec:
         - ports:
             - port: "7880"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/60-services/firefly-iii-importer/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/firefly-iii-importer/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -18,3 +19,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/60-services/firefly-iii/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/firefly-iii/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -18,3 +19,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/60-services/g4f/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/g4f/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -18,3 +19,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/60-services/n8n/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/n8n/base/cilium-networkpolicy.yaml
@@ -18,3 +18,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: tools
+  egress:
+    - {}

--- a/apps/60-services/openclaw/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/openclaw/base/cilium-networkpolicy.yaml
@@ -22,3 +22,5 @@ spec:
         - matchLabels:
             app: n8n
             io.kubernetes.pod.namespace: services
+  egress:
+    - {}

--- a/apps/60-services/sakapuss/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/sakapuss/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -41,3 +42,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/60-services/vaultwarden/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/vaultwarden/base/cilium-networkpolicy.yaml
@@ -18,3 +18,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/70-tools/changedetection/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/changedetection/base/cilium-networkpolicy.yaml
@@ -15,3 +15,5 @@ spec:
         - ports:
             - port: "5000"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/70-tools/headlamp/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/headlamp/base/cilium-networkpolicy.yaml
@@ -17,3 +17,5 @@ spec:
         - ports:
             - port: "4466"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/70-tools/homepage/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/homepage/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -18,3 +19,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/70-tools/it-tools/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/it-tools/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -18,3 +19,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/70-tools/linkwarden/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/linkwarden/base/cilium-networkpolicy.yaml
@@ -17,3 +17,5 @@ spec:
         - ports:
             - port: "3000"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/70-tools/netbox/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/netbox/base/cilium-networkpolicy.yaml
@@ -17,3 +17,5 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/70-tools/nexterm/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/nexterm/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -18,3 +19,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/70-tools/nocodb/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/nocodb/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -18,3 +19,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/70-tools/penpot/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/penpot/base/cilium-networkpolicy.yaml
@@ -15,3 +15,5 @@ spec:
         - ports:
             - port: "6060"
               protocol: TCP
+  egress:
+    - {}

--- a/apps/70-tools/radar/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/radar/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -18,3 +19,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/70-tools/stirling-pdf/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/stirling-pdf/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -18,3 +19,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/70-tools/trilium/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/trilium/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -18,3 +19,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/70-tools/vikunja/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/vikunja/base/cilium-networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -18,3 +19,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/99-test/whoami/base/cilium-networkpolicy.yaml
+++ b/apps/99-test/whoami/base/cilium-networkpolicy.yaml
@@ -15,3 +15,5 @@ spec:
         - ports:
             - port: "80"
               protocol: TCP
+  egress:
+    - {}


### PR DESCRIPTION
## Summary

Prépare les CNPs pour l'activation future du `enableDefaultDeny`.

- **Restore `egress: [{}]`** sur les 71 CNPs — supprimés par #2984 (Cilium 1.18.3 ClusterIP bug), mais nécessaires pour que `enableDefaultDeny: egress: true` ne coupe pas tout le trafic sortant avant qu'on ait des règles egress par app
- **Nouveaux CNPs** pour les namespaces sans couverture en prod :
  - `synology-csi` : controller, node-driver, iscsi-lock-cleanup — **critique** (storage)
  - `cnpg-system` : cloudnative-pg operator avec webhook kube-apiserver — **critique** (databases)
  - `local-path-storage` : local-path-provisioner

## Contexte

Audit pre-deny révèle que synology-csi et cnpg-system n'ont aucun CNP. Activer le deny sans ces CNPs bloquerait tout le storage iSCSI et l'opérateur PostgreSQL.

Toutes les règles egress sont `[{}]` (allow-all) — seront restreintes app par app après validation du deny.

## Test plan

- [ ] ArgoCD syncs synology-csi → 3 nouveaux CNPs appliqués
- [ ] ArgoCD syncs cloudnative-pg → CNP appliqué (webhook ingress kube-apiserver OK)
- [ ] ArgoCD syncs local-path-provisioner → CNP appliqué
- [ ] Tous les PVCs iSCSI continuent de fonctionner
- [ ] `kubectl get cnp -A` couvre tous les namespaces prod avec pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)