### PR TITLE
fix(cnp): round 10 — fluent-bit-syslog egress + vmagent cluster scraping

### DIFF
--- a/apps/02-monitoring/fluent-bit-syslog/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/fluent-bit-syslog/base/cilium-networkpolicy.yaml
@@ -25,3 +25,12 @@ spec:
         - ports:
             - port: "2020"
               protocol: TCP
+  egress:
+    # fluent-bit-syslog → loki (syslog log shipping)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "3100"
+              protocol: TCP

--- a/apps/02-monitoring/victoria-metrics/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/victoria-metrics/base/cilium-networkpolicy.yaml
@@ -17,16 +17,17 @@ spec:
             - port: "8429"
               protocol: TCP
   egress:
-    # vmagent → vmalert, vmsingle, and other monitoring endpoints (scrape targets + remote_write)
-    - toEndpoints:
-        - matchLabels:
-            io.kubernetes.pod.namespace: monitoring
-    # vmagent → kubelet on all nodes (node metrics scraping, port 10250)
+    # vmagent → all cluster pods (scrapes metrics from every namespace)
+    - toEntities:
+        - cluster
+    # vmagent → kubelet (port 10250) + node-exporter hostNetwork (port 9100) on all nodes
     - toEntities:
         - host
         - remote-node
       toPorts:
         - ports:
+            - port: "9100"
+              protocol: TCP
             - port: "10250"
               protocol: TCP
 ---


### PR DESCRIPTION
## Summary

Round 9 testing revealed 3 more gaps after merging #3010. ArgoCD selfHeal continued to auto-revert test patches correctly.

### Changes

| Component | Gap | Fix |
|-----------|-----|-----|
| **fluent-bit-syslog** | `fluent-bit-syslog → monitoring/loki:3100` EGRESS DENIED | egress: monitoring:3100 |
| **vmagent (egress)** | `vmagent → media/whisparr:9090` and `cert-manager:9402` EGRESS DENIED — vmagent scrapes metrics from ALL namespaces | Change `toEndpoints: monitoring` → `toEntities: cluster` |
| **vmagent (node)** | `vmagent → node:9100` EGRESS DENIED — prometheus-node-exporter runs with hostNetwork | Add port 9100 to existing `host + remote-node` rule (alongside kubelet:10250) |

## Test plan

- [ ] Merge → promote → ArgoCD syncs to prod
- [ ] Enable `enableDefaultDeny: true` on all CCNPs (Round 10)
- [ ] Verify 0 POLICY_DENIED drops (excluding IGMP multicast)
- [ ] If clean → implement defaultDeny permanently via GitOps CCNP patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)