### PR TITLE
fix(cnp): replace fromEndpoints: [{}] with fromEntities: cluster (Cilium 1.18.3)

### DIFF
--- a/apps/00-infra/argocd/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/argocd/base/cilium-networkpolicy.yaml
@@ -20,5 +20,3 @@ spec:
     - fromEntities:
         - host
         - remote-node
-  egress:
-    - {}

--- a/apps/00-infra/cert-manager-webhook-gandi/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/base/cilium-networkpolicy.yaml
@@ -20,5 +20,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/00-infra/cert-manager/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/cert-manager/base/cilium-networkpolicy.yaml
@@ -14,8 +14,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # cert-manager cainjector
 apiVersion: cilium.io/v2
@@ -32,8 +30,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # cert-manager webhook — reçoit des appels de kube-apiserver
 apiVersion: cilium.io/v2
@@ -56,5 +52,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/00-infra/crowdsec/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/crowdsec/base/cilium-networkpolicy.yaml
@@ -13,8 +13,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # crowdsec-lapi — reçoit des requêtes de Traefik (bouncer) et monitoring
 apiVersion: cilium.io/v2
@@ -37,5 +35,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/00-infra/infisical-operator/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/infisical-operator/base/cilium-networkpolicy.yaml
@@ -12,5 +12,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/00-infra/keda/overlays/prod/cilium-networkpolicy.yaml
+++ b/apps/00-infra/keda/overlays/prod/cilium-networkpolicy.yaml
@@ -13,8 +13,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # keda-admission-webhooks — reçoit des appels de kube-apiserver
 apiVersion: cilium.io/v2
@@ -36,8 +34,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # keda http-add-on (controller, scaler, interceptor)
 apiVersion: cilium.io/v2
@@ -53,5 +49,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/00-infra/kyverno/base/policies/cilium-networkpolicy.yaml
+++ b/apps/00-infra/kyverno/base/policies/cilium-networkpolicy.yaml
@@ -22,8 +22,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # kyverno background-controller
 apiVersion: cilium.io/v2
@@ -40,8 +38,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # kyverno cleanup-controller — reçoit des appels de kube-apiserver
 apiVersion: cilium.io/v2
@@ -66,8 +62,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # kyverno reports-controller
 apiVersion: cilium.io/v2
@@ -84,5 +78,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/00-infra/policy-reporter/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/policy-reporter/base/cilium-networkpolicy.yaml
@@ -20,8 +20,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # policy-reporter kyverno-plugin
 apiVersion: cilium.io/v2
@@ -37,8 +35,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # policy-reporter UI
 apiVersion: cilium.io/v2
@@ -62,5 +58,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/00-infra/reloader/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/reloader/base/cilium-networkpolicy.yaml
@@ -12,5 +12,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/00-infra/traefik/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/traefik/base/cilium-networkpolicy.yaml
@@ -21,5 +21,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/00-infra/velero/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/velero/base/cilium-networkpolicy.yaml
@@ -13,5 +13,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/00-infra/vpa/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/vpa/base/cilium-networkpolicy.yaml
@@ -20,8 +20,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # vpa-recommender
 apiVersion: cilium.io/v2
@@ -38,8 +36,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # vpa-updater
 apiVersion: cilium.io/v2
@@ -56,5 +52,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/01-storage/local-path-provisioner/base/cilium-networkpolicy.yaml
+++ b/apps/01-storage/local-path-provisioner/base/cilium-networkpolicy.yaml
@@ -12,5 +12,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/01-storage/synology-csi/base/cilium-networkpolicy.yaml
+++ b/apps/01-storage/synology-csi/base/cilium-networkpolicy.yaml
@@ -13,8 +13,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # synology-csi-node — node driver (iSCSI mount)
 apiVersion: cilium.io/v2
@@ -30,8 +28,6 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
 ---
 # iscsi-lock-cleanup — DaemonSet lock management
 apiVersion: cilium.io/v2
@@ -47,5 +43,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/02-monitoring/fluent-bit-syslog/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/fluent-bit-syslog/base/cilium-networkpolicy.yaml
@@ -9,8 +9,9 @@ spec:
     matchLabels:
       app.kubernetes.io/name: fluent-bit-syslog
   ingress:
-    - fromEndpoints:
-        - {}
+    # fromEndpoints: [{}] cassé dans Cilium 1.18.3 → fromEntities: cluster
+    - fromEntities:
+        - cluster
       toPorts:
         - ports:
             - port: "514"

--- a/apps/02-monitoring/fluent-bit-syslog/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/fluent-bit-syslog/base/cilium-networkpolicy.yaml
@@ -24,5 +24,3 @@ spec:
         - ports:
             - port: "2020"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/02-monitoring/fluent-bit/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/fluent-bit/base/cilium-networkpolicy.yaml
@@ -16,5 +16,3 @@ spec:
         - ports:
             - port: "2020"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/02-monitoring/goldilocks/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/goldilocks/base/cilium-networkpolicy.yaml
@@ -35,5 +35,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/02-monitoring/grafana/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/grafana/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/02-monitoring/loki/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/loki/base/cilium-networkpolicy.yaml
@@ -17,5 +17,3 @@ spec:
         - ports:
             - port: "3100"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/02-monitoring/snmp-exporter/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/cilium-networkpolicy.yaml
@@ -16,5 +16,3 @@ spec:
         - ports:
             - port: "9116"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/02-monitoring/victoria-metrics/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/victoria-metrics/base/cilium-networkpolicy.yaml
@@ -16,8 +16,6 @@ spec:
         - ports:
             - port: "8429"
               protocol: TCP
-  egress:
-    - {}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -36,8 +34,6 @@ spec:
         - ports:
             - port: "8428"
               protocol: TCP
-  egress:
-    - {}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -56,8 +52,6 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
-  egress:
-    - {}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -76,8 +70,6 @@ spec:
         - ports:
             - port: "9093"
               protocol: TCP
-  egress:
-    - {}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -96,8 +88,6 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
-  egress:
-    - {}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -116,8 +106,6 @@ spec:
         - ports:
             - port: "9100"
               protocol: TCP
-  egress:
-    - {}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -136,5 +124,3 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/03-security/authentik/base/cilium-networkpolicy.yaml
+++ b/apps/03-security/authentik/base/cilium-networkpolicy.yaml
@@ -18,5 +18,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/03-security/trivy/base/cilium-networkpolicy.yaml
+++ b/apps/03-security/trivy/base/cilium-networkpolicy.yaml
@@ -12,5 +12,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/04-databases/cloudnative-pg/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/cloudnative-pg/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/04-databases/mariadb-shared/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/mariadb-shared/base/cilium-networkpolicy.yaml
@@ -14,5 +14,3 @@ spec:
         - ports:
             - port: "3306"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/04-databases/mariadb-shared/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/mariadb-shared/base/cilium-networkpolicy.yaml
@@ -8,8 +8,9 @@ spec:
     matchLabels:
       app: mariadb-shared
   ingress:
-    - fromEndpoints:
-        - {}
+    # fromEndpoints: [{}] cassé dans Cilium 1.18.3 → fromEntities: cluster
+    - fromEntities:
+        - cluster
       toPorts:
         - ports:
             - port: "3306"

--- a/apps/04-databases/postgresql-shared/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/postgresql-shared/base/cilium-networkpolicy.yaml
@@ -14,8 +14,9 @@ spec:
       cnpg.io/cluster: postgresql-shared
   ingress:
     # PostgreSQL depuis tous les pods du cluster (multi-namespace)
-    - fromEndpoints:
-        - {}
+    # fromEndpoints: [{}] cassé dans Cilium 1.18.3 → fromEntities: cluster
+    - fromEntities:
+        - cluster
       toPorts:
         - ports:
             - port: "5432"

--- a/apps/04-databases/postgresql-shared/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/postgresql-shared/base/cilium-networkpolicy.yaml
@@ -37,5 +37,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/04-databases/redis-shared/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/redis-shared/base/cilium-networkpolicy.yaml
@@ -21,5 +21,3 @@ spec:
         - ports:
             - port: "6379"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/10-home/homeassistant/base/cilium-networkpolicy.yaml
+++ b/apps/10-home/homeassistant/base/cilium-networkpolicy.yaml
@@ -25,5 +25,3 @@ spec:
         - ports:
             - port: "8123"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/10-home/mealie/base/cilium-networkpolicy.yaml
+++ b/apps/10-home/mealie/base/cilium-networkpolicy.yaml
@@ -18,5 +18,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/10-home/mosquitto/base/cilium-networkpolicy.yaml
+++ b/apps/10-home/mosquitto/base/cilium-networkpolicy.yaml
@@ -17,5 +17,3 @@ spec:
         - ports:
             - port: "1883"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/20-media/amule/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/amule/base/cilium-networkpolicy.yaml
@@ -27,7 +27,5 @@ spec:
               protocol: UDP
             - port: "4672"
               protocol: UDP
-  egress:
-    - {}
     - toEntities:
         - world

--- a/apps/20-media/birdnet-go/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/birdnet-go/base/cilium-networkpolicy.yaml
@@ -19,7 +19,5 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}
     - toEntities:
         - world

--- a/apps/20-media/booklore/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/booklore/base/cilium-networkpolicy.yaml
@@ -15,5 +15,3 @@ spec:
         - ports:
             - port: "6060"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/20-media/bookshelf/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/bookshelf/base/cilium-networkpolicy.yaml
@@ -15,5 +15,3 @@ spec:
         - ports:
             - port: "8787"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/20-media/frigate/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/frigate/base/cilium-networkpolicy.yaml
@@ -18,5 +18,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/20-media/hydrus-client/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/hydrus-client/base/cilium-networkpolicy.yaml
@@ -20,5 +20,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/20-media/jellyfin/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/jellyfin/base/cilium-networkpolicy.yaml
@@ -15,5 +15,3 @@ spec:
         - ports:
             - port: "8096"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/20-media/jellyseerr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/jellyseerr/base/cilium-networkpolicy.yaml
@@ -17,5 +17,3 @@ spec:
         - ports:
             - port: "5055"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/20-media/lidarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/lidarr/base/cilium-networkpolicy.yaml
@@ -25,5 +25,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/20-media/music-assistant/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/music-assistant/base/cilium-networkpolicy.yaml
@@ -15,5 +15,3 @@ spec:
         - ports:
             - port: "8095"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/20-media/mylar/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/mylar/base/cilium-networkpolicy.yaml
@@ -18,5 +18,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/20-media/prowlarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/prowlarr/base/cilium-networkpolicy.yaml
@@ -18,5 +18,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/20-media/pyload/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/pyload/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/20-media/qbittorrent/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/qbittorrent/base/cilium-networkpolicy.yaml
@@ -25,7 +25,5 @@ spec:
               protocol: TCP
             - port: "6881"
               protocol: UDP
-  egress:
-    - {}
     - toEntities:
         - world

--- a/apps/20-media/radarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/radarr/base/cilium-networkpolicy.yaml
@@ -18,5 +18,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/20-media/sabnzbd/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/sabnzbd/base/cilium-networkpolicy.yaml
@@ -20,5 +20,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/20-media/sonarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/sonarr/base/cilium-networkpolicy.yaml
@@ -18,5 +18,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/20-media/whisparr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/whisparr/base/cilium-networkpolicy.yaml
@@ -18,5 +18,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/40-network/adguard-home/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/adguard-home/base/cilium-networkpolicy.yaml
@@ -28,5 +28,3 @@ spec:
               protocol: TCP
             - port: "53"
               protocol: UDP
-  egress:
-    - {}

--- a/apps/40-network/external-dns-gandi/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/external-dns-gandi/base/cilium-networkpolicy.yaml
@@ -12,5 +12,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/40-network/external-dns-unifi/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/external-dns-unifi/base/cilium-networkpolicy.yaml
@@ -12,5 +12,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/40-network/netbird/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/netbird/base/cilium-networkpolicy.yaml
@@ -15,5 +15,3 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/40-network/netvisor/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/netvisor/base/cilium-networkpolicy.yaml
@@ -17,5 +17,3 @@ spec:
         - ports:
             - port: "60072"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/60-services/docspell/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/docspell/base/cilium-networkpolicy.yaml
@@ -17,5 +17,3 @@ spec:
         - ports:
             - port: "7880"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/60-services/firefly-iii-importer/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/firefly-iii-importer/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/60-services/firefly-iii/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/firefly-iii/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/60-services/g4f/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/g4f/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/60-services/gluetun/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/gluetun/base/cilium-networkpolicy.yaml
@@ -22,5 +22,3 @@ spec:
         - ports:
             - port: "1080"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/60-services/n8n/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/n8n/base/cilium-networkpolicy.yaml
@@ -18,5 +18,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: tools
-  egress:
-    - {}

--- a/apps/60-services/openclaw/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/openclaw/base/cilium-networkpolicy.yaml
@@ -22,5 +22,3 @@ spec:
         - matchLabels:
             app: n8n
             io.kubernetes.pod.namespace: services
-  egress:
-    - {}

--- a/apps/60-services/sakapuss/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/sakapuss/base/cilium-networkpolicy.yaml
@@ -42,5 +42,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/60-services/vaultwarden/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/vaultwarden/base/cilium-networkpolicy.yaml
@@ -18,5 +18,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/70-tools/changedetection/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/changedetection/base/cilium-networkpolicy.yaml
@@ -15,5 +15,3 @@ spec:
         - ports:
             - port: "5000"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/70-tools/headlamp/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/headlamp/base/cilium-networkpolicy.yaml
@@ -17,5 +17,3 @@ spec:
         - ports:
             - port: "4466"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/70-tools/homepage/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/homepage/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/70-tools/it-tools/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/it-tools/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/70-tools/linkwarden/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/linkwarden/base/cilium-networkpolicy.yaml
@@ -17,5 +17,3 @@ spec:
         - ports:
             - port: "3000"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/70-tools/netbox/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/netbox/base/cilium-networkpolicy.yaml
@@ -17,5 +17,3 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/70-tools/nexterm/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/nexterm/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/70-tools/nocodb/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/nocodb/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/70-tools/penpot/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/penpot/base/cilium-networkpolicy.yaml
@@ -15,5 +15,3 @@ spec:
         - ports:
             - port: "6060"
               protocol: TCP
-  egress:
-    - {}

--- a/apps/70-tools/radar/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/radar/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/70-tools/stirling-pdf/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/stirling-pdf/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/70-tools/trilium/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/trilium/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/70-tools/vikunja/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/vikunja/base/cilium-networkpolicy.yaml
@@ -19,5 +19,3 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-  egress:
-    - {}

--- a/apps/99-test/whoami/base/cilium-networkpolicy.yaml
+++ b/apps/99-test/whoami/base/cilium-networkpolicy.yaml
@@ -15,5 +15,3 @@ spec:
         - ports:
             - port: "80"
               protocol: TCP
-  egress:
-    - {}


### PR DESCRIPTION
## Résumé

Même bug que PR #3001 mais côté ingress. `fromEndpoints: [{}]` (sélecteur vide) en ingress déclenche l'enforcement mais ne matche aucune identité régulière — seuls host(1) et kube-apiserver(7) sont autorisés.

### Symptômes
- `authentik-worker → postgresql-shared:5432` INGRESS DENIED
- `firefly-iii → postgresql-shared:5432` INGRESS DENIED  
- `vikunja, linkwarden, netbox, nocodb → postgresql-shared:5432` INGRESS DENIED
- `crowdsec-lapi → postgresql-shared:5432` INGRESS DENIED
- Toute source syslog → `fluent-bit-syslog:514` INGRESS DENIED

### Fix
`fromEndpoints: [{}]` → `fromEntities: [cluster]`

`fromEntities: cluster` est la façon native Cilium d'autoriser tous les endpoints du cluster. Pas de sélecteur vide cassé.

### Fichiers
- `postgresql-shared`: port 5432 (shared PostgreSQL)
- `mariadb-shared`: port 3306 (shared MariaDB)
- `fluent-bit-syslog`: ports 514 TCP/UDP (syslog receiver)

## Test plan
- [ ] firefly-iii → postgresql-shared: connexion OK
- [ ] authentik → postgresql-shared: connexion OK
- [ ] Hubble: 0 `policy-verdict:none INGRESS DENIED` sur postgresql-shared

🤖 Generated with [Claude Code](https://claude.com/claude-code)