### PR TITLE
fix(cnp): homeassistant — allow kubelet probes from host/remote-node

### DIFF
--- a/apps/10-home/homeassistant/base/cilium-networkpolicy.yaml
+++ b/apps/10-home/homeassistant/base/cilium-networkpolicy.yaml
@@ -18,5 +18,12 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+    - fromEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "8123"
+              protocol: TCP
   egress:
     - {}


### PR DESCRIPTION
## Summary

- Ajout de `host` et `remote-node` en ingress sur port 8123 dans la CNP homeassistant
- Même pattern que lidarr (PR #2995) : les readiness probes kubelet arrivent depuis l'entité `host`/`remote-node`, pas depuis un pod traefik
- Sans cette règle, les probes timeout dès que `enableDefaultDeny: true` est activé

## Test plan

- [ ] Merge → promote prod-stable → ArgoCD sync homeassistant
- [ ] Vérifier readiness probe OK avec deny actif

🤖 Generated with [Claude Code](https://claude.com/claude-code)