### PR TITLE
fix(cloudnative-pg): add CNP to prod overlay

### DIFF
--- a/apps/04-databases/cloudnative-pg/overlays/prod/kustomization.yaml
+++ b/apps/04-databases/cloudnative-pg/overlays/prod/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: cnpg-system
 resources:
   - servicemonitor.yaml
   - pdb.yaml
+  - ../../base/cilium-networkpolicy.yaml
 
 components:
   - ../../../../_shared/components/poddisruptionbudget/1


### PR DESCRIPTION
## Summary

- The cloudnative-pg ArgoCD app uses a multi-source setup (Helm chart + Kustomize overlay)
- The prod overlay (`overlays/prod`) doesn't extend the base, so the CiliumNetworkPolicy added to `base/` was only deployed in dev (via `overlays/dev` which references the base)
- Add direct reference to `../../base/cilium-networkpolicy.yaml` in prod overlay so the CNP is deployed in prod

## Test plan

- [ ] PR merged → ArgoCD auto-syncs cloudnative-pg on dev cluster
- [ ] `kubectl get cnp -n cnpg-system` shows `cloudnative-pg` policy (Valid: True)
- [ ] After prod-stable promotion: same check on prod cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)