### PR TITLE
fix(cnp): fix selectors and add egress rules (Round 18)

### DIFF
--- a/apps/00-infra/policy-reporter/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/policy-reporter/base/cilium-networkpolicy.yaml
@@ -20,6 +20,18 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # policy-reporter → policy-reporter-ui:8080 (backend pushes results to UI)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: policy-reporter
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # policy-reporter → kube-apiserver (watch PolicyReport CRDs)
+    - toEntities:
+        - kube-apiserver
 ---
 # policy-reporter kyverno-plugin
 apiVersion: cilium.io/v2

--- a/apps/04-databases/cloudnative-pg/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/cloudnative-pg/base/cilium-networkpolicy.yaml
@@ -19,3 +19,14 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # cloudnative-pg operator → databases (barman backup API port 8000, PostgreSQL)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+    # cloudnative-pg operator → kube-apiserver (watch PostgreSQL cluster CRDs)
+    - toEntities:
+        - kube-apiserver
+    # cloudnative-pg operator → world (MinIO/NAS for backup archives)
+    - toEntities:
+        - world

--- a/apps/04-databases/postgresql-shared/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/postgresql-shared/base/cilium-networkpolicy.yaml
@@ -46,3 +46,11 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # postgresql-shared → world (NAS/MinIO at 192.168.111.69:9000 for WAL archiving via barman)
+    - toEntities:
+        - world
+    # postgresql-shared → CNPG operator barman API + intra-cluster replication
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases

--- a/apps/40-network/external-dns-gandi/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/external-dns-gandi/base/cilium-networkpolicy.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   endpointSelector:
     matchLabels:
-      app.kubernetes.io/name: external-dns-gandi
+      app.kubernetes.io/instance: external-dns-gandi
   ingress:
     - fromEndpoints:
         - matchLabels:

--- a/apps/40-network/external-dns-unifi/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/external-dns-unifi/base/cilium-networkpolicy.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   endpointSelector:
     matchLabels:
-      app.kubernetes.io/name: external-dns-unifi
+      app.kubernetes.io/instance: external-dns-unifi
   ingress:
     - fromEndpoints:
         - matchLabels:

--- a/apps/70-tools/nocodb/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/nocodb/base/cilium-networkpolicy.yaml
@@ -19,3 +19,11 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # nocodb → world (NAS/MinIO at 192.168.111.69:9000 for file storage)
+    - toEntities:
+        - world
+    # nocodb → databases (PostgreSQL/MariaDB)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases


### PR DESCRIPTION
## Summary

Continuous Hubble monitoring after PR #3018 (permanent defaultDeny) revealed 6 more gaps.

## Fixes

### Selector fixes
| CNP | Before | After |
|-----|--------|-------|
| `external-dns-unifi` | `app.kubernetes.io/name: external-dns-unifi` | `app.kubernetes.io/instance: external-dns-unifi` |
| `external-dns-gandi` | `app.kubernetes.io/name: external-dns-gandi` | `app.kubernetes.io/instance: external-dns-gandi` |

Both use the `external-dns` Helm chart which sets `app.kubernetes.io/name: external-dns` on all pods. Instance label differentiates them.

### Missing egress
| App | Gap | Fix |
|-----|-----|-----|
| `postgresql-shared` | No egress → world (MinIO/NAS barman WAL archiving) | Added `toEntities: world` + `toEndpoints: databases` |
| `cloudnative-pg` | No egress → databases:8000 (barman backup API) | Added `toEndpoints: databases` + kube-apiserver + world |
| `policy-reporter` | No egress → policy-reporter-ui:8080 | Added intra-namespace egress:8080 + kube-apiserver |
| `nocodb` | No egress → world or databases | Added `toEntities: world` + `toEndpoints: databases` |

## Test plan

- [ ] Merge + promote to prod
- [ ] Force-sync affected ArgoCD apps
- [ ] Monitor Hubble → expect 0 actionable drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)