### PR TITLE
feat(monitoring): dashboard Grafana CPU/mémoire UDM via SNMP

### DIFF
--- a/apps/02-monitoring/grafana/base/dashboards/unifi-udm-resources.yaml
+++ b/apps/02-monitoring/grafana/base/dashboards/unifi-udm-resources.yaml
@@ -1,0 +1,250 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-unifi-udm-resources
+  labels:
+    grafana_dashboard: "1"
+immutable: false
+data:
+  unifi-udm-resources.json: |
+    {
+      "title": "UniFi UDM \u2014 CPU & M\u00e9moire",
+      "uid": "unifi-udm-resources-vixens",
+      "description": "CPU et m\u00e9moire de l'UDM Pro SE via SNMP (UCD-SNMP-MIB)",
+      "schemaVersion": 38,
+      "version": 1,
+      "refresh": "1m",
+      "time": { "from": "now-3h", "to": "now" },
+      "timezone": "browser",
+      "graphTooltip": 1,
+      "tags": ["snmp", "unifi", "udm", "cpu", "memory"],
+      "links": [
+        {
+          "title": "UniFi Network \u2014 SNMP",
+          "url": "/d/unifi-snmp-vixens",
+          "type": "link",
+          "icon": "external link",
+          "targetBlank": false
+        }
+      ],
+      "annotations": { "list": [] },
+      "templating": { "list": [] },
+      "panels": [
+        {
+          "id": 1,
+          "type": "stat",
+          "title": "Uptime UDM",
+          "gridPos": { "x": 0, "y": 0, "w": 4, "h": 4 },
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "orientation": "auto",
+            "textMode": "auto",
+            "colorMode": "background",
+            "graphMode": "none"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "red", "value": null },
+                  { "color": "yellow", "value": 3600 },
+                  { "color": "green", "value": 86400 }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "expr": "sysUpTime{job=\"snmp-unifi\", device_type=\"udm\"} / 100",
+              "legendFormat": "uptime",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "type": "gauge",
+          "title": "CPU Usage",
+          "gridPos": { "x": 4, "y": 0, "w": 4, "h": 4 },
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "orientation": "auto",
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "min": 0,
+              "max": 100,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 70 },
+                  { "color": "red", "value": 90 }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "expr": "(\n  rate(ssCpuRawUser{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) +\n  rate(ssCpuRawNice{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) +\n  rate(ssCpuRawSystem{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) +\n  rate(ssCpuRawWait{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) +\n  rate(ssCpuRawInterrupt{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval])\n) / (\n  rate(ssCpuRawUser{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) +\n  rate(ssCpuRawNice{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) +\n  rate(ssCpuRawSystem{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) +\n  rate(ssCpuRawIdle{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) +\n  rate(ssCpuRawWait{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) +\n  rate(ssCpuRawInterrupt{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval])\n) * 100",
+              "legendFormat": "CPU %",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "type": "gauge",
+          "title": "M\u00e9moire Usage",
+          "gridPos": { "x": 8, "y": 0, "w": 4, "h": 4 },
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "orientation": "auto",
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "min": 0,
+              "max": 100,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 70 },
+                  { "color": "red", "value": 90 }
+                ]
+              }
+            }
+          },
+          "targets": [
+            {
+              "expr": "(memTotalReal{job=\"snmp-unifi\",device_type=\"udm\"} - memAvailReal{job=\"snmp-unifi\",device_type=\"udm\"} - memBuffer{job=\"snmp-unifi\",device_type=\"udm\"} - memCached{job=\"snmp-unifi\",device_type=\"udm\"}) / memTotalReal{job=\"snmp-unifi\",device_type=\"udm\"} * 100",
+              "legendFormat": "M\u00e9moire %",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "type": "stat",
+          "title": "M\u00e9moire totale",
+          "gridPos": { "x": 12, "y": 0, "w": 4, "h": 4 },
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "orientation": "auto",
+            "textMode": "auto",
+            "colorMode": "none",
+            "graphMode": "none"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "kbytes",
+              "mappings": [],
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }
+            }
+          },
+          "targets": [
+            {
+              "expr": "memTotalReal{job=\"snmp-unifi\",device_type=\"udm\"}",
+              "legendFormat": "Total RAM",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 10,
+          "type": "timeseries",
+          "title": "CPU \u2014 d\u00e9tail par type",
+          "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+          "options": {
+            "tooltip": { "mode": "multi", "sort": "none" },
+            "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "min": 0,
+              "max": 100,
+              "custom": {
+                "fillOpacity": 20,
+                "lineWidth": 1,
+                "stacking": { "mode": "normal", "group": "A" }
+              }
+            }
+          },
+          "targets": [
+            {
+              "expr": "rate(ssCpuRawUser{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) / (rate(ssCpuRawUser{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) + rate(ssCpuRawNice{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) + rate(ssCpuRawSystem{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) + rate(ssCpuRawIdle{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) + rate(ssCpuRawWait{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) + rate(ssCpuRawInterrupt{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval])) * 100",
+              "legendFormat": "user",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(ssCpuRawSystem{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) / (rate(ssCpuRawUser{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) + rate(ssCpuRawNice{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) + rate(ssCpuRawSystem{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) + rate(ssCpuRawIdle{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) + rate(ssCpuRawWait{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) + rate(ssCpuRawInterrupt{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval])) * 100",
+              "legendFormat": "system",
+              "refId": "B"
+            },
+            {
+              "expr": "rate(ssCpuRawWait{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) / (rate(ssCpuRawUser{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) + rate(ssCpuRawNice{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) + rate(ssCpuRawSystem{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) + rate(ssCpuRawIdle{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) + rate(ssCpuRawWait{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) + rate(ssCpuRawInterrupt{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval])) * 100",
+              "legendFormat": "iowait",
+              "refId": "C"
+            },
+            {
+              "expr": "rate(ssCpuRawInterrupt{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) / (rate(ssCpuRawUser{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) + rate(ssCpuRawNice{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) + rate(ssCpuRawSystem{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) + rate(ssCpuRawIdle{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) + rate(ssCpuRawWait{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval]) + rate(ssCpuRawInterrupt{job=\"snmp-unifi\",device_type=\"udm\"}[$__rate_interval])) * 100",
+              "legendFormat": "interrupt",
+              "refId": "D"
+            }
+          ]
+        },
+        {
+          "id": 11,
+          "type": "timeseries",
+          "title": "M\u00e9moire \u2014 d\u00e9tail",
+          "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 },
+          "options": {
+            "tooltip": { "mode": "multi", "sort": "none" },
+            "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "kbytes",
+              "custom": {
+                "fillOpacity": 15,
+                "lineWidth": 1,
+                "stacking": { "mode": "normal", "group": "A" }
+              }
+            }
+          },
+          "targets": [
+            {
+              "expr": "memTotalReal{job=\"snmp-unifi\",device_type=\"udm\"} - memAvailReal{job=\"snmp-unifi\",device_type=\"udm\"} - memBuffer{job=\"snmp-unifi\",device_type=\"udm\"} - memCached{job=\"snmp-unifi\",device_type=\"udm\"}",
+              "legendFormat": "used",
+              "refId": "A"
+            },
+            {
+              "expr": "memBuffer{job=\"snmp-unifi\",device_type=\"udm\"}",
+              "legendFormat": "buffers",
+              "refId": "B"
+            },
+            {
+              "expr": "memCached{job=\"snmp-unifi\",device_type=\"udm\"}",
+              "legendFormat": "cached",
+              "refId": "C"
+            },
+            {
+              "expr": "memAvailReal{job=\"snmp-unifi\",device_type=\"udm\"}",
+              "legendFormat": "free",
+              "refId": "D"
+            }
+          ]
+        }
+      ]
+    }

--- a/apps/02-monitoring/grafana/base/kustomization.yaml
+++ b/apps/02-monitoring/grafana/base/kustomization.yaml
@@ -14,4 +14,5 @@ resources:
   - dashboards/velero.yaml
   - dashboards/cert-manager.yaml
   - dashboards/unifi-snmp.yaml
+  - dashboards/unifi-udm-resources.yaml
 # Helm chart managed by ArgoCD

--- a/apps/02-monitoring/snmp-exporter/base/configmap-snmp.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/configmap-snmp.yaml
@@ -195,3 +195,58 @@ data:
                 labelname: ifAlias
                 oid: 1.3.6.1.2.1.31.1.1.1.18
                 type: DisplayString
+
+      udm_resources:
+        walk:
+          - 1.3.6.1.4.1.2021.11  # UCD-SNMP-MIB CPU raw counters
+          - 1.3.6.1.4.1.2021.4   # UCD-SNMP-MIB memory
+          - 1.3.6.1.2.1.1.3      # sysUpTime
+        metrics:
+          - name: sysUpTime
+            oid: 1.3.6.1.2.1.1.3.0
+            type: gauge
+            help: Time since last reinit (centiseconds)
+
+          # CPU raw counters (UCD-SNMP-MIB) — use rate() in Grafana
+          - name: ssCpuRawUser
+            oid: 1.3.6.1.4.1.2021.11.50.0
+            type: counter
+            help: CPU time spent in user space (raw ticks)
+          - name: ssCpuRawNice
+            oid: 1.3.6.1.4.1.2021.11.51.0
+            type: counter
+            help: CPU time spent in nice processes (raw ticks)
+          - name: ssCpuRawSystem
+            oid: 1.3.6.1.4.1.2021.11.52.0
+            type: counter
+            help: CPU time spent in kernel space (raw ticks)
+          - name: ssCpuRawIdle
+            oid: 1.3.6.1.4.1.2021.11.53.0
+            type: counter
+            help: CPU idle time (raw ticks)
+          - name: ssCpuRawWait
+            oid: 1.3.6.1.4.1.2021.11.54.0
+            type: counter
+            help: CPU time waiting for I/O (raw ticks)
+          - name: ssCpuRawInterrupt
+            oid: 1.3.6.1.4.1.2021.11.56.0
+            type: counter
+            help: CPU time spent handling hardware interrupts (raw ticks)
+
+          # Memory (UCD-SNMP-MIB) — values in KB
+          - name: memTotalReal
+            oid: 1.3.6.1.4.1.2021.4.5.0
+            type: gauge
+            help: Total RAM in KB
+          - name: memAvailReal
+            oid: 1.3.6.1.4.1.2021.4.6.0
+            type: gauge
+            help: Available RAM in KB (excluding buffers/cache)
+          - name: memBuffer
+            oid: 1.3.6.1.4.1.2021.4.14.0
+            type: gauge
+            help: Memory used as buffers in KB
+          - name: memCached
+            oid: 1.3.6.1.4.1.2021.4.15.0
+            type: gauge
+            help: Memory used as cache in KB

--- a/apps/02-monitoring/snmp-exporter/base/deployment.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/deployment.yaml
@@ -85,6 +85,17 @@ spec:
                       ]
                     },
                     {
+                      "targets": ["%s"],
+                      "labels": {"device_type": "udm", "device_name": "udm-pro-se"},
+                      "scrapeTimeout": "30s", "interval": "60s", "path": "/snmp",
+                      "params": {"module": ["udm_resources"], "auth": ["unifi_v2c_full"]},
+                      "relabelConfigs": [
+                        {"sourceLabels": ["__address__"], "targetLabel": "__param_target"},
+                        {"sourceLabels": ["__param_target"], "targetLabel": "instance"},
+                        {"targetLabel": "__address__", "replacement": "snmp-exporter.monitoring.svc.cluster.local:9116"}
+                      ]
+                    },
+                    {
                       "targets": ["%s", "%s"],
                       "labels": {"device_type": "switch"},
                       "scrapeTimeout": "30s", "interval": "60s", "path": "/snmp",
@@ -115,6 +126,7 @@ spec:
                   ]
                 }
               }' \
+                "${SNMP_TARGET_UDM}" \
                 "${SNMP_TARGET_UDM}" \
                 "${SNMP_TARGET_SW_BAIE}" "${SNMP_TARGET_SW_ATELIER}" \
                 "${SNMP_TARGET_SW_BAIE}" "${SNMP_TARGET_SW_ATELIER}" \


