### PR TITLE
fix(cnp): round 15 — keda egress + vikunja world egress

### DIFF
--- a/apps/00-infra/keda/overlays/prod/cilium-networkpolicy.yaml
+++ b/apps/00-infra/keda/overlays/prod/cilium-networkpolicy.yaml
@@ -17,6 +17,14 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: keda
+  egress:
+    # keda-operator → kube-apiserver (watch ScaledObjects, manage HPA)
+    - toEntities:
+        - kube-apiserver
+    # keda-operator → keda http-add-on components (external-scaler:9090, etc.)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: keda
 ---
 # keda-admission-webhooks — reçoit des appels de kube-apiserver
 apiVersion: cilium.io/v2
@@ -88,3 +96,8 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
+  egress:
+    # metrics-apiserver → keda-operator:9666 (aggregate metrics queries)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: keda

--- a/apps/70-tools/vikunja/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/vikunja/base/cilium-networkpolicy.yaml
@@ -19,3 +19,14 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # vikunja → databases (MariaDB/PostgreSQL)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+    # vikunja → world (NAS/MinIO at 192.168.111.69:9000, external OAuth/SMTP)
+    - toEntities:
+        - world
+    # vikunja → kube-apiserver
+    - toEntities:
+        - kube-apiserver


### PR DESCRIPTION
## Summary

Round 14 testing revealed 3 remaining drops (2 keda, 1 vikunja).

### Changes

| Component | Gap | Fix |
|-----------|-----|-----|
| **keda-operator** | `keda-operator → keda/http-external-scaler:9090` EGRESS DENIED — no egress CNP | Add egress: keda namespace + kube-apiserver |
| **keda-operator-metrics-apiserver** | `metrics-apiserver → keda-operator:9666` EGRESS DENIED — no egress CNP | Add egress: keda namespace |
| **vikunja** | `tools/vikunja → 192.168.111.69:9000 (world)` EGRESS DENIED | Add egress: databases + world + kube-apiserver |

🤖 Generated with [Claude Code](https://claude.com/claude-code)