### PR TITLE
fix(cnp): fix CNP placement for velero/cloudnative-pg, add trivy egress

### DIFF
--- a/apps/00-infra/velero/overlays/prod/cilium-networkpolicy.yaml
+++ b/apps/00-infra/velero/overlays/prod/cilium-networkpolicy.yaml
@@ -1,0 +1,22 @@
+---
+# velero server
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: velero
+  namespace: velero
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: velero
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+  egress:
+    # velero → world (NAS/MinIO at 192.168.111.69:9000 for backup storage)
+    - toEntities:
+        - world
+    # velero → kube-apiserver (watch/restore cluster resources)
+    - toEntities:
+        - kube-apiserver

--- a/apps/00-infra/velero/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/velero/overlays/prod/kustomization.yaml
@@ -3,7 +3,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 # Velero is Helm-managed (multi-source). Patches target Helm-rendered Deployments via ArgoCD SSA.
-resources: []
+resources:
+  - cilium-networkpolicy.yaml
 
 patches:
   - patch: |-

--- a/apps/03-security/trivy/base/cilium-networkpolicy.yaml
+++ b/apps/03-security/trivy/base/cilium-networkpolicy.yaml
@@ -12,3 +12,28 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # trivy-operator → kube-apiserver (watch/create VulnerabilityReports)
+    - toEntities:
+        - kube-apiserver
+    # trivy-operator → world (pull images from registries for scanning)
+    - toEntities:
+        - world
+---
+# scan-vulnerabilityreport jobs spawned by trivy-operator to scan images
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: trivy-scan-jobs
+  namespace: security
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/managed-by: trivy-operator
+  egress:
+    # scan jobs → world (pull images from container registries)
+    - toEntities:
+        - world
+    # scan jobs → kube-apiserver (report results)
+    - toEntities:
+        - kube-apiserver

--- a/apps/04-databases/cloudnative-pg/overlays/prod/cilium-networkpolicy.yaml
+++ b/apps/04-databases/cloudnative-pg/overlays/prod/cilium-networkpolicy.yaml
@@ -1,0 +1,32 @@
+---
+# cloudnative-pg operator — reçoit des appels webhook de kube-apiserver
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cloudnative-pg
+  namespace: cnpg-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: cloudnative-pg
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "9443"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+  egress:
+    # cloudnative-pg operator → databases (barman backup API port 8000, PostgreSQL)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+    # cloudnative-pg operator → kube-apiserver (watch PostgreSQL cluster CRDs)
+    - toEntities:
+        - kube-apiserver
+    # cloudnative-pg operator → world (MinIO/NAS for backup archives)
+    - toEntities:
+        - world

--- a/apps/04-databases/cloudnative-pg/overlays/prod/kustomization.yaml
+++ b/apps/04-databases/cloudnative-pg/overlays/prod/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: cnpg-system
 resources:
   - servicemonitor.yaml
   - pdb.yaml
-  - ../../base/cilium-networkpolicy.yaml
+  - cilium-networkpolicy.yaml
 
 components:
   - ../../../../_shared/components/poddisruptionbudget/1


### PR DESCRIPTION
## Summary

Continuous Hubble monitoring revealed that velero and cloudnative-pg CNPs were never actually deployed to prod cluster despite being in Git.

## Root Causes

### cloudnative-pg
The prod overlay referenced `../../base/cilium-networkpolicy.yaml` — a path traversal that kustomize blocks via its security restriction. ArgoCD marked the app as `Unknown` with `ComparisonError: file is not in or below overlays/prod`.

**Fix:** Copy CNP to `overlays/prod/cilium-networkpolicy.yaml` and reference locally.

### velero  
The prod overlay had `resources: []` — the CNP in `base/` was never included.

**Fix:** Add `cilium-networkpolicy.yaml` to prod overlay resources.

### trivy-operator scan jobs
`security/scan-vulnerabilityreport-*` jobs (spawned by trivy-operator) had no egress to pull container images from registries.

**Fix:** 
- trivy-operator: add egress → world + kube-apiserver
- scan jobs (`app.kubernetes.io/managed-by: trivy-operator`): add egress → world + kube-apiserver

## Test plan

- [ ] Merge + promote to prod
- [ ] Force-sync cloudnative-pg and velero ArgoCD apps
- [ ] Verify CNPs appear in cnpg-system and velero namespaces
- [ ] Monitor Hubble → expect 0 actionable drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)