### PR TITLE
fix(cnp): round 8 — victoria-metrics-operator webhook + vmagent kubelet scrape

### DIFF
--- a/apps/02-monitoring/victoria-metrics/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/victoria-metrics/base/cilium-networkpolicy.yaml
@@ -21,6 +21,14 @@ spec:
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+    # vmagent → kubelet on all nodes (node metrics scraping, port 10250)
+    - toEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "10250"
+              protocol: TCP
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -130,4 +138,12 @@ spec:
       toPorts:
         - ports:
             - port: "8080"
+              protocol: TCP
+    # kube-apiserver calls admission webhook on port 9443
+    - fromEntities:
+        - kube-apiserver
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "9443"
               protocol: TCP


### PR DESCRIPTION
## Summary

Round 7 testing (after merging #3008) revealed two remaining INGRESS/EGRESS DENIED drops with `enableDefaultDeny: true`:

| Component | Drop | Fix |
|-----------|------|-----|
| **victoria-metrics-operator** | `remote-node → victoria-metrics-operator:9443` INGRESS DENIED — kube-apiserver admission webhook calls | ingress from `kube-apiserver` + `remote-node` on port 9443 |
| **vmagent** | `vmagent → node:10250 (remote-node)` EGRESS DENIED — kubelet metrics scraping | egress to `host` + `remote-node` on port 10250 |

**Not actionable:** `music-assistant → 224.0.0.22` — IGMP multicast (`CT: Unknown L4 protocol`), expected Cilium behavior for IGMP/IPv4, not addressable via CNP.

### Positive result from Round 7

ArgoCD selfHeal **automatically reverted** the test defaultDeny patches within ~3 minutes — confirming that the argocd egress fix from #3008 resolved the selfHeal deadlock. No manual recovery needed.

## Test plan

- [ ] Merge → ArgoCD syncs to prod
- [ ] Enable `enableDefaultDeny: true` on all CCNPs (Round 8)
- [ ] Verify 0 POLICY_DENIED drops (excluding music-assistant IGMP)
- [ ] Confirm ArgoCD selfHeal reverts within 3 min
- [ ] Promote to prod-stable permanently via GitOps CCNP patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network access policies for monitoring infrastructure to enable proper connectivity between monitoring services and underlying infrastructure components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->