### PR DESCRIPTION
## Summary

- **Nouveau module SNMP `udm_resources`** dans le configmap — collecte CPU (UCD-SNMP-MIB : ssCpuRawUser/Nice/System/Idle/Wait/Interrupt) et mémoire (memTotalReal/AvailReal/Buffer/Cached) depuis l'UDM Pro SE
- **Nouveau endpoint scrape** dans init-vmscrape pour l'UDM avec ce module (en plus du if_mib existant)
- **Dashboard Grafana** "UniFi UDM — CPU & Mémoire" (uid: unifi-udm-resources-vixens) :
  - Stat : uptime, RAM totale
  - Gauge : CPU % et mémoire % avec seuils warning (70%) / critical (90%)
  - Timeseries CPU empilé : user / system / iowait / interrupt
  - Timeseries mémoire empilé : used / buffers / cached / free
  - Lien vers le dashboard UniFi SNMP existant

## Test plan

- [ ] snmp-exporter redémarre et applique le nouveau module `udm_resources`
- [ ] VictoriaMetrics reçoit les métriques `ssCpuRaw*` et `mem*` avec `device_type="udm"`
- [ ] Dashboard visible dans Grafana sous "UniFi UDM — CPU & Mémoire"
- [ ] Les gauges CPU/mémoire affichent des valeurs cohérentes (pas NaN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)