### PR TITLE
feat(openclaw): add avoid-i915 scheduling preference on prod

### DIFF
--- a/apps/60-services/openclaw/overlays/prod/kustomization.yaml
+++ b/apps/60-services/openclaw/overlays/prod/kustomization.yaml
@@ -11,6 +11,7 @@ components:
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/dataangel
   - ../../../../_shared/components/poddisruptionbudget/1
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: dataangel.yaml


### PR DESCRIPTION
## Summary
- Openclaw n'a pas besoin de GPU i915
- Ajoute `avoid-i915` (weight 80, soft) pour préférer les nœuds sans GPU
- Libère poison/powder/phoebe pour frigate et homeassistant
- Permet à openclaw de migrer hors de poison au prochain restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)