### PR TITLE
fix(cnp): add egress rules revealed by permanent defaultDeny (Round 17)

### DIFF
--- a/apps/00-infra/crowdsec/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/crowdsec/base/cilium-networkpolicy.yaml
@@ -13,6 +13,15 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # crowdsec-agent → crowdsec-lapi:8080 (push decisions/alerts)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: crowdsec
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
 ---
 # crowdsec-lapi — reçoit des requêtes de Traefik (bouncer), agents crowdsec et monitoring
 apiVersion: cilium.io/v2
@@ -37,3 +46,19 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # crowdsec-lapi → databases (PostgreSQL for decisions/bans storage)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # crowdsec-lapi → world (CrowdSec Central API for community blocklists)
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/apps/00-infra/velero/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/velero/base/cilium-networkpolicy.yaml
@@ -13,3 +13,10 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # velero → world (NAS/MinIO at 192.168.111.69:9000 for backup storage)
+    - toEntities:
+        - world
+    # velero → kube-apiserver (watch/restore cluster resources)
+    - toEntities:
+        - kube-apiserver

--- a/apps/20-media/birdnet-go/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/birdnet-go/base/cilium-networkpolicy.yaml
@@ -19,5 +19,7 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # birdnet-go → world (NAS/MinIO at 192.168.111.69:9000 for recordings)
     - toEntities:
         - world

--- a/apps/20-media/pyload/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/pyload/base/cilium-networkpolicy.yaml
@@ -19,3 +19,7 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # pyload → world (download sources, NAS/MinIO at 192.168.111.69:9000)
+    - toEntities:
+        - world

--- a/apps/40-network/external-dns-gandi/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/external-dns-gandi/base/cilium-networkpolicy.yaml
@@ -12,3 +12,14 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # external-dns-gandi → Gandi LiveDNS API (213.167.231.x:443)
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # external-dns-gandi → kube-apiserver (watch Ingress/Service resources)
+    - toEntities:
+        - kube-apiserver

--- a/apps/70-tools/nexterm/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/nexterm/base/cilium-networkpolicy.yaml
@@ -19,3 +19,7 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # nexterm → world (SSH targets, external servers)
+    - toEntities:
+        - world

--- a/apps/70-tools/trilium/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/trilium/base/cilium-networkpolicy.yaml
@@ -19,3 +19,7 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # trilium → world (NAS/MinIO at 192.168.111.69:9000 for attachments)
+    - toEntities:
+        - world


### PR DESCRIPTION
## Summary

After permanently enabling `enableDefaultDeny: {egress: true, ingress: true}` (PR #3018), continuous Hubble monitoring revealed 7 additional CNP gaps across 6 apps that were missed during the timed test rounds.

## Fixes

| App | Gap | Fix |
|-----|-----|-----|
| `crowdsec-agent` | No egress → crowdsec-lapi:8080 | Added egress to crowdsec namespace:8080 |
| `crowdsec-lapi` | No egress → databases:5432 or world | Added egress to databases:5432 + world:443 (Central API) |
| `birdnet-go` | `toEntities: world` in **ingress** section (invalid) | Moved to `egress` section |
| `trilium` | No egress | Added egress → world (NAS/MinIO attachments) |
| `nexterm` | No egress | Added egress → world (SSH targets) |
| `external-dns-gandi` | No egress | Added egress → world:443 + kube-apiserver |
| `velero` | No egress | Added egress → world + kube-apiserver |
| `pyload` | No egress | Added egress → world |

**Note:** `external-dns-unifi` was a stale ArgoCD sync issue (managed by `external-dns-unifi-secrets` app on old revision), not a CNP gap — fixed by force-syncing the app.

## Test plan

- [ ] Merge + promote to prod
- [ ] Force-sync affected ArgoCD apps
- [ ] Monitor Hubble for drops → expect 0 actionable drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)