### PR TITLE
fix(cnp): remove egress wildcard {} breaking ClusterIP (Cilium 1.18.3)

### DIFF
--- a/apps/00-infra/argocd/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/argocd/base/cilium-networkpolicy.yaml
@@ -1,0 +1,25 @@
+---
+# ArgoCD — communication interne entre composants
+# Critique : sans cette CNP, selfHeal est bloqué quand le default-deny est actif
+# argocd-application-controller <-> argocd-repo-server <-> argocd-redis <-> argocd-server
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: argocd
+  namespace: argocd
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: argocd
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: argocd
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+    - fromEntities:
+        - host
+        - remote-node
+  egress:
+    - {}

--- a/apps/00-infra/argocd/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/argocd/base/cilium-networkpolicy.yaml
@@ -2,15 +2,14 @@
 # ArgoCD — communication interne entre composants
 # Critique : sans cette CNP, selfHeal est bloqué quand le default-deny est actif
 # argocd-application-controller <-> argocd-repo-server <-> argocd-redis <-> argocd-server
+# endpointSelector: {} = tous les pods du namespace argocd
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: argocd
   namespace: argocd
 spec:
-  endpointSelector:
-    matchLabels:
-      app.kubernetes.io/part-of: argocd
+  endpointSelector: {}
   ingress:
     - fromEndpoints:
         - matchLabels:

--- a/apps/00-infra/argocd/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/argocd/base/cilium-networkpolicy.yaml
@@ -20,5 +20,3 @@ spec:
     - fromEntities:
         - host
         - remote-node
-  egress:
-    - {}

--- a/apps/00-infra/argocd/base/kustomization.yaml
+++ b/apps/00-infra/argocd/base/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - argocd-install.yaml
   - servicemonitor.yaml
   - pdb.yaml
+  - cilium-networkpolicy.yaml
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/00-infra/cert-manager-webhook-gandi/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/base/cilium-networkpolicy.yaml
@@ -20,5 +20,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/00-infra/cert-manager/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/cert-manager/base/cilium-networkpolicy.yaml
@@ -14,8 +14,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # cert-manager cainjector
 apiVersion: cilium.io/v2
@@ -32,8 +30,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # cert-manager webhook — reçoit des appels de kube-apiserver
 apiVersion: cilium.io/v2
@@ -56,5 +52,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-cilium-health.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-cilium-health.yaml
@@ -20,6 +20,14 @@ spec:
         - ports:
             - port: "4240"
               protocol: TCP
+    # ICMP EchoRequest pour les health IPs inter-nœuds (10.244.x.x/health)
+    - fromEntities:
+        - host
+        - remote-node
+      icmps:
+        - fields:
+            - type: 8
+              family: IPv4
   egress:
     - toEntities:
         - host
@@ -28,3 +36,11 @@ spec:
         - ports:
             - port: "4240"
               protocol: TCP
+    # ICMP EchoReply pour les health IPs inter-nœuds
+    - toEntities:
+        - host
+        - remote-node
+      icmps:
+        - fields:
+            - type: 0
+              family: IPv4

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-coredns-egress.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-coredns-egress.yaml
@@ -5,7 +5,7 @@
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
-  name: allow-coredns-egress
+  name: allow-coredns-upstream-egress
 spec:
   endpointSelector:
     matchLabels:

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-coredns-egress.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-coredns-egress.yaml
@@ -1,0 +1,37 @@
+---
+# CoreDNS a besoin d'envoyer des requêtes DNS upstream (forwarder)
+# 169.254.116.108:53 (link-local node DNS) est classifié "world" par Cilium
+# enableDefaultDeny: false = additif seulement
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-coredns-egress
+spec:
+  endpointSelector:
+    matchLabels:
+      io.kubernetes.pod.namespace: kube-system
+      k8s-app: kube-dns
+  enableDefaultDeny:
+    ingress: false
+    egress: false
+  egress:
+    # Upstream DNS forwarder (link-local, world)
+    - toEntities:
+        - world
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # Résolution DNS dans le cluster
+    - toEndpoints:
+        - {}
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-hubble-relay.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-hubble-relay.yaml
@@ -1,0 +1,24 @@
+---
+# Hubble-relay doit se connecter aux cilium agents sur chaque node
+# Port 4244 = cilium agent gRPC (Hubble observer)
+# enableDefaultDeny: false = additif seulement
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-hubble-relay
+spec:
+  endpointSelector:
+    matchLabels:
+      io.kubernetes.pod.namespace: kube-system
+      k8s-app: hubble-relay
+  enableDefaultDeny:
+    ingress: false
+    egress: false
+  egress:
+    - toEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "4244"
+              protocol: TCP

