### PR TITLE
fix(cnp): round 2 — coredns-ingress, cilium-health, qbittorrent, postgresql-shared

### DIFF
--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-cilium-health.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-cilium-health.yaml
@@ -1,0 +1,30 @@
+---
+# Autorise les health checks inter-nœuds Cilium (port 4240)
+# remote-node → tous les pods sur port 4240 (cilium-health)
+# Nécessaire avec enableDefaultDeny.ingress: true
+# enableDefaultDeny: false = additif seulement
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-cilium-health
+spec:
+  endpointSelector: {}
+  enableDefaultDeny:
+    ingress: false
+    egress: false
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "4240"
+              protocol: TCP
+  egress:
+    - toEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "4240"
+              protocol: TCP

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-coredns-ingress.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-coredns-ingress.yaml
@@ -1,0 +1,35 @@
+---
+# Autorise CoreDNS à recevoir les requêtes DNS depuis tous les pods/nodes
+# Nécessaire avec enableDefaultDeny.ingress: true sur CoreDNS
+# allow-coredns-egress couvre l'egress des pods SOURCE, mais pas l'ingress de CoreDNS lui-même
+# enableDefaultDeny: false = additif seulement
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-coredns-ingress
+spec:
+  endpointSelector:
+    matchLabels:
+      io.kubernetes.pod.namespace: kube-system
+      k8s-app: kube-dns
+  enableDefaultDeny:
+    ingress: false
+    egress: false
+  ingress:
+    - fromEndpoints:
+        - {}
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    - fromEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/apps/00-infra/cilium-lb/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
   - ccnp-allow-prometheus.yaml
   - ccnp-allow-coredns.yaml
   - ccnp-allow-kube-apiserver.yaml
+  - ccnp-allow-coredns-ingress.yaml
+  - ccnp-allow-cilium-health.yaml
 
 components:
 

--- a/apps/04-databases/postgresql-shared/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/postgresql-shared/base/cilium-networkpolicy.yaml
@@ -1,0 +1,41 @@
+---
+# postgresql-shared (CloudNativePG cluster) — accès PostgreSQL depuis tous les pods clients
+# Le cluster est partagé entre de nombreux namespaces (auth, networking, services, tools, etc.)
+# L'authentification PostgreSQL protège l'accès au niveau applicatif
+# Les pods CNPG ont le label cnpg.io/cluster: postgresql-shared (pas app.kubernetes.io/name)
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: postgresql-shared
+  namespace: databases
+spec:
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: postgresql-shared
+  ingress:
+    # PostgreSQL depuis tous les pods du cluster (multi-namespace)
+    - fromEndpoints:
+        - {}
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Réplication intra-cluster CNPG
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgresql-shared
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Kubelet health probes depuis host/remote-node
+    - fromEntities:
+        - host
+        - remote-node
+    # Métriques Prometheus (pg_exporter port 9187)
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+  egress:
+    - {}

--- a/apps/04-databases/postgresql-shared/base/kustomization.yaml
+++ b/apps/04-databases/postgresql-shared/base/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 namespace: databases
 resources:
   - cluster.yaml
+  - cilium-networkpolicy.yaml
   - credentials/admin-secret.yaml
   - credentials/docspell-secret.yaml
   - credentials/linkwarden-secret.yaml

--- a/apps/20-media/qbittorrent/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/qbittorrent/base/cilium-networkpolicy.yaml
@@ -27,3 +27,5 @@ spec:
               protocol: UDP
   egress:
     - {}
+    - toEntities:
+        - world


### PR DESCRIPTION
## Summary

Deuxième vague de corrections CNP avant activation permanente du default-deny.

### Problèmes corrigés

- **CCNP allow-coredns-ingress** (650/832 drops) : `allow-coredns-egress` couvre uniquement l'egress *depuis* les pods vers CoreDNS, mais pas l'ingress *de* CoreDNS lui-même. Avec `enableDefaultDeny.ingress: true`, CoreDNS bloquait toutes les requêtes DNS entrantes.
- **CCNP allow-cilium-health** (24 drops) : les health checks inter-nœuds Cilium (`remote-node → :4240`) étaient bloqués.
- **qbittorrent** : ajout de `toEntities: [world]` pour le trafic P2P internet (même pattern que amule).
- **postgresql-shared** : aucun CNP n'existait pour les pods CNPG cluster. Le cluster sert de nombreux namespaces — ingress depuis tous les pods sur port 5432, kubelet probes, métriques monitoring.

## Test plan

- [ ] PR mergée → promote prod-stable → ArgoCD sync
- [ ] kubectl patch temporaire enableDefaultDeny + Hubble observe
- [ ] Vérifier zéro drop coredns/cilium-health/qbittorrent/postgresql
- [ ] selfHeal ArgoCD restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added cluster health monitoring network policy enabling health check traffic
  * Added DNS service network policy enabling DNS query traffic routing
  * Added database network policy enabling database connection handling
  * Updated service network connectivity configuration policies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->