### PR TITLE
fix(cnp): fix gaps found in deny test + kyverno CNP

### DIFF
--- a/apps/00-infra/cert-manager-webhook-gandi/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/base/cilium-networkpolicy.yaml
@@ -11,9 +11,11 @@ spec:
   ingress:
     - fromEntities:
         - kube-apiserver
+        - host
+        - remote-node
       toPorts:
         - ports:
-            - port: "443"
+            - port: "8443"
               protocol: TCP
     - fromEndpoints:
         - matchLabels:

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-kube-apiserver.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-kube-apiserver.yaml
@@ -1,0 +1,17 @@
+---
+# Autorise tous les pods à joindre le kube-apiserver (port 6443)
+# Nécessaire pour les opérateurs/controllers : cert-manager, kyverno, ArgoCD, etc.
+# egress: [{}] ne couvre pas l'entité réservée kube-apiserver avec enableDefaultDeny
+# enableDefaultDeny: false = additif seulement, ne bloque pas le reste de l'egress
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-kube-apiserver-egress
+spec:
+  endpointSelector: {}
+  enableDefaultDeny:
+    ingress: false
+    egress: false
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/apps/00-infra/cilium-lb/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ccnp-allow-traefik.yaml
   - ccnp-allow-prometheus.yaml
   - ccnp-allow-coredns.yaml
+  - ccnp-allow-kube-apiserver.yaml
 
 components:
 

--- a/apps/20-media/amule/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/amule/base/cilium-networkpolicy.yaml
@@ -29,3 +29,5 @@ spec:
               protocol: UDP
   egress:
     - {}
+    - toEntities:
+        - world

--- a/apps/20-media/birdnet-go/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/birdnet-go/base/cilium-networkpolicy.yaml
@@ -21,3 +21,5 @@ spec:
             io.kubernetes.pod.namespace: monitoring
   egress:
     - {}
+    - toEntities:
+        - world

--- a/apps/20-media/lidarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/lidarr/base/cilium-networkpolicy.yaml
@@ -15,6 +15,13 @@ spec:
         - ports:
             - port: "8686"
               protocol: TCP
+    - fromEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "8686"
+              protocol: TCP
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring

--- a/apps/60-services/gluetun/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/gluetun/base/cilium-networkpolicy.yaml
@@ -15,5 +15,12 @@ spec:
         - ports:
             - port: "8888"
               protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: downloads
+      toPorts:
+        - ports:
+            - port: "1080"
+              protocol: TCP
   egress:
     - {}


### PR DESCRIPTION
## Summary

Findings from 90s `enableDefaultDeny` kubectl patch test on prod.

### Structural gaps (clear from Hubble drops)

- **cert-manager-webhook-gandi**: port `443` → `8443` (pod container port); add `host`+`remote-node` entities to allow kube-apiserver calls in multi-node setup
- **lidarr**: kubelet health probes from `host`+`remote-node` not allowed on port 8686
- **gluetun**: ingress from `downloads` namespace on port 1080 missing (SOCKS proxy used by amule)
- **amule / birdnet-go**: `egress: [{}]` does NOT cover `reserved:world` entity when `enableDefaultDeny` is active — add `toEntities: [world]` explicitly

### Systemic finding

`egress: [{}]` covers in-cluster pod-to-pod traffic but NOT Cilium reserved entities (`reserved:world`, `reserved:kube-apiserver`) when `enableDefaultDeny` is active.

- **New CCNP `allow-kube-apiserver-egress`**: allows all pods to reach kube-apiserver — required for cert-manager, kyverno, ArgoCD, and any operator that calls the k8s API. Without this, all operators break when deny is enabled.

### Remaining open question

`fluent-bit → loki:3100` drops (298x) — both have correct CNPs. Likely timing artifact from CCNP propagation. Will re-test after this PR.

## Test plan

- [ ] PR merged → ArgoCD syncs on dev
- [ ] `kubectl get ccnp allow-kube-apiserver-egress` — Valid: True
- [ ] Re-run 90s deny test → fluent-bit/loki drops should disappear; amule/birdnet-go world drops gone; cert-manager-webhook-gandi drops gone
- [ ] prod-stable promotion after validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)