### PR TITLE
fix(openclaw): extend LLM idle timeout to 300s for kimi thinking time

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -228,7 +228,8 @@ spec:
                       'moonshot/kimi-k2.5': {'alias': 'Kimi'},
                       'kilocode/moonshotai/kimi-k2.5': {'alias': 'Kimi (kilocode)'},
                   })
-                  print('Default model: moonshot/kimi-k2.5')
+                  agent_defaults.setdefault('llm', {})['idleTimeoutSeconds'] = 300
+                  print('Default model: moonshot/kimi-k2.5, idleTimeout: 300s')
                   json.dump(d, open(p, 'w'))
                   print('Config keys checked')
 


### PR DESCRIPTION
## Summary
- Set `agents.defaults.llm.idleTimeoutSeconds = 300` (was 120s default)
- Kimi K2.5 can take time for complex reasoning — 2min timeout too short

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated default agent model selection
  * Added explicit idle timeout configuration (300 seconds)

* **Authentication**
  * Added support for MOONSHOT_API_KEY environment variable configuration
  * Automatic auth-profile generation when API key is present

<!-- end of auto-generated comment: release notes by coderabbit.ai -->