### PR TITLE
fix(cnp): round 14 — snmp-exporter SNMP egress (final CNP gap)

### DIFF
--- a/apps/02-monitoring/snmp-exporter/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/cilium-networkpolicy.yaml
@@ -16,3 +16,11 @@ spec:
         - ports:
             - port: "9116"
               protocol: TCP
+  egress:
+    # snmp-exporter → SNMP devices on local network (port 161 UDP)
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "161"
+              protocol: UDP


### PR DESCRIPTION
## Summary

Round 13 testing revealed **only 1 remaining drop** — the snmp-exporter missing egress for SNMP polling.

### Change

| Component | Gap | Fix |
|-----------|-----|-----|
| **snmp-exporter** | `monitoring/snmp-exporter → 192.168.0.x:161 (world)` EGRESS DENIED — SNMP polling of network devices | Add `toEntities: world` on port 161/UDP |

### Progress summary (rounds 6-14)

After 8 iterative rounds of testing with `enableDefaultDeny: {egress: true, ingress: true}`, we fixed:
- ArgoCD egress (selfHeal deadlock fix)
- fluent-bit, fluent-bit-syslog → loki egress
- vmagent → cluster scraping + kubelet/node-exporter node egress  
- victoria-metrics-operator webhook ingress
- infisical-operator egress
- traefik egress (cluster + world)
- KEDA metrics-apiserver CNP + keda intra-namespace communication
- firefly-iii port fix + DB egress + world egress + cron CNP
- amule + qbittorrent P2P egress
- external-dns-unifi egress

## Next step after merge

Enable `enableDefaultDeny` permanently in the 8 CCNP GitOps manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)