--- a/apps/00-infra/cilium-lb/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/kustomization.yaml
@@ -9,7 +9,9 @@ resources:
   - ccnp-allow-coredns.yaml
   - ccnp-allow-kube-apiserver.yaml
   - ccnp-allow-coredns-ingress.yaml
+  - ccnp-allow-coredns-egress.yaml
   - ccnp-allow-cilium-health.yaml
+  - ccnp-allow-hubble-relay.yaml
 
 components:
 

--- a/apps/00-infra/crowdsec/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/crowdsec/base/cilium-networkpolicy.yaml
@@ -13,8 +13,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # crowdsec-lapi — reçoit des requêtes de Traefik (bouncer) et monitoring
 apiVersion: cilium.io/v2
@@ -37,5 +35,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/00-infra/infisical-operator/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/infisical-operator/base/cilium-networkpolicy.yaml
@@ -12,5 +12,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/00-infra/keda/overlays/prod/cilium-networkpolicy.yaml
+++ b/apps/00-infra/keda/overlays/prod/cilium-networkpolicy.yaml
@@ -13,8 +13,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # keda-admission-webhooks — reçoit des appels de kube-apiserver
 apiVersion: cilium.io/v2
@@ -36,8 +34,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # keda http-add-on (controller, scaler, interceptor)
 apiVersion: cilium.io/v2
@@ -53,5 +49,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/00-infra/kyverno/base/policies/cilium-networkpolicy.yaml
+++ b/apps/00-infra/kyverno/base/policies/cilium-networkpolicy.yaml
@@ -22,8 +22,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # kyverno background-controller
 apiVersion: cilium.io/v2
@@ -40,8 +38,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # kyverno cleanup-controller — reçoit des appels de kube-apiserver
 apiVersion: cilium.io/v2
@@ -66,8 +62,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # kyverno reports-controller
 apiVersion: cilium.io/v2
@@ -84,5 +78,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/00-infra/metrics-server/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/metrics-server/base/cilium-networkpolicy.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   endpointSelector:
     matchLabels:
-      app.kubernetes.io/name: metrics-server
+      k8s-app: metrics-server
   ingress:
     - fromEntities:
         - host

--- a/apps/00-infra/metrics-server/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/metrics-server/base/cilium-networkpolicy.yaml
@@ -1,0 +1,35 @@
+---
+# metrics-server — collecte les métriques kubelet sur chaque node
+# Ingress: kubelet (remote-node) → metrics-server:4443 (aggregated API)
+# Egress: metrics-server → kubelet sur tous les nodes (port 10250)
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: metrics-server
+  namespace: kube-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: metrics-server
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "4443"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: keda
+  egress:
+    - toEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "10250"
+              protocol: TCP

--- a/apps/00-infra/metrics-server/base/kustomization.yaml
+++ b/apps/00-infra/metrics-server/base/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.7.2/components.yaml
+  - cilium-networkpolicy.yaml
 
 patches:
   - patch: |

--- a/apps/00-infra/policy-reporter/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/policy-reporter/base/cilium-networkpolicy.yaml
@@ -20,8 +20,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # policy-reporter kyverno-plugin
 apiVersion: cilium.io/v2
@@ -37,8 +35,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # policy-reporter UI
 apiVersion: cilium.io/v2
@@ -62,5 +58,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/00-infra/reloader/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/reloader/base/cilium-networkpolicy.yaml
@@ -12,5 +12,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/00-infra/traefik/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/traefik/base/cilium-networkpolicy.yaml
@@ -21,5 +21,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/00-infra/velero/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/velero/base/cilium-networkpolicy.yaml
@@ -13,5 +13,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/00-infra/vpa/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/vpa/base/cilium-networkpolicy.yaml
@@ -20,8 +20,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # vpa-recommender
 apiVersion: cilium.io/v2
