### PR TITLE
fix(dataangel): bump to sha-2957234 — fix nil pointer panic on iSCSI

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -169,6 +169,11 @@ spec:
                   d.setdefault('plugins', {}).setdefault('entries', {})['claw-hass'] = {'enabled': False}
                   # Enable kilocode plugin (kilo.ai gateway — MiniMax, etc.)
                   d['plugins']['entries']['kilocode'] = {'enabled': True}
+                  # Register kilocode auth profile (required for UI to show provider as authenticated)
+                  d.setdefault('auth', {}).setdefault('profiles', {}).setdefault('kilocode:default', {
+                      'provider': 'kilocode',
+                      'mode': 'api_key',
+                  })
                   # Ensure google-gemini-cli provider has gemini-3-flash-preview
                   # NOTE: only inject if the provider already exists (openclaw manages baseUrl internally)
                   # Creating it from scratch leaves baseUrl=undefined which fails validation

--- a/apps/_shared/components/dataangel/kustomization.yaml
+++ b/apps/_shared/components/dataangel/kustomization.yaml
@@ -105,4 +105,4 @@ patches:
 
 images:
   - name: charchess/dataangel
-    newTag: "sha-c6cb960"
+    newTag: "sha-2957234"


### PR DESCRIPTION
## Summary
- Bumps dataAngel image `sha-c6cb960` → `sha-2957234`
- Fix: `os.IsNotExist` → `err != nil` in restoreSQLite + nil check before `.Size()` (truxonline/dataAngel#45 #46)
- Unblocks frigate which was stuck in `Init:CrashLoopBackOff` on the iSCSI cache PVC

## Test plan
- [ ] Frigate pod starts cleanly (init container passes restore phase)
- [ ] No panic in dataangel logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication setup for the kilocode provider
  * Updated dataangel service to the latest version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->