### PR TITLE
fix(cnp): metrics-server port, crowdsec-lapi intra-ns, traefik service ports

### DIFF
--- a/apps/00-infra/crowdsec/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/crowdsec/base/cilium-networkpolicy.yaml
@@ -14,7 +14,7 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
 ---
-# crowdsec-lapi — reçoit des requêtes de Traefik (bouncer) et monitoring
+# crowdsec-lapi — reçoit des requêtes de Traefik (bouncer), agents crowdsec et monitoring
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -28,6 +28,8 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik
+        - matchLabels:
+            io.kubernetes.pod.namespace: crowdsec
       toPorts:
         - ports:
             - port: "8080"

--- a/apps/00-infra/metrics-server/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/metrics-server/base/cilium-networkpolicy.yaml
@@ -1,6 +1,6 @@
 ---
 # metrics-server — collecte les métriques kubelet sur chaque node
-# Ingress: kubelet (remote-node) → metrics-server:4443 (aggregated API)
+# Ingress: kube-apiserver (host/remote-node) → metrics-server:10250 (--secure-port=10250)
 # Egress: metrics-server → kubelet sur tous les nodes (port 10250)
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -17,7 +17,7 @@ spec:
         - remote-node
       toPorts:
         - ports:
-            - port: "4443"
+            - port: "10250"
               protocol: TCP
     - fromEndpoints:
         - matchLabels:

--- a/apps/00-infra/traefik/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/traefik/base/cilium-networkpolicy.yaml
@@ -1,4 +1,10 @@
 ---
+# traefik — reverse proxy + ingress controller
+# Ports TCP: 80 (web), 443 (websecure), 25 (smtp), 514 (syslog), 587 (submission),
+#            993 (imaps), 1883 (mqtt), 3483 (slimproto), 5000 (frigate-api),
+#            5683 (coiot), 8554 (frigate-rtsp), 8555 (frigate-webrtc)
+# Ports UDP: 53 (dns), 514 (syslog), 3483 (slimproto), 5683 (coiot)
+# cross-node traffic: source = cilium_host IP → needs remote-node entity alongside world/cluster
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -12,12 +18,51 @@ spec:
     - fromEntities:
         - world
         - cluster
+        - remote-node
       toPorts:
         - ports:
             - port: "80"
               protocol: TCP
             - port: "443"
               protocol: TCP
+            - port: "25"
+              protocol: TCP
+            - port: "53"
+              protocol: TCP
+            - port: "514"
+              protocol: TCP
+            - port: "587"
+              protocol: TCP
+            - port: "993"
+              protocol: TCP
+            - port: "1883"
+              protocol: TCP
+            - port: "3483"
+              protocol: TCP
+            - port: "5000"
+              protocol: TCP
+            - port: "5683"
+              protocol: TCP
+            - port: "8554"
+              protocol: TCP
+            - port: "8555"
+              protocol: TCP
+    - fromEntities:
+        - world
+        - cluster
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "514"
+              protocol: UDP
+            - port: "3483"
+              protocol: UDP
+            - port: "5683"
+              protocol: UDP
+            - port: "8555"
+              protocol: UDP
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring


### PR DESCRIPTION
## Summary

Three CNP gaps identified via Hubble `policy-verdict:none INGRESS DENIED` on prod:

- **metrics-server**: pod runs with `--secure-port=10250` but CNP allowed ingress on port 4443; kube-apiserver/remote-node hitting metrics-server:10250 was denied
- **crowdsec-lapi**: crowdsec-agent→lapi (port 8080) was denied because `crowdsec` namespace wasn't in the allowed ingress — only `traefik` and `monitoring` were listed
- **traefik**: service exposes many TCP/UDP entrypoints (syslog/514, dns/53, mqtt/1883, slimproto/3483, coiot/5683, smtp/25, imaps/993, submission/587, frigate-*) but CNP only permitted ports 80 and 443; cross-node LB traffic arrives via `cilium_host` (classified as `remote-node`) so that entity was added alongside `world + cluster`

## Test plan

- [ ] ArgoCD syncs all 3 apps (metrics-server, crowdsec, traefik)
- [ ] Hubble: no more `metrics-server:10250` INGRESS DENIED from remote-node
- [ ] Hubble: no more `crowdsec-lapi:8080` INGRESS DENIED from remote-node
- [ ] Hubble: no more `traefik:514/1883/53/…` INGRESS DENIED from remote-node
- [ ] `kubectl top nodes` / `kubectl top pods` work (metrics-server functional)
- [ ] CrowdSec agents report healthy connection to LAPI
- [ ] Round 6 deny test (enableDefaultDeny) after drop count ≈ 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Updates**
  * Updated CrowdSec network policies to allow additional internal service communication on port 8080
  * Modified metrics server network policies to allow traffic on port 10250
  * Expanded Traefik network policies to support remote node connectivity and additional TCP/UDP port access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->