@@ -38,8 +36,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # vpa-updater
 apiVersion: cilium.io/v2
@@ -56,5 +52,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/01-storage/local-path-provisioner/base/cilium-networkpolicy.yaml
+++ b/apps/01-storage/local-path-provisioner/base/cilium-networkpolicy.yaml
@@ -12,5 +12,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/01-storage/synology-csi/base/cilium-networkpolicy.yaml
+++ b/apps/01-storage/synology-csi/base/cilium-networkpolicy.yaml
@@ -13,8 +13,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # synology-csi-node — node driver (iSCSI mount)
 apiVersion: cilium.io/v2
@@ -30,8 +28,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # iscsi-lock-cleanup — DaemonSet lock management
 apiVersion: cilium.io/v2
@@ -47,5 +43,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/02-monitoring/fluent-bit-syslog/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/fluent-bit-syslog/base/cilium-networkpolicy.yaml
@@ -24,5 +24,3 @@ spec:
         - ports:
             - port: "2020"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/02-monitoring/fluent-bit/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/fluent-bit/base/cilium-networkpolicy.yaml
@@ -16,5 +16,3 @@ spec:
         - ports:
             - port: "2020"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/02-monitoring/goldilocks/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/goldilocks/base/cilium-networkpolicy.yaml
@@ -35,5 +35,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/02-monitoring/grafana/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/grafana/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/02-monitoring/loki/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/loki/base/cilium-networkpolicy.yaml
@@ -17,5 +17,3 @@ spec:
         - ports:
             - port: "3100"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/02-monitoring/snmp-exporter/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/cilium-networkpolicy.yaml
@@ -16,5 +16,3 @@ spec:
         - ports:
             - port: "9116"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/02-monitoring/victoria-metrics/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/victoria-metrics/base/cilium-networkpolicy.yaml
@@ -16,8 +16,6 @@ spec:
         - ports:
             - port: "8429"
               protocol: TCP
-  egress:
-    - {}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -36,8 +34,6 @@ spec:
         - ports:
             - port: "8428"
               protocol: TCP
-  egress:
-    - {}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -56,8 +52,6 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
-  egress:
-    - {}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -76,8 +70,6 @@ spec:
         - ports:
             - port: "9093"
               protocol: TCP
-  egress:
-    - {}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -96,8 +88,6 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
-  egress:
-    - {}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -116,8 +106,6 @@ spec:
         - ports:
             - port: "9100"
               protocol: TCP
-  egress:
-    - {}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -136,5 +124,3 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/02-monitoring/victoria-metrics/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/victoria-metrics/base/cilium-networkpolicy.yaml
@@ -16,6 +16,8 @@ spec:
         - ports:
             - port: "8429"
               protocol: TCP
+  egress:
+    - {}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/apps/03-security/authentik/base/cilium-networkpolicy.yaml
+++ b/apps/03-security/authentik/base/cilium-networkpolicy.yaml
@@ -18,5 +18,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/03-security/trivy/base/cilium-networkpolicy.yaml
+++ b/apps/03-security/trivy/base/cilium-networkpolicy.yaml
@@ -12,5 +12,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/04-databases/cloudnative-pg/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/cloudnative-pg/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/04-databases/mariadb-shared/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/mariadb-shared/base/cilium-networkpolicy.yaml
@@ -14,5 +14,3 @@ spec:
         - ports:
             - port: "3306"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/04-databases/postgresql-shared/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/postgresql-shared/base/cilium-networkpolicy.yaml
@@ -37,5 +37,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/04-databases/redis-shared/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/redis-shared/base/cilium-networkpolicy.yaml
@@ -21,5 +21,3 @@ spec:
         - ports:
             - port: "6379"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/10-home/homeassistant/base/cilium-networkpolicy.yaml
