### PR TITLE
fix(cnp): allow remote-node for mealie and sabnzbd service ports

### DIFF
--- a/apps/10-home/mealie/base/cilium-networkpolicy.yaml
+++ b/apps/10-home/mealie/base/cilium-networkpolicy.yaml
@@ -15,6 +15,13 @@ spec:
         - ports:
             - port: "9000"
               protocol: TCP
+    # remote-node: cilium_host health checks + cross-node VXLAN identity resolution fallback
+    - fromEntities:
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring

--- a/apps/20-media/sabnzbd/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/sabnzbd/base/cilium-networkpolicy.yaml
@@ -17,6 +17,13 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
+    # remote-node: cilium_host health checks + cross-node VXLAN identity resolution fallback
+    - fromEntities:
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring


### PR DESCRIPTION
## Summary

- Persistent INGRESS DENIED drops: `10.244.4.51 (remote-node) → mealie:9000` and `→ sabnzbd:8080` at 1 SYN/sec
- Source `10.244.4.51` is the `cilium_host` bridge IP on peach node
- Traefik was recently rescheduled to a third node (peach); cross-node connections via VXLAN fall back to `remote-node` identity when Cilium identity resolution isn't fully propagated after agent restarts (peach: 83 restarts total)
- Add `fromEntities: remote-node` scoped to the service port for both apps so Cilium health checks and cross-node traffic can pass

## Test plan

- [ ] ArgoCD syncs mealie and sabnzbd apps
- [ ] Hubble: no more `mealie:9000` / `sabnzbd:8080` INGRESS DENIED from remote-node
- [ ] mealie and sabnzbd remain accessible via Traefik
- [ ] Total Hubble POLICY_DENIED drops ≈ 0 (ready for Round 6 defaultDeny test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)