### PR TITLE
fix(cnp): round 13 — keda intra-namespace communication gaps

### DIFF
--- a/apps/00-infra/keda/overlays/prod/cilium-networkpolicy.yaml
+++ b/apps/00-infra/keda/overlays/prod/cilium-networkpolicy.yaml
@@ -13,6 +13,10 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+    # keda-operator-metrics-apiserver → keda-operator:9666 (internal keda communication)
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: keda
 ---
 # keda-admission-webhooks — reçoit des appels de kube-apiserver
 apiVersion: cilium.io/v2
@@ -49,6 +53,10 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+    # http-add-on internal: external-scaler → interceptor:9090 (scaling coordination)
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: keda
   egress:
     # keda-http-interceptor proxies HTTP requests to backend services across all namespaces
     - toEntities:


### PR DESCRIPTION
## Summary

Round 12 testing revealed only 2 remaining drops — both intra-keda communication.

### Changes

| Component | Gap | Fix |
|-----------|-----|-----|
| **keda-http-add-on** | `external-scaler → interceptor:9090` INGRESS DENIED | Add ingress from `keda` namespace to keda-http-add-on CNP |
| **keda-operator** | `metrics-apiserver → keda-operator:9666` INGRESS DENIED | Add ingress from `keda` namespace to keda-operator CNP |

Both are internal keda component communication that was blocked because the existing CNPs only allowed ingress from `monitoring` namespace.

## Test plan

- [ ] Merge → promote → ArgoCD syncs to prod
- [ ] Enable `enableDefaultDeny: true` on all CCNPs (Round 13)
- [ ] Verify 0 POLICY_DENIED drops
- [ ] Implement defaultDeny permanently in CCNP GitOps manifests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network policy rules in production infrastructure to enhance inter-pod communication permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->