+++ b/apps/10-home/homeassistant/base/cilium-networkpolicy.yaml
@@ -25,5 +25,3 @@ spec:
         - ports:
             - port: "8123"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/10-home/mealie/base/cilium-networkpolicy.yaml
+++ b/apps/10-home/mealie/base/cilium-networkpolicy.yaml
@@ -18,5 +18,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/10-home/mosquitto/base/cilium-networkpolicy.yaml
+++ b/apps/10-home/mosquitto/base/cilium-networkpolicy.yaml
@@ -17,5 +17,3 @@ spec:
         - ports:
             - port: "1883"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/20-media/amule/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/amule/base/cilium-networkpolicy.yaml
@@ -27,7 +27,5 @@ spec:
               protocol: UDP
             - port: "4672"
               protocol: UDP
-  egress:
-    - {}
     - toEntities:
         - world

--- a/apps/20-media/birdnet-go/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/birdnet-go/base/cilium-networkpolicy.yaml
@@ -19,7 +19,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
     - toEntities:
         - world

--- a/apps/20-media/booklore/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/booklore/base/cilium-networkpolicy.yaml
@@ -15,5 +15,3 @@ spec:
         - ports:
             - port: "6060"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/20-media/bookshelf/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/bookshelf/base/cilium-networkpolicy.yaml
@@ -15,5 +15,3 @@ spec:
         - ports:
             - port: "8787"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/20-media/frigate/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/frigate/base/cilium-networkpolicy.yaml
@@ -18,5 +18,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/20-media/hydrus-client/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/hydrus-client/base/cilium-networkpolicy.yaml
@@ -20,5 +20,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/20-media/jellyfin/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/jellyfin/base/cilium-networkpolicy.yaml
@@ -15,5 +15,3 @@ spec:
         - ports:
             - port: "8096"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/20-media/jellyseerr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/jellyseerr/base/cilium-networkpolicy.yaml
@@ -17,5 +17,3 @@ spec:
         - ports:
             - port: "5055"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/20-media/lidarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/lidarr/base/cilium-networkpolicy.yaml
@@ -25,5 +25,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/20-media/music-assistant/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/music-assistant/base/cilium-networkpolicy.yaml
@@ -15,5 +15,3 @@ spec:
         - ports:
             - port: "8095"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/20-media/mylar/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/mylar/base/cilium-networkpolicy.yaml
@@ -18,5 +18,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/20-media/prowlarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/prowlarr/base/cilium-networkpolicy.yaml
@@ -18,5 +18,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/20-media/pyload/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/pyload/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/20-media/qbittorrent/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/qbittorrent/base/cilium-networkpolicy.yaml
@@ -25,7 +25,5 @@ spec:
               protocol: TCP
             - port: "6881"
               protocol: UDP
-  egress:
-    - {}
     - toEntities:
         - world

--- a/apps/20-media/radarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/radarr/base/cilium-networkpolicy.yaml
@@ -18,5 +18,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/20-media/sabnzbd/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/sabnzbd/base/cilium-networkpolicy.yaml
@@ -20,5 +20,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/20-media/sonarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/sonarr/base/cilium-networkpolicy.yaml
@@ -18,5 +18,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/20-media/whisparr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/whisparr/base/cilium-networkpolicy.yaml
@@ -18,5 +18,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/40-network/adguard-home/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/adguard-home/base/cilium-networkpolicy.yaml
@@ -28,5 +28,3 @@ spec:
               protocol: TCP
             - port: "53"
               protocol: UDP
-  egress:
-    - {}

--- a/apps/40-network/external-dns-gandi/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/external-dns-gandi/base/cilium-networkpolicy.yaml
@@ -12,5 +12,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/40-network/external-dns-unifi/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/external-dns-unifi/base/cilium-networkpolicy.yaml
@@ -12,5 +12,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/40-network/netbird/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/netbird/base/cilium-networkpolicy.yaml
@@ -15,5 +15,3 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/40-network/netvisor/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/netvisor/base/cilium-networkpolicy.yaml
@@ -17,5 +17,3 @@ spec:
         - ports:
             - port: "60072"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/60-services/docspell/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/docspell/base/cilium-networkpolicy.yaml
