### PR TITLE
fix(cnp): round 11 — firefly-iii DB egress + cron CNP + amule world egress

### DIFF
--- a/apps/20-media/amule/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/amule/base/cilium-networkpolicy.yaml
@@ -30,7 +30,7 @@ spec:
     - toEntities:
         - world
   egress:
-    # amule → gluetun SOCKS5 proxy (all P2P traffic tunneled through VPN)
+    # amule → gluetun SOCKS5 proxy (P2P traffic tunneled through VPN)
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: services
@@ -38,3 +38,6 @@ spec:
         - ports:
             - port: "1080"
               protocol: TCP
+    # amule → world (local NAS access, direct P2P connections not via proxy)
+    - toEntities:
+        - world

--- a/apps/60-services/firefly-iii/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/firefly-iii/base/cilium-networkpolicy.yaml
@@ -26,3 +26,36 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # firefly-iii → PostgreSQL database
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # firefly-iii → kube-apiserver (health checks, service discovery)
+    - toEntities:
+        - kube-apiserver
+---
+# firefly-iii CronJob pods have different labels from the main deployment
+# Pod template only sets: vixens.io/sizing.firefly-iii-cron: G-nano
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: firefly-iii-cron
+  namespace: finance
+spec:
+  endpointSelector:
+    matchLabels:
+      vixens.io/sizing.firefly-iii-cron: G-nano
+  egress:
+    # cron → PostgreSQL database (scheduled financial tasks)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP


### PR DESCRIPTION
## Summary

Round 10 testing revealed 2 more gaps after merging #3011.

### Changes

| Component | Gap | Fix |
|-----------|-----|-----|
| **firefly-iii** | No egress CNP → `databases/postgresql:5432` EGRESS DENIED when defaultDeny active | Add egress: databases:5432 + kube-apiserver |
| **firefly-iii-cron** | CronJob pods use label `vixens.io/sizing.firefly-iii-cron: G-nano` (no `app.kubernetes.io/*`), not matched by firefly-iii CNP | New dedicated CNP `firefly-iii-cron` with databases:5432 egress |
| **amule** | `downloads/amule → 192.168.111.69:9000 (world)` EGRESS DENIED — NAS access and direct connections bypass gluetun SOCKS proxy | Add `toEntities: world` to amule egress |

## Test plan

- [ ] Merge → promote → ArgoCD syncs to prod
- [ ] Enable `enableDefaultDeny: true` on all CCNPs (Round 11)
- [ ] Verify 0 POLICY_DENIED drops
- [ ] Promote defaultDeny to GitOps if clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)