### PR TITLE
fix(openclaw): expose GEMINI_API_KEY for Google AI Studio provider

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -520,6 +520,11 @@ spec:
                 secretKeyRef:
                   name: openclaw-secrets
                   key: MOONSHOT_API_KEY
+            - name: GEMINI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw-secrets
+                  key: GEMINI_API_KEY
           livenessProbe:
             tcpSocket:
               port: 18789


### PR DESCRIPTION
## Summary
- Add `GEMINI_API_KEY` env var to main openclaw container
- Enables `google` plugin (AI Studio API) as alternative to `google-gemini-cli` (OAuth, rate-limited)
- Primary model: `google/gemini-2.5-flash-preview-05-20`, fallback: `kilocode/kilo/auto`

## Why
`google-gemini-cli` uses fair-use OAuth limits. Google AI Studio API key gives 1500 req/day on Flash — no fair-use throttling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to enable Gemini API integration in the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->