### PR TITLE
fix(cilium): round 4 CNP fixes — argocd, metrics-server, coredns-egress, hubble-relay, vmagent

### DIFF
--- a/apps/00-infra/argocd/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/argocd/base/cilium-networkpolicy.yaml
@@ -1,0 +1,25 @@
+---
+# ArgoCD — communication interne entre composants
+# Critique : sans cette CNP, selfHeal est bloqué quand le default-deny est actif
+# argocd-application-controller <-> argocd-repo-server <-> argocd-redis <-> argocd-server
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: argocd
+  namespace: argocd
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: argocd
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: argocd
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+    - fromEntities:
+        - host
+        - remote-node
+  egress:
+    - {}

--- a/apps/00-infra/argocd/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/argocd/base/cilium-networkpolicy.yaml
@@ -2,15 +2,14 @@
 # ArgoCD — communication interne entre composants
 # Critique : sans cette CNP, selfHeal est bloqué quand le default-deny est actif
 # argocd-application-controller <-> argocd-repo-server <-> argocd-redis <-> argocd-server
+# endpointSelector: {} = tous les pods du namespace argocd
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: argocd
   namespace: argocd
 spec:
-  endpointSelector:
-    matchLabels:
-      app.kubernetes.io/part-of: argocd
+  endpointSelector: {}
   ingress:
     - fromEndpoints:
         - matchLabels:

--- a/apps/00-infra/argocd/base/kustomization.yaml
+++ b/apps/00-infra/argocd/base/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - argocd-install.yaml
   - servicemonitor.yaml
   - pdb.yaml
+  - cilium-networkpolicy.yaml
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-cilium-health.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-cilium-health.yaml
@@ -20,6 +20,14 @@ spec:
         - ports:
             - port: "4240"
               protocol: TCP
+    # ICMP EchoRequest pour les health IPs inter-nœuds (10.244.x.x/health)
+    - fromEntities:
+        - host
+        - remote-node
+      icmps:
+        - fields:
+            - type: 8
+              family: IPv4
   egress:
     - toEntities:
         - host
@@ -28,3 +36,11 @@ spec:
         - ports:
             - port: "4240"
               protocol: TCP
+    # ICMP EchoReply pour les health IPs inter-nœuds
+    - toEntities:
+        - host
+        - remote-node
+      icmps:
+        - fields:
+            - type: 0
+              family: IPv4

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-coredns-egress.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-coredns-egress.yaml
@@ -5,7 +5,7 @@
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
-  name: allow-coredns-egress
+  name: allow-coredns-upstream-egress
 spec:
   endpointSelector:
     matchLabels:

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-coredns-egress.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-coredns-egress.yaml
@@ -1,0 +1,37 @@
+---
+# CoreDNS a besoin d'envoyer des requêtes DNS upstream (forwarder)
+# 169.254.116.108:53 (link-local node DNS) est classifié "world" par Cilium
+# enableDefaultDeny: false = additif seulement
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-coredns-egress
+spec:
+  endpointSelector:
+    matchLabels:
+      io.kubernetes.pod.namespace: kube-system
+      k8s-app: kube-dns
+  enableDefaultDeny:
+    ingress: false
+    egress: false
+  egress:
+    # Upstream DNS forwarder (link-local, world)
+    - toEntities:
+        - world
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # Résolution DNS dans le cluster
+    - toEndpoints:
+        - {}
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-hubble-relay.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-hubble-relay.yaml
@@ -1,0 +1,24 @@
+---
+# Hubble-relay doit se connecter aux cilium agents sur chaque node
+# Port 4244 = cilium agent gRPC (Hubble observer)
+# enableDefaultDeny: false = additif seulement
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-hubble-relay
+spec:
+  endpointSelector:
+    matchLabels:
+      io.kubernetes.pod.namespace: kube-system
+      k8s-app: hubble-relay
+  enableDefaultDeny:
+    ingress: false
+    egress: false
+  egress:
+    - toEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "4244"
+              protocol: TCP

--- a/apps/00-infra/cilium-lb/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/kustomization.yaml
@@ -9,7 +9,9 @@ resources:
   - ccnp-allow-coredns.yaml
   - ccnp-allow-kube-apiserver.yaml
   - ccnp-allow-coredns-ingress.yaml
+  - ccnp-allow-coredns-egress.yaml
   - ccnp-allow-cilium-health.yaml
+  - ccnp-allow-hubble-relay.yaml
 
 components:
 

--- a/apps/00-infra/metrics-server/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/metrics-server/base/cilium-networkpolicy.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   endpointSelector:
     matchLabels:
-      app.kubernetes.io/name: metrics-server
+      k8s-app: metrics-server
   ingress:
     - fromEntities:
         - host

--- a/apps/00-infra/metrics-server/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/metrics-server/base/cilium-networkpolicy.yaml
@@ -1,0 +1,35 @@
+---
+# metrics-server — collecte les métriques kubelet sur chaque node
+# Ingress: kubelet (remote-node) → metrics-server:4443 (aggregated API)
+# Egress: metrics-server → kubelet sur tous les nodes (port 10250)
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: metrics-server
+  namespace: kube-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: metrics-server
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "4443"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: keda
+  egress:
+    - toEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "10250"
+              protocol: TCP

--- a/apps/00-infra/metrics-server/base/kustomization.yaml
+++ b/apps/00-infra/metrics-server/base/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.7.2/components.yaml
+  - cilium-networkpolicy.yaml
 
 patches:
   - patch: |

--- a/apps/02-monitoring/victoria-metrics/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/victoria-metrics/base/cilium-networkpolicy.yaml
@@ -16,6 +16,8 @@ spec:
         - ports:
             - port: "8429"
               protocol: TCP
+  egress:
+    - {}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy


### PR DESCRIPTION
## Summary

Round 4 de fixes CNP pour la préparation du default-deny Cilium.

Drops observés lors du test round 4 (observation multi-nœuds plus complète qu'avant) :

- **argocd** : aucun CNP → `argocd-application-controller → argocd-repo-server` bloqué → selfHeal impossible pendant que le deny est actif
- **metrics-server** : aucun CNP → kubelet → metrics-server ingress bloqué + metrics-server → kubelet egress bloqué (HPA/VPA cassés)
- **coredns upstream DNS** : `coredns → 169.254.116.108:53 (world)` bloqué → forwarding DNS externe cassé
- **hubble-relay** : `hubble-relay → host:4244` bloqué → Hubble ne peut plus observer
- **allow-cilium-health CCNP** : pas d'ICMP → health IPs inter-nœuds (`10.244.x.x`) dropping
- **vmagent** : CNP sans section `egress` → scraping de toutes les cibles bloqué

## Test plan

- [ ] Merger → déployer sur dev via ArgoCD
- [ ] Promouvoir en prod-stable
- [ ] Test round 5 : `kubectl patch ccnp allow-cilium-health --type merge -p '{"spec":{"enableDefaultDeny":{"ingress":true,"egress":true}}}'`
- [ ] Observer Hubble 90s depuis les 5 nodes
- [ ] Vérifier 0 drops (ou identifier nouveaux cas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configured network security policies for cluster services (ArgoCD, metrics-server, monitoring)
  * Enhanced inter-node health checks with ICMP support
  * Established network access controls for DNS and observability services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->