@@ -17,5 +17,3 @@ spec:
         - ports:
             - port: "7880"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/60-services/firefly-iii-importer/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/firefly-iii-importer/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/60-services/firefly-iii/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/firefly-iii/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/60-services/g4f/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/g4f/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/60-services/gluetun/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/gluetun/base/cilium-networkpolicy.yaml
@@ -22,5 +22,3 @@ spec:
         - ports:
             - port: "1080"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/60-services/n8n/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/n8n/base/cilium-networkpolicy.yaml
@@ -18,5 +18,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: tools
-  egress:
-    - {}

--- a/apps/60-services/openclaw/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/openclaw/base/cilium-networkpolicy.yaml
@@ -22,5 +22,3 @@ spec:
         - matchLabels:
             app: n8n
             io.kubernetes.pod.namespace: services
-  egress:
-    - {}

--- a/apps/60-services/sakapuss/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/sakapuss/base/cilium-networkpolicy.yaml
@@ -42,5 +42,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/60-services/vaultwarden/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/vaultwarden/base/cilium-networkpolicy.yaml
@@ -18,5 +18,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/70-tools/changedetection/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/changedetection/base/cilium-networkpolicy.yaml
@@ -15,5 +15,3 @@ spec:
         - ports:
             - port: "5000"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/70-tools/headlamp/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/headlamp/base/cilium-networkpolicy.yaml
@@ -17,5 +17,3 @@ spec:
         - ports:
             - port: "4466"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/70-tools/homepage/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/homepage/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/70-tools/it-tools/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/it-tools/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/70-tools/linkwarden/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/linkwarden/base/cilium-networkpolicy.yaml
@@ -17,5 +17,3 @@ spec:
         - ports:
             - port: "3000"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/70-tools/netbox/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/netbox/base/cilium-networkpolicy.yaml
@@ -17,5 +17,3 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/70-tools/nexterm/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/nexterm/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/70-tools/nocodb/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/nocodb/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/70-tools/penpot/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/penpot/base/cilium-networkpolicy.yaml
@@ -15,5 +15,3 @@ spec:
         - ports:
             - port: "6060"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/70-tools/radar/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/radar/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/70-tools/stirling-pdf/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/stirling-pdf/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/70-tools/trilium/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/trilium/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/70-tools/vikunja/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/vikunja/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/99-test/whoami/base/cilium-networkpolicy.yaml
+++ b/apps/99-test/whoami/base/cilium-networkpolicy.yaml
@@ -15,5 +15,3 @@ spec:
         - ports:
             - port: "80"
               protocol: TCP
-  egress:
-    - {}


### PR DESCRIPTION
## Résumé

**Bug critique en production** : `egress: [{}]` dans les CNPs namespace-scoped déclenche le mode enforcement egress sur Cilium 1.18.3, mais n'autorise PAS le trafic vers les identités cluster.

### Symptômes observés SANS enableDefaultDeny
Hubble montrait `policy-verdict:none EGRESS DENIED` en continu :
- `fluent-bit → loki:3100` DENIED
- `argocd-server → redis:6379` DENIED
- `keda → keda-interceptor:9090` DENIED
- `firefly-iii → postgresql-shared:5432` DENIED
- `infisical-operator → 192.168.111.69:8085` DENIED

### Cause racine
PR #2984 avait déjà corrigé ce bug. PR #2999 a réintroduit le pattern `egress: [{}]` sur 76 fichiers par erreur (prep default-deny).

### Fix
Supprimer `egress: [{}]` de tous les 76 CNPs namespace-scoped.

**Règle Cilium 1.18.3** : CNP sans section egress = pas d'enforcement egress = tout l'egress autorisé. Dès qu'une section egress existe (même `[{}]`), Cilium enforce et deny ce qui n'est pas listé.

### Préservé
- `metrics-server` : règle egress spécifique vers kubelet `:10250` conservée

## Test plan
- [ ] Hubble: aucun `policy-verdict:none EGRESS DENIED` sans enableDefaultDeny
- [ ] fluent-bit → loki : OK
- [ ] argocd interne : OK
- [ ] ArgoCD: toutes les apps Synced+Healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)