### PR TITLE
fix(openclaw): disable LLM idle timeout for kimi reasoning, set 10min hard cap

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -228,7 +228,8 @@ spec:
                       'moonshot/kimi-k2.5': {'alias': 'Kimi'},
                       'kilocode/moonshotai/kimi-k2.5': {'alias': 'Kimi (kilocode)'},
                   })
-                  print('Default model: moonshot/kimi-k2.5')
+                  agent_defaults.setdefault('llm', {})['idleTimeoutSeconds'] = 300
+                  print('Default model: moonshot/kimi-k2.5, idleTimeout: 300s')
                   json.dump(d, open(p, 'w'))
                   print('Config keys checked')
 

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -233,8 +233,8 @@ spec:
                   # timeoutSeconds=1800: large session contexts need up to 30min to reason.
                   agent_defaults.setdefault('llm', {})['idleTimeoutSeconds'] = 0
                   agent_defaults['timeoutSeconds'] = 1800
-                  agent_defaults['compaction'] = {'mode': 'auto'}
-                  print('Default model: moonshot/kimi-k2.5, idleTimeout: disabled, total: 1800s, compaction: auto')
+                  agent_defaults['compaction'] = {'mode': 'safeguard'}
+                  print('Default model: moonshot/kimi-k2.5, idleTimeout: disabled, total: 1800s, compaction: safeguard')
                   json.dump(d, open(p, 'w'))
                   print('Config keys checked')
 

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -222,18 +222,17 @@ spec:
                   agent_defaults = d.setdefault('agents', {}).setdefault('defaults', {})
                   agent_defaults['model'] = {
                       'primary': 'moonshot/kimi-k2.5',
-                      'fallbacks': ['kilocode/moonshotai/kimi-k2.5', 'cerebras/qwen-3-235b-a22b-instruct-2507'],
+                      'fallbacks': ['anthropic/claude-3-5-haiku-20241022'],
                   }
                   agent_defaults.setdefault('models', {}).update({
                       'moonshot/kimi-k2.5': {'alias': 'Kimi'},
-                      'kilocode/moonshotai/kimi-k2.5': {'alias': 'Kimi (kilocode)'},
                   })
-                  # idleTimeoutSeconds=0: kimi-k2.5 is a reasoning model — it thinks silently
-                  # before streaming tokens. Idle timeout fires during reasoning phase.
-                  # timeoutSeconds=600: hard cap for truly hung requests.
+                  # idleTimeoutSeconds=0: kimi-k2.5 is a reasoning model — thinks silently
+                  # before streaming. Idle timeout fires during silent reasoning phase.
+                  # timeoutSeconds=1800: large session contexts need up to 30min to reason.
                   agent_defaults.setdefault('llm', {})['idleTimeoutSeconds'] = 0
-                  agent_defaults['timeoutSeconds'] = 600
-                  print('Default model: moonshot/kimi-k2.5, idleTimeout: disabled, total: 600s')
+                  agent_defaults['timeoutSeconds'] = 1800
+                  print('Default model: moonshot/kimi-k2.5, idleTimeout: disabled, total: 1800s')
                   json.dump(d, open(p, 'w'))
                   print('Config keys checked')
 

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -233,7 +233,8 @@ spec:
                   # timeoutSeconds=1800: large session contexts need up to 30min to reason.
                   agent_defaults.setdefault('llm', {})['idleTimeoutSeconds'] = 0
                   agent_defaults['timeoutSeconds'] = 1800
-                  print('Default model: moonshot/kimi-k2.5, idleTimeout: disabled, total: 1800s')
+                  agent_defaults['compaction'] = {'mode': 'auto'}
+                  print('Default model: moonshot/kimi-k2.5, idleTimeout: disabled, total: 1800s, compaction: auto')
                   json.dump(d, open(p, 'w'))
                   print('Config keys checked')
 

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -222,10 +222,11 @@ spec:
                   agent_defaults = d.setdefault('agents', {}).setdefault('defaults', {})
                   agent_defaults['model'] = {
                       'primary': 'moonshot/kimi-k2.5',
-                      'fallbacks': ['anthropic/claude-3-5-haiku-20241022'],
+                      'fallbacks': ['google-gemini-cli/gemini-3.1-flash-preview'],
                   }
                   agent_defaults.setdefault('models', {}).update({
                       'moonshot/kimi-k2.5': {'alias': 'Kimi'},
+                      'google-gemini-cli/gemini-3.1-flash-preview': {'alias': 'Gemini Flash'},
                   })
                   # idleTimeoutSeconds=0: kimi-k2.5 is a reasoning model — thinks silently
                   # before streaming. Idle timeout fires during silent reasoning phase.

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -228,8 +228,12 @@ spec:
                       'moonshot/kimi-k2.5': {'alias': 'Kimi'},
                       'kilocode/moonshotai/kimi-k2.5': {'alias': 'Kimi (kilocode)'},
                   })
-                  agent_defaults.setdefault('llm', {})['idleTimeoutSeconds'] = 300
-                  print('Default model: moonshot/kimi-k2.5, idleTimeout: 300s')
+                  # idleTimeoutSeconds=0: kimi-k2.5 is a reasoning model — it thinks silently
+                  # before streaming tokens. Idle timeout fires during reasoning phase.
+                  # timeoutSeconds=600: hard cap for truly hung requests.
+                  agent_defaults.setdefault('llm', {})['idleTimeoutSeconds'] = 0
+                  agent_defaults['timeoutSeconds'] = 600
+                  print('Default model: moonshot/kimi-k2.5, idleTimeout: disabled, total: 600s')
                   json.dump(d, open(p, 'w'))
                   print('Config keys checked')
 


### PR DESCRIPTION
## Summary
- `idleTimeoutSeconds = 0` (disabled) — kimi-k2.5 is a reasoning model that thinks silently before streaming tokens; idle timeout fires during reasoning phase causing false failures
- `timeoutSeconds = 600` — 10min hard cap for truly hung requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated default AI models for agents to include Google Gemini Flash as a primary option.

* **Chores**
  * Modified agent timeout configuration for improved performance during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->