### PR TITLE
fix(cnp): round 12 — qbittorrent P2P egress + firefly-iii world egress

### DIFF
--- a/apps/20-media/qbittorrent/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/qbittorrent/base/cilium-networkpolicy.yaml
@@ -27,3 +27,7 @@ spec:
               protocol: UDP
     - toEntities:
         - world
+  egress:
+    # qbittorrent → world (P2P traffic, BitTorrent peers)
+    - toEntities:
+        - world

--- a/apps/60-services/firefly-iii/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/firefly-iii/base/cilium-networkpolicy.yaml
@@ -38,6 +38,9 @@ spec:
     # firefly-iii → kube-apiserver (health checks, service discovery)
     - toEntities:
         - kube-apiserver
+    # firefly-iii → world (NAS/MinIO at 192.168.111.69:9000, external APIs)
+    - toEntities:
+        - world
 ---
 # firefly-iii CronJob pods have different labels from the main deployment
 # Pod template only sets: vixens.io/sizing.firefly-iii-cron: G-nano


### PR DESCRIPTION
## Summary

Round 11 testing revealed 2 remaining gaps.

### Changes

| Component | Gap | Fix |
|-----------|-----|-----|
| **qbittorrent** | `media/qbittorrent:6881 → world (UDP)` EGRESS DENIED — outbound P2P traffic | Add `toEntities: world` to egress |
| **firefly-iii** | `finance/firefly-iii → 192.168.111.69:9000 (world)` EGRESS DENIED — NAS/MinIO access for file attachments | Add `toEntities: world` to egress |

## Test plan

- [ ] Merge → promote → ArgoCD syncs to prod
- [ ] Enable `enableDefaultDeny: true` on all CCNPs (Round 12)
- [ ] Verify 0 POLICY_DENIED drops
- [ ] If clean → implement defaultDeny permanently in CCNP GitOps manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)