### PR TITLE
fix(cnp): add missing egress rules for defaultDeny (round 7)

### DIFF
--- a/apps/00-infra/argocd/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/argocd/base/cilium-networkpolicy.yaml
@@ -20,3 +20,20 @@ spec:
     - fromEntities:
         - host
         - remote-node
+  egress:
+    # argocd-controller → redis, repo-server, dex, server (intra-namespace)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: argocd
+    # argocd-controller → kube-apiserver (manage cluster resources, watch CRDs)
+    - toEntities:
+        - kube-apiserver
+    # argocd-repo-server → git/helm repos, argocd-server → SSO/webhooks
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/apps/00-infra/infisical-operator/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/infisical-operator/base/cilium-networkpolicy.yaml
@@ -12,3 +12,14 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # infisical-operator → kube-apiserver (watch InfisicalSecret CRDs, patch K8s Secrets)
+    - toEntities:
+        - kube-apiserver
+    # infisical-operator → Infisical instance (self-hosted on NAS at 192.168.111.69:8085)
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "8085"
+              protocol: TCP

--- a/apps/00-infra/keda/overlays/prod/cilium-networkpolicy.yaml
+++ b/apps/00-infra/keda/overlays/prod/cilium-networkpolicy.yaml
@@ -49,3 +49,30 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+---
+# keda-operator-metrics-apiserver — external metrics API called by kube-apiserver
+# kube-apiserver connects as remote-node (cross-node) or kube-apiserver entity
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: keda-operator-metrics-apiserver
+  namespace: keda
+spec:
+  endpointSelector:
+    matchLabels:
+      app: keda-operator-metrics-apiserver
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/apps/00-infra/traefik/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/traefik/base/cilium-networkpolicy.yaml
@@ -66,3 +66,17 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # traefik → all backend services (reverse-proxy, TCP/UDP proxies to any namespace)
+    - toEntities:
+        - cluster
+    # traefik → kube-apiserver (service discovery, IngressRoutes via CRD watch)
+    - toEntities:
+        - kube-apiserver
+    # traefik → ACME (Let's Encrypt), external APIs
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/apps/02-monitoring/fluent-bit/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/fluent-bit/base/cilium-networkpolicy.yaml
@@ -16,3 +16,12 @@ spec:
         - ports:
             - port: "2020"
               protocol: TCP
+  egress:
+    # fluent-bit → loki (log shipping)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "3100"
+              protocol: TCP

--- a/apps/02-monitoring/victoria-metrics/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/victoria-metrics/base/cilium-networkpolicy.yaml
@@ -16,6 +16,11 @@ spec:
         - ports:
             - port: "8429"
               protocol: TCP
+  egress:
+    # vmagent → vmalert, vmsingle, and other monitoring endpoints (scrape targets + remote_write)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy


### PR DESCRIPTION
## Summary

Round 6 testing with `enableDefaultDeny: {egress: true, ingress: true}` on all CCNPs revealed multiple components with missing egress CNPs. This PR fixes all identified gaps before the next round of testing.

### Changes

| Component | Gap | Fix |
|-----------|-----|-----|
| **argocd** | Controller→redis/repo-server EGRESS DENIED → ArgoCD selfHeal deadlock | egress: argocd namespace + kube-apiserver + world:443/80 |
| **fluent-bit** | fluent-bit→loki:3100 EGRESS DENIED (log shipping broken) | egress: monitoring:3100 |
| **vmagent** | vmagent→vmalert:8080 EGRESS DENIED | egress: monitoring namespace (all VictoriaMetrics components) |
| **infisical-operator** | operator→Infisical NAS:8085 EGRESS DENIED | egress: kube-apiserver + world:8085 |
| **traefik** | traefik→backends EGRESS DENIED (routing broken) | egress: cluster + kube-apiserver + world:443 |
| **keda** | kube-apiserver→keda metrics-apiserver:6443 INGRESS DENIED | new CNP for keda-operator-metrics-apiserver (label: `app=keda-operator-metrics-apiserver`) |

### Critical note: ArgoCD selfHeal deadlock

When defaultDeny/egress was enabled without this fix, `argocd-controller` could not reach `argocd-redis:6379` or `argocd-repo-server:8081`. ArgoCD comparison failed with `i/o timeout`, which prevented selfHeal from reverting the test patches. This required manual `kubectl patch` across all 8 CCNPs to recover.

The argocd egress rule added here directly prevents this deadlock.

## Test plan

- [ ] Merge PR → ArgoCD syncs to dev cluster
- [ ] Run Hubble observation (check 0 DROPPED in argocd, monitoring, keda, traefik, infisical-operator-system)
- [ ] Enable `enableDefaultDeny: {egress: true, ingress: true}` on all CCNPs (Round 7)
- [ ] Verify 0 POLICY_DENIED drops after 5 minutes
- [ ] Revert defaultDeny
- [ ] Promote to prod-stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)