### PR TITLE
feat(cilium): permanently enable defaultDeny egress+ingress on prod CCNPs

### DIFF
--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-cilium-health.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-cilium-health.yaml
@@ -2,7 +2,7 @@
 # Autorise les health checks inter-nœuds Cilium (port 4240)
 # remote-node → tous les pods sur port 4240 (cilium-health)
 # Nécessaire avec enableDefaultDeny.ingress: true
-# enableDefaultDeny: false = additif seulement
+# enableDefaultDeny: true = default-deny actif (ingress + egress)
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
@@ -10,8 +10,8 @@ metadata:
 spec:
   endpointSelector: {}
   enableDefaultDeny:
-    ingress: false
-    egress: false
+    ingress: true
+    egress: true
   ingress:
     - fromEntities:
         - host

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-coredns-egress.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-coredns-egress.yaml
@@ -1,7 +1,7 @@
 ---
 # CoreDNS a besoin d'envoyer des requêtes DNS upstream (forwarder)
 # 169.254.116.108:53 (link-local node DNS) est classifié "world" par Cilium
-# enableDefaultDeny: false = additif seulement
+# enableDefaultDeny: true = default-deny actif (ingress + egress)
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
@@ -12,8 +12,8 @@ spec:
       io.kubernetes.pod.namespace: kube-system
       k8s-app: kube-dns
   enableDefaultDeny:
-    ingress: false
-    egress: false
+    ingress: true
+    egress: true
   egress:
     # Upstream DNS forwarder (link-local, world)
     - toEntities:

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-coredns-ingress.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-coredns-ingress.yaml
@@ -2,7 +2,7 @@
 # Autorise CoreDNS à recevoir les requêtes DNS depuis tous les pods/nodes
 # Nécessaire avec enableDefaultDeny.ingress: true sur CoreDNS
 # allow-coredns-egress couvre l'egress des pods SOURCE, mais pas l'ingress de CoreDNS lui-même
-# enableDefaultDeny: false = additif seulement
+# enableDefaultDeny: true = default-deny actif (ingress + egress)
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
@@ -13,8 +13,8 @@ spec:
       io.kubernetes.pod.namespace: kube-system
       k8s-app: kube-dns
   enableDefaultDeny:
-    ingress: false
-    egress: false
+    ingress: true
+    egress: true
   ingress:
     - fromEndpoints:
         - {}

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-coredns.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-coredns.yaml
@@ -1,6 +1,6 @@
 ---
 # Autorise tous les pods à résoudre le DNS via CoreDNS (kube-system)
-# enableDefaultDeny: false = additif seulement, ne bloque pas le reste de l'egress
+# enableDefaultDeny: true = default-deny actif (ingress + egress)
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
@@ -8,8 +8,8 @@ metadata:
 spec:
   endpointSelector: {}
   enableDefaultDeny:
-    ingress: false
-    egress: false
+    ingress: true
+    egress: true
   egress:
     - toEndpoints:
         - matchLabels:

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-hubble-relay.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-hubble-relay.yaml
@@ -1,7 +1,7 @@
 ---
 # Hubble-relay doit se connecter aux cilium agents sur chaque node
 # Port 4244 = cilium agent gRPC (Hubble observer)
-# enableDefaultDeny: false = additif seulement
+# enableDefaultDeny: true = default-deny actif (ingress + egress)
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
@@ -12,8 +12,8 @@ spec:
       io.kubernetes.pod.namespace: kube-system
       k8s-app: hubble-relay
   enableDefaultDeny:
-    ingress: false
-    egress: false
+    ingress: true
+    egress: true
   egress:
     - toEntities:
         - host

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-kube-apiserver.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-kube-apiserver.yaml
@@ -2,7 +2,7 @@
 # Autorise tous les pods à joindre le kube-apiserver (port 6443)
 # Nécessaire pour les opérateurs/controllers : cert-manager, kyverno, ArgoCD, etc.
 # egress: [{}] ne couvre pas l'entité réservée kube-apiserver avec enableDefaultDeny
-# enableDefaultDeny: false = additif seulement, ne bloque pas le reste de l'egress
+# enableDefaultDeny: true = default-deny actif (ingress + egress)
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
@@ -10,8 +10,8 @@ metadata:
 spec:
   endpointSelector: {}
   enableDefaultDeny:
-    ingress: false
-    egress: false
+    ingress: true
+    egress: true
   egress:
     - toEntities:
         - kube-apiserver

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-prometheus.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-prometheus.yaml
@@ -1,6 +1,6 @@
 ---
 # Autorise vmagent (monitoring) à scraper les métriques de tous les pods
-# enableDefaultDeny: false = additif seulement, ne bloque pas le reste de l'ingress
+# enableDefaultDeny: true = default-deny actif (ingress + egress)
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
@@ -8,8 +8,8 @@ metadata:
 spec:
   endpointSelector: {}
   enableDefaultDeny:
-    ingress: false
-    egress: false
+    ingress: true
+    egress: true
   ingress:
     - fromEndpoints:
         - matchLabels:

--- a/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-traefik.yaml
+++ b/apps/00-infra/cilium-lb/overlays/prod/ccnp-allow-traefik.yaml
@@ -1,6 +1,6 @@
 ---
 # Autorise Traefik à accéder à tous les pods applicatifs (ingress)
-# enableDefaultDeny: false = additif seulement, ne bloque pas le reste de l'ingress
+# enableDefaultDeny: true = default-deny actif sur tous les pods (ingress + egress)
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
 metadata:
@@ -8,8 +8,8 @@ metadata:
 spec:
   endpointSelector: {}
   enableDefaultDeny:
-    ingress: false
-    egress: false
+    ingress: true
+    egress: true
   ingress:
     - fromEndpoints:
         - matchLabels:


### PR DESCRIPTION
## Summary

After **16 rounds** of iterative defaultDeny testing (enable CCNPs → Hubble observe → identify gaps → fix CNPs → re-test), **Round 16 confirmed 0 actionable POLICY_DENIED drops** across all 5 prod nodes.

This PR permanently enables `enableDefaultDeny: {egress: true, ingress: true}` on all 8 prod `CiliumClusterwideNetworkPolicy` resources.

## CCNPs updated (8)

| CCNP | Before | After |
|------|--------|-------|
| `allow-cilium-health` | `{egress: false, ingress: false}` | `{egress: true, ingress: true}` |
| `allow-coredns-upstream-egress` | `{egress: false, ingress: false}` | `{egress: true, ingress: true}` |
| `allow-coredns-ingress` | `{egress: false, ingress: false}` | `{egress: true, ingress: true}` |
| `allow-coredns-egress` | `{egress: false, ingress: false}` | `{egress: true, ingress: true}` |
| `allow-hubble-relay` | `{egress: false, ingress: false}` | `{egress: true, ingress: true}` |
| `allow-kube-apiserver-egress` | `{egress: false, ingress: false}` | `{egress: true, ingress: true}` |
| `allow-prometheus-scrape` | `{egress: false, ingress: false}` | `{egress: true, ingress: true}` |
| `allow-traefik-ingress` | `{egress: false, ingress: false}` | `{egress: true, ingress: true}` |

## PRs in this defaultDeny series (PRs #3008–#3018)

| PR | Fix |
|----|-----|
| #3008 | ArgoCD egress, infisical-operator, traefik, fluent-bit, keda-metrics-apiserver |
| #3009 | victoria-metrics-operator webhook port 9443, vmagent scraping |
| #3010 | traefik world unrestricted, amule gluetun, external-dns-unifi, firefly-iii port fix, keda-http-add-on |
| #3011 | vmagent kubelet:10250 + node-exporter:9100, fluent-bit-syslog |
| #3012 | amule world egress, firefly-iii databases + kube-apiserver, firefly-iii-cron CNP |
| #3013 | qbittorrent P2P egress, firefly-iii world egress, keda intra-ns ingress |
| #3014 | keda intra-namespace ingress (keda-operator + keda-http-add-on) |
| #3015 | snmp-exporter SNMP:161/UDP egress |
| #3016 | keda-operator egress + keda-metrics-apiserver egress + vikunja egress |
| #3017 | keda-operator → databases/postgresql:5432 (PostgreSQL ScaledObject triggers) |
| **#3018** | **This PR: permanent defaultDeny on all 8 CCNPs** |

## Test plan

- [ ] Merge + promote to prod
- [ ] Verify ArgoCD syncs all 8 CCNPs on prod
- [ ] Monitor Hubble for unexpected drops (none expected)
- [ ] Confirm all services remain healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network security policies across infrastructure services to enforce default-deny behavior for both ingress and egress traffic directions. All explicitly configured and allowed traffic continues to function as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->