### PR TITLE
fix(cnp): round 9 — app-level egress/ingress gaps from round 8 test

### DIFF
--- a/apps/00-infra/keda/overlays/prod/cilium-networkpolicy.yaml
+++ b/apps/00-infra/keda/overlays/prod/cilium-networkpolicy.yaml
@@ -49,6 +49,10 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # keda-http-interceptor proxies HTTP requests to backend services across all namespaces
+    - toEntities:
+        - cluster
 ---
 # keda-operator-metrics-apiserver — external metrics API called by kube-apiserver
 # kube-apiserver connects as remote-node (cross-node) or kube-apiserver entity

--- a/apps/00-infra/traefik/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/traefik/base/cilium-networkpolicy.yaml
@@ -73,10 +73,6 @@ spec:
     # traefik → kube-apiserver (service discovery, IngressRoutes via CRD watch)
     - toEntities:
         - kube-apiserver
-    # traefik → ACME (Let's Encrypt), external APIs
+    # traefik → ACME, external APIs, and NAS-hosted backends (frigate, etc.)
     - toEntities:
         - world
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP

--- a/apps/20-media/amule/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/amule/base/cilium-networkpolicy.yaml
@@ -29,3 +29,12 @@ spec:
               protocol: UDP
     - toEntities:
         - world
+  egress:
+    # amule → gluetun SOCKS5 proxy (all P2P traffic tunneled through VPN)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: services
+      toPorts:
+        - ports:
+            - port: "1080"
+              protocol: TCP

--- a/apps/40-network/external-dns-unifi/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/external-dns-unifi/base/cilium-networkpolicy.yaml
@@ -12,3 +12,14 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # external-dns-unifi → Unifi controller (192.168.200.1:443)
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # external-dns-unifi → kube-apiserver (watch Ingress/Service resources)
+    - toEntities:
+        - kube-apiserver

--- a/apps/60-services/firefly-iii/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/firefly-iii/base/cilium-networkpolicy.yaml
@@ -14,7 +14,14 @@ spec:
             io.kubernetes.pod.namespace: traefik
       toPorts:
         - ports:
-            - port: "80"
+            - port: "8080"
+              protocol: TCP
+    # remote-node: cross-node Traefik traffic via VXLAN loses pod identity
+    - fromEntities:
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "8080"
               protocol: TCP
     - fromEndpoints:
         - matchLabels:


### PR DESCRIPTION
## Summary

Round 8 testing (after merging #3009) revealed 5 more gaps. ArgoCD selfHeal automatically reverted the test patches in ~3 minutes — confirming the argocd egress fix from #3008 is working correctly.

### Changes

| Component | Gap | Fix |
|-----------|-----|-----|
| **firefly-iii** | `remote-node → finance/firefly-iii:8080` INGRESS DENIED; also **port bug**: CNP had port 80 but container listens on 8080 | Fix port 80→8080 for traefik rule + add remote-node ingress on 8080 |
| **amule** | `downloads/amule → services/gluetun:1080` EGRESS DENIED | egress: services namespace port 1080 (SOCKS5 proxy) |
| **external-dns-unifi** | `networking/external-dns-unifi → 192.168.200.1:443` EGRESS DENIED | egress: world:443 + kube-apiserver |
| **traefik** | `traefik → 192.168.111.69:5000 (world)` EGRESS DENIED — NAS-hosted backends (Frigate, etc.) on non-443 ports | Remove port restriction on world egress (traefik proxies to any external backend) |
| **keda-http-add-on** | `keda/interceptor → tools/linkwarden:3000` EGRESS DENIED | egress: cluster entity (interceptor proxies to backend services) |

**Not actionable (carry-over):** `music-assistant → 224.0.0.22` IGMP multicast.

## Test plan

- [ ] Merge → promote → ArgoCD syncs to prod
- [ ] Enable `enableDefaultDeny: true` on all CCNPs (Round 9)
- [ ] Verify 0 POLICY_DENIED drops (excluding music-assistant IGMP)
- [ ] Confirm ArgoCD selfHeal reverts within 3 min
- [ ] After 0 drops confirmed: implement defaultDeny permanently via GitOps CCNP patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)