### PR TITLE
fix(openclaw): avoid i915 node + ensure Gemini Flash 3 as first fallback

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -218,19 +218,9 @@ spec:
                       control_ui['dangerouslyAllowHostHeaderOriginFallback'] = True
                       print('gateway.controlUi fallback enabled')
                   gateway_cfg.pop('agentModel', None)
-                  # Ensure google-gemini-cli/gemini-3-flash-preview is first fallback.
-                  # Idempotent: only reorders, never removes user-added fallbacks.
-                  gemini_flash = 'google-gemini-cli/gemini-3-flash-preview'
-                  agents_def = d.setdefault('agents', {}).setdefault('defaults', {})
-                  model_def = agents_def.setdefault('model', {})
-                  fallbacks = model_def.get('fallbacks', [])
-                  if not fallbacks or fallbacks[0] != gemini_flash:
-                      model_def['fallbacks'] = [gemini_flash] + [f for f in fallbacks if f != gemini_flash]
-                      print('Ensured Gemini Flash 3 as first fallback')
-                  # Ensure alias is set
-                  models_aliases = agents_def.setdefault('models', {})
-                  if gemini_flash not in models_aliases:
-                      models_aliases[gemini_flash] = {'alias': 'Gemini Flash 3'}
+                  # NOTE: agent model config (primary, fallbacks, timeouts) lives in
+                  # /data/openclaw.json and is managed via DataAngel backup/restore.
+                  # Do NOT inject model config here — it would overwrite the restored config.
                   json.dump(d, open(p, 'w'))
                   print('Config keys checked')
 

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -218,9 +218,19 @@ spec:
                       control_ui['dangerouslyAllowHostHeaderOriginFallback'] = True
                       print('gateway.controlUi fallback enabled')
                   gateway_cfg.pop('agentModel', None)
-                  # NOTE: agent model config (primary, fallbacks, timeouts) lives in
-                  # /data/openclaw.json and is managed via DataAngel backup/restore.
-                  # Do NOT inject model config here — it would overwrite the restored config.
+                  # Ensure google-gemini-cli/gemini-3-flash-preview is first fallback.
+                  # Idempotent: only reorders, never removes user-added fallbacks.
+                  gemini_flash = 'google-gemini-cli/gemini-3-flash-preview'
+                  agents_def = d.setdefault('agents', {}).setdefault('defaults', {})
+                  model_def = agents_def.setdefault('model', {})
+                  fallbacks = model_def.get('fallbacks', [])
+                  if not fallbacks or fallbacks[0] != gemini_flash:
+                      model_def['fallbacks'] = [gemini_flash] + [f for f in fallbacks if f != gemini_flash]
+                      print('Ensured Gemini Flash 3 as first fallback')
+                  # Ensure alias is set
+                  models_aliases = agents_def.setdefault('models', {})
+                  if gemini_flash not in models_aliases:
+                      models_aliases[gemini_flash] = {'alias': 'Gemini Flash 3'}
                   json.dump(d, open(p, 'w'))
                   print('Config keys checked')
 

--- a/apps/60-services/openclaw/overlays/prod/kustomization.yaml
+++ b/apps/60-services/openclaw/overlays/prod/kustomization.yaml
@@ -11,6 +11,7 @@ components:
   - ../../../../_shared/components/goldilocks/enabled
   - ../../../../_shared/components/dataangel
   - ../../../../_shared/components/poddisruptionbudget/1
+  - ../../../../_shared/components/scheduling/avoid-i915
 
 patches:
   - path: dataangel.yaml


### PR DESCRIPTION
## Summary

- Add `avoid-i915` soft scheduling preference on prod so OpenClaw avoids the GPU node (peach)
- Ensure `google-gemini-cli/gemini-3-flash-preview` is always first fallback in `agents.defaults.model.fallbacks` via idempotent injection in `setup-config` init container

## Why

- DataAngel backup broken since 2026-04-19 → direct edits to `/data/openclaw.json` don't survive pod restarts (DataAngel restore brings back old config)
- Without persistent injection, Lisa falls back to kimi-k2.5 (Moonshot) which has 30min timeout issues

## Test plan

- [ ] PR merges cleanly to main → ArgoCD syncs openclaw on dev
- [ ] On next openclaw pod restart: verify `fallbacks[0] == 'google-gemini-cli/gemini-3-flash-preview'`
- [ ] Lisa uses Gemini Flash 3 for default requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenCLAW service deployment configuration to properly handle model defaults.
  * Added GPU scheduling optimization to production environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->