### PR TITLE
fix(openclaw): expose KILOCODE_API_KEY and MOONSHOT_API_KEY to main container

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -510,6 +510,16 @@ spec:
                 secretKeyRef:
                   name: openclaw-secrets
                   key: CEREBRAS_API_KEY
+            - name: KILOCODE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw-secrets
+                  key: KILOCODE_API_KEY
+            - name: MOONSHOT_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw-secrets
+                  key: MOONSHOT_API_KEY
           livenessProbe:
             tcpSocket:
               port: 18789


### PR DESCRIPTION
## Summary
- Add `KILOCODE_API_KEY` and `MOONSHOT_API_KEY` env vars to the main openclaw container
- The kilocode plugin uses dynamic model discovery (`buildKilocodeProviderWithDiscovery`) which requires `KILOCODE_API_KEY` at runtime — without it, all `kilocode/*` model IDs return "Unknown model"
- MOONSHOT_API_KEY added for symmetry (plugin may also use it for validation)

## Root Cause
`envFrom: secretRef` was only on the init container. Main container had explicit `env:` entries only for `OPENCLAW_GATEWAY_TOKEN`, `DISCORD_TOKEN`, `CEREBRAS_API_KEY` — kilocode/moonshot keys were missing.

## Test plan
- [ ] Pod redeploys with new env vars
- [ ] `kilocode/kilo/auto` resolves correctly (no "Unknown model" error)
- [ ] Lisa responds via kilocode

🤖 Generated with [Claude Code](https://claude.com/claude-code)