### PR TITLE
fix(cnp): allow policy-reporter to reach policy-reporter-ui

### DIFF
--- a/apps/00-infra/policy-reporter/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/policy-reporter/base/cilium-networkpolicy.yaml
@@ -36,7 +36,7 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
 ---
-# policy-reporter UI
+# policy-reporter UI — reçoit des requêtes de Traefik, monitoring, et du backend policy-reporter
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -51,6 +51,8 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik
+        - matchLabels:
+            io.kubernetes.pod.namespace: policy-reporter
       toPorts:
         - ports:
             - port: "8080"


### PR DESCRIPTION
## Summary

- `policy-reporter` backend → `policy-reporter-ui:8080` was INGRESS DENIED
- The UI CNP only allowed from `traefik` and `monitoring` namespaces
- Add `policy-reporter` namespace to allowed ingress for port 8080

## Test plan

- [ ] ArgoCD syncs policy-reporter app
- [ ] Hubble: no more `policy-reporter → policy-reporter-ui:8080` INGRESS DENIED
- [ ] Total POLICY_DENIED drops ≈ 0 → proceed with Round 6 defaultDeny test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network policy configuration for policy-reporter-ui to allow ingress traffic from both traefik and policy-reporter namespaces on port 8080.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->