### PR TITLE
fix(openclaw): remove model config from init container

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -218,22 +218,9 @@ spec:
                       control_ui['dangerouslyAllowHostHeaderOriginFallback'] = True
                       print('gateway.controlUi fallback enabled')
                   gateway_cfg.pop('agentModel', None)
-                  # Always force agents default to moonshot/kimi-k2.5 (direct Moonshot API)
-                  agent_defaults = d.setdefault('agents', {}).setdefault('defaults', {})
-                  agent_defaults['model'] = {
-                      'primary': 'moonshot/kimi-k2.5',
-                      'fallbacks': ['kilocode/moonshotai/kimi-k2.5', 'cerebras/qwen-3-235b-a22b-instruct-2507'],
-                  }
-                  agent_defaults.setdefault('models', {}).update({
-                      'moonshot/kimi-k2.5': {'alias': 'Kimi'},
-                      'kilocode/moonshotai/kimi-k2.5': {'alias': 'Kimi (kilocode)'},
-                  })
-                  # idleTimeoutSeconds=0: kimi-k2.5 is a reasoning model — it thinks silently
-                  # before streaming tokens. Idle timeout fires during reasoning phase.
-                  # timeoutSeconds=600: hard cap for truly hung requests.
-                  agent_defaults.setdefault('llm', {})['idleTimeoutSeconds'] = 0
-                  agent_defaults['timeoutSeconds'] = 600
-                  print('Default model: moonshot/kimi-k2.5, idleTimeout: disabled, total: 600s')
+                  # NOTE: agent model config (primary, fallbacks, timeouts) lives in
+                  # /data/openclaw.json and is managed via DataAngel backup/restore.
+                  # Do NOT inject model config here — it would overwrite the restored config.
                   json.dump(d, open(p, 'w'))
                   print('Config keys checked')
 

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -228,8 +228,12 @@ spec:
                       'moonshot/kimi-k2.5': {'alias': 'Kimi'},
                       'kilocode/moonshotai/kimi-k2.5': {'alias': 'Kimi (kilocode)'},
                   })
-                  agent_defaults.setdefault('llm', {})['idleTimeoutSeconds'] = 300
-                  print('Default model: moonshot/kimi-k2.5, idleTimeout: 300s')
+                  # idleTimeoutSeconds=0: kimi-k2.5 is a reasoning model — it thinks silently
+                  # before streaming tokens. Idle timeout fires during reasoning phase.
+                  # timeoutSeconds=600: hard cap for truly hung requests.
+                  agent_defaults.setdefault('llm', {})['idleTimeoutSeconds'] = 0
+                  agent_defaults['timeoutSeconds'] = 600
+                  print('Default model: moonshot/kimi-k2.5, idleTimeout: disabled, total: 600s')
                   json.dump(d, open(p, 'w'))
                   print('Config keys checked')
 


### PR DESCRIPTION
## Summary

- Supprime le bloc d'injection de model config (`agents.defaults.model`, fallbacks, timeouts) de l'init container `setup-config`
- La config agent appartient à `/data/openclaw.json`, gérée directement et persistée via DataAngel → MinIO
- L'init container écrasait la config restaurée par DataAngel à chaque restart — anti-pattern

## What stays in init container

- Nettoyage clés legacy, plugin overrides, fixes compat modèles, gateway.controlUi
- **Refresh OAuth token Gemini** (expire 1h, vient des secrets K8s)
- **Injection API keys** dans auth-profiles.json (secrets K8s, pas dans MinIO)

## What moved to /data/openclaw.json (DataAngel-managed)

- `agents.defaults.model.primary/fallbacks`, `idleTimeoutSeconds`, `timeoutSeconds`, `compaction.mode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated how agent model configurations are managed to use external backup and restore processes instead of hardcoded defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->