### PR TITLE
fix(cnp): correct VPA webhook port, add vmsingle 8429, CNPG barman port 8000

### DIFF
--- a/apps/00-infra/vpa/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/vpa/base/cilium-networkpolicy.yaml
@@ -1,5 +1,7 @@
 ---
 # vpa-admission-controller — reçoit des appels de kube-apiserver
+# Port 8000 = webhook TLS (--port=8000, named "https" dans le container)
+# Port 8944 = métriques Prometheus (--address=:8944, named "http-metrics")
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -11,15 +13,22 @@ spec:
       app.kubernetes.io/name: vertical-pod-autoscaler
       app.kubernetes.io/component: admission-controller
   ingress:
+    # kube-apiserver → webhook admission (port 8000 = containerPort "https")
     - fromEntities:
         - kube-apiserver
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+    # Prometheus scraping → métriques (port 8944)
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
       toPorts:
         - ports:
             - port: "8944"
               protocol: TCP
-    - fromEndpoints:
-        - matchLabels:
-            io.kubernetes.pod.namespace: monitoring
 ---
 # vpa-recommender
 apiVersion: cilium.io/v2

--- a/apps/02-monitoring/victoria-metrics/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/victoria-metrics/base/cilium-networkpolicy.yaml
@@ -34,6 +34,8 @@ spec:
         - ports:
             - port: "8428"
               protocol: TCP
+            - port: "8429"
+              protocol: TCP
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/apps/04-databases/postgresql-shared/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/postgresql-shared/base/cilium-networkpolicy.yaml
@@ -34,6 +34,14 @@ spec:
     - fromEntities:
         - host
         - remote-node
+    # CloudNativePG operator — barman backup API (port 8000)
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: cnpg-system
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
     # Métriques Prometheus (pg_exporter port 9187)
     - fromEndpoints:
         - matchLabels:


### PR DESCRIPTION
## Contexte

Suite à l'investigation des drops Hubble en préparation du default-deny (Round 6), trois gaps CNP identifiés et corrigés.

## Changements

### VPA admission-controller — port webhook corrigé
- **Avant**: `kube-apiserver` autorisé sur port 8944 (port métriques)
- **Après**: `kube-apiserver` + `remote-node` autorisés sur port 8000 (webhook TLS, `containerPort: "https"`)
- Prometheus scopé explicitement sur port 8944 (`http-metrics`)
- **Cause**: VPA `--port=8000` (webhook) ≠ `--address=:8944` (metrics). Le CNP avait les ports inversés → webhook DENIED.

### vmsingle — ajout port 8429
- **Avant**: ingress monitoring uniquement sur port 8428
- **Après**: ports 8428 + 8429 autorisés
- **Cause**: service `vmsingle-vm-stack` expose `8429/TCP,8428/TCP`. vmalert se connecte sur 8429 → INGRESS DENIED (confirmé Hubble).

### postgresql-shared — port barman CNPG operator
- Ajout: `cnpg-system` → port 8000 (barman backup API CloudNativePG)
- **Cause**: gap identifié — l'opérateur CNPG appelle les pods PostgreSQL sur port 8000 pour la gestion des backups.

## Test plan
- [ ] ArgoCD sync vert sur vpa, victoria-metrics, postgresql-shared
- [ ] Hubble: plus de drops vmalert→vmsingle:8429
- [ ] Hubble: plus de drops VPA admission controller
- [ ] Round 6 deny test une fois ces fixes en prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal network traffic policies to optimize communication pathways between monitoring, database infrastructure, and system management components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->