### PR TITLE
fix(keda): allow keda-operator egress to databases namespace

### DIFF
--- a/apps/00-infra/keda/overlays/prod/cilium-networkpolicy.yaml
+++ b/apps/00-infra/keda/overlays/prod/cilium-networkpolicy.yaml
@@ -25,6 +25,10 @@ spec:
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: keda
+    # keda-operator → databases (PostgreSQL ScaledObject triggers)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
 ---
 # keda-admission-webhooks — reçoit des appels de kube-apiserver
 apiVersion: cilium.io/v2


### PR DESCRIPTION
## Summary

- keda-operator needs egress to `databases` namespace for PostgreSQL ScaledObject triggers
- Round 15 defaultDeny test revealed: `keda/keda-operator → databases/postgresql-shared-1:5432 EGRESS DENIED`

## Actionable drops from Round 15

| Source | Destination | Direction | Action needed |
|--------|------------|-----------|---------------|
| `keda/keda-operator` | `databases/postgresql-shared-1:5432` | EGRESS | ✅ Fixed here |

ICMPv6 RouterSolicitation drops are benign (Unsupported L3 protocol, not policy-denied).

## Test plan

- [ ] Merge + promote to prod
- [ ] Round 16: enable defaultDeny on 8 CCNPs, observe Hubble → expect 0 actionable drops
- [ ] If clean: permanently enable `enableDefaultDeny: {egress: true, ingress: true}` in CCNP GitOps manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)