### PR TITLE
feat(databases+home): mongodb-shared + nightscout (#3037)

### DIFF
--- a/apps/04-databases/mongodb-shared/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/mongodb-shared/base/cilium-networkpolicy.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: mongodb-shared
+spec:
+  endpointSelector:
+    matchLabels:
+      app: mongodb-shared
+  ingress:
+    # fromEndpoints: [{}] cassé dans Cilium 1.18.3 → fromEntities: cluster
+    - fromEntities:
+        - cluster
+      toPorts:
+        - ports:
+            - port: "27017"
+              protocol: TCP

--- a/apps/04-databases/mongodb-shared/base/infisical-secret.yaml
+++ b/apps/04-databases/mongodb-shared/base/infisical-secret.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: mongodb-shared-credentials
+  namespace: databases
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  hostAPI: http://192.168.111.69:8085
+  authentication:
+    universalAuth:
+      credentialsRef:
+        secretName: infisical-universal-auth
+        secretNamespace: argocd
+      secretsScope:
+        projectSlug: vixens
+        envSlug: dev
+        secretsPath: /apps/04-databases/mongodb-shared
+  managedSecretReference:
+    secretName: mongodb-shared-credentials
+    creationPolicy: Owner
+    secretNamespace: databases

--- a/apps/04-databases/mongodb-shared/base/kustomization.yaml
+++ b/apps/04-databases/mongodb-shared/base/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - infisical-secret.yaml
+  - statefulset.yaml
+  - service.yaml
+  - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
+  - pdb.yaml

--- a/apps/04-databases/mongodb-shared/base/networkpolicy.yaml
+++ b/apps/04-databases/mongodb-shared/base/networkpolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mongodb-shared
+spec:
+  podSelector:
+    matchLabels:
+      app: mongodb-shared
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 27017
+  egress:
+    - {}

--- a/apps/04-databases/mongodb-shared/base/pdb.yaml
+++ b/apps/04-databases/mongodb-shared/base/pdb.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: mongodb-shared
+spec:
+  selector:
+    matchLabels:
+      app: mongodb-shared

--- a/apps/04-databases/mongodb-shared/base/service.yaml
+++ b/apps/04-databases/mongodb-shared/base/service.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb-shared
+spec:
+  ports:
+    - port: 27017
+      targetPort: 27017
+      name: mongodb
+  selector:
+    app: mongodb-shared

--- a/apps/04-databases/mongodb-shared/base/statefulset.yaml
+++ b/apps/04-databases/mongodb-shared/base/statefulset.yaml
@@ -1,0 +1,188 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongodb-shared
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+spec:
+  serviceName: mongodb-shared
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mongodb-shared
+  template:
+    metadata:
+      labels:
+        app: mongodb-shared
+        vixens.io/sizing.mongodb: SB-micro
+        vixens.io/sizing.db-backup: V-nano
+        vixens.io/sizing.mongodb-exporter: V-nano
+        vixens.io/backup-profile: "standard"
+      annotations:
+        vixens.io/fast-start: "true"
+        vixens.io/no-long-connections: "true"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9216"
+        prometheus.io/path: "/metrics"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        fsGroupChangePolicy: OnRootMismatch
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: mongodb
+          image: mongo:8.0
+          ports:
+            - containerPort: 27017
+              name: mongodb
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-shared-credentials
+                  key: MONGO_INITDB_ROOT_USERNAME
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-shared-credentials
+                  key: MONGO_INITDB_ROOT_PASSWORD
+          startupProbe:
+            exec:
+              command:
+                - mongosh
+                - --quiet
+                - --eval
+                - "db.adminCommand('ping')"
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          livenessProbe:
+            exec:
+              command:
+                - mongosh
+                - --quiet
+                - --eval
+                - "db.adminCommand('ping')"
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - mongosh
+                - --quiet
+                - --eval
+                - "db.adminCommand('ping')"
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          volumeMounts:
+            - name: data
+              mountPath: /data/db
+        - name: db-backup
+          image: alpine:3.22
+          securityContext:
+            runAsUser: 999
+            runAsGroup: 999
+          command:
+            - sh
+            - -c
+          args:
+            - |
+              apk add --no-cache mongodb-tools rclone > /dev/null 2>&1
+              export RCLONE_CONFIG_S3_TYPE=s3
+              export RCLONE_CONFIG_S3_PROVIDER=Other
+              export RCLONE_CONFIG_S3_ACCESS_KEY_ID=$LITESTREAM_ACCESS_KEY_ID
+              export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY=$LITESTREAM_SECRET_ACCESS_KEY
+              export RCLONE_CONFIG_S3_ENDPOINT=$LITESTREAM_ENDPOINT
+              while true; do
+                TIMESTAMP=$(date +%Y%m%d-%H%M)
+                mongodump \
+                  --uri="mongodb://$MONGO_INITDB_ROOT_USERNAME:$MONGO_INITDB_ROOT_PASSWORD@localhost:27017" \
+                  --excludeDb=admin,config,local \
+                  --archive=/tmp/mongodb-backup.archive \
+                  --gzip 2>/dev/null
+                if [ $? -eq 0 ] && [ -s /tmp/mongodb-backup.archive ]; then
+                  rclone copyto /tmp/mongodb-backup.archive "s3:$LITESTREAM_BUCKET/mongodb/backup-${TIMESTAMP}.archive"
+                  rclone copyto /tmp/mongodb-backup.archive "s3:$LITESTREAM_BUCKET/mongodb/backup-latest.archive"
+                  echo "[$(date)] Backup OK (${TIMESTAMP})"
+                  rm -f /tmp/mongodb-backup.archive
+                fi
+                sleep 900
+              done
+          envFrom:
+            - secretRef:
+                name: mongodb-shared-credentials
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f "mongodump" || pgrep -f "sleep 900" || exit 1
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            timeoutSeconds: 5
+        - name: mongodb-exporter
+          image: percona/mongodb_exporter:0.42.0
+          command: ["/bin/sh", "-c"]
+          args:
+            - exec /mongodb_exporter --mongodb.uri="mongodb://$MONGO_INITDB_ROOT_USERNAME:$MONGO_INITDB_ROOT_PASSWORD@localhost:27017/admin?authSource=admin"
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-shared-credentials
+                  key: MONGO_INITDB_ROOT_USERNAME
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-shared-credentials
+                  key: MONGO_INITDB_ROOT_PASSWORD
+          ports:
+            - containerPort: 9216
+              name: metrics
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 9216
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 9216
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 3
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: synelia-iscsi-retain
+        resources:
+          requests:
+            storage: 10Gi

--- a/apps/04-databases/mongodb-shared/overlays/prod/kustomization.yaml
+++ b/apps/04-databases/mongodb-shared/overlays/prod/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: databases
+resources:
+  - ../../base
+components:
+  - ../../../../_shared/components/sync-wave/wave-2
+  - ../../../../_shared/components/goldilocks/enabled
+  - ../../../../_shared/components/revision-history-limit
+  - ../../../../_shared/components/poddisruptionbudget/1
+  - ../../../../_shared/components/scheduling/avoid-i915
+
+patches:
+  - path: patch-infisical-env.yaml
+  - path: resources-patch.yaml
+labels:
+  - pairs:
+      environment: prod
+    includeSelectors: false

--- a/apps/04-databases/mongodb-shared/overlays/prod/patch-infisical-env.yaml
+++ b/apps/04-databases/mongodb-shared/overlays/prod/patch-infisical-env.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: mongodb-shared-credentials
+  namespace: databases
+spec:
+  authentication:
+    universalAuth:
+      secretsScope:
+        envSlug: prod
+  managedSecretReference:
+    secretNamespace: databases

--- a/apps/04-databases/mongodb-shared/overlays/prod/resources-patch.yaml
+++ b/apps/04-databases/mongodb-shared/overlays/prod/resources-patch.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongodb-shared
+spec:
+  template:
+    spec:
+      priorityClassName: vixens-critical

--- a/apps/10-home/nightscout/base/cilium-networkpolicy.yaml
+++ b/apps/10-home/nightscout/base/cilium-networkpolicy.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: nightscout
+spec:
+  endpointSelector:
+    matchLabels:
+      app: nightscout
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+      toPorts:
+        - ports:
+            - port: "1337"
+              protocol: TCP
+    - fromEntities:
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "1337"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            app: mongodb-shared
+      toPorts:
+        - ports:
+            - port: "27017"
+              protocol: TCP
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/apps/10-home/nightscout/base/deployment.yaml
+++ b/apps/10-home/nightscout/base/deployment.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nightscout
+  labels:
+    app: nightscout
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: nightscout
+  template:
+    metadata:
+      labels:
+        app: nightscout
+        vixens.io/sizing.nightscout: V-small
+      annotations:
+        reloader.stakater.com/auto: "true"
+        vixens.io/fast-start: "true"
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: nightscout
+          image: nightscout/cgm-remote-monitor:15.0.2
+          ports:
+            - containerPort: 1337
+              name: http
+          env:
+            - name: BASE_URL
+              value: https://nightscout.truxonline.com
+            - name: DISPLAY_UNITS
+              value: mmol
+            - name: TIME_FORMAT
+              value: "24"
+            - name: LANGUAGE
+              value: fr
+            - name: THEME
+              value: colors
+            - name: AUTH_DEFAULT_ROLES
+              value: denied
+            - name: NODE_ENV
+              value: production
+            - name: TZ
+              value: Europe/Paris
+            - name: ENABLE
+              value: careportal basal dbsize rawbg iob cob cage iage sage boluscalc cors
+          envFrom:
+            - secretRef:
+                name: nightscout-secrets
+          livenessProbe:
+            httpGet:
+              path: /api/v1/status
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/v1/status
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3

--- a/apps/10-home/nightscout/base/infisical-secret.yaml
+++ b/apps/10-home/nightscout/base/infisical-secret.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: nightscout-secrets-sync
+spec:
+  hostAPI: http://192.168.111.69:8085
+  resyncInterval: 60
+  managedSecretReference:
+    secretName: nightscout-secrets
+    creationPolicy: Owner
+    secretNamespace: nightscout
+  authentication:
+    universalAuth:
+      credentialsRef:
+        secretName: infisical-universal-auth
+        secretNamespace: argocd
+      secretsScope:
+        projectSlug: vixens
+        envSlug: dev
+        secretsPath: /apps/10-home/nightscout

--- a/apps/10-home/nightscout/base/kustomization.yaml
+++ b/apps/10-home/nightscout/base/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - infisical-secret.yaml
+  - networkpolicy.yaml
+  - cilium-networkpolicy.yaml
+  - pdb.yaml

--- a/apps/10-home/nightscout/base/namespace.yaml
+++ b/apps/10-home/nightscout/base/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nightscout

--- a/apps/10-home/nightscout/base/networkpolicy.yaml
+++ b/apps/10-home/nightscout/base/networkpolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: nightscout
+spec:
+  podSelector:
+    matchLabels:
+      app: nightscout
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 1337
+  egress:
+    - {}

--- a/apps/10-home/nightscout/base/pdb.yaml
+++ b/apps/10-home/nightscout/base/pdb.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: nightscout
+spec:
+  selector:
+    matchLabels:
+      app: nightscout

--- a/apps/10-home/nightscout/base/service.yaml
+++ b/apps/10-home/nightscout/base/service.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nightscout
+spec:
+  ports:
+    - port: 1337
+      targetPort: 1337
+      name: http
+  selector:
+    app: nightscout

--- a/apps/10-home/nightscout/overlays/prod/ingress.yaml
+++ b/apps/10-home/nightscout/overlays/prod/ingress.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nightscout
+  namespace: nightscout
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-redirect-https@kubernetescrd
+    external-dns.alpha.kubernetes.io/target: truxonline.com
+    external-dns.alpha.kubernetes.io/public: "true"
+    vixens.io/nossoneeded: "true"
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Home
+    gethomepage.dev/name: Nightscout
+    gethomepage.dev/icon: nightscout.png
+    gethomepage.dev/description: Suivi glycémie
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: nightscout.truxonline.com
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: nightscout
+                port:
+                  number: 1337
+  tls:
+    - secretName: nightscout-tls-prod
+      hosts:
+        - nightscout.truxonline.com

--- a/apps/10-home/nightscout/overlays/prod/kustomization.yaml
+++ b/apps/10-home/nightscout/overlays/prod/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nightscout
+resources:
+  - ../../base
+  - ingress.yaml
+components:
+  - ../../../../_shared/components/infisical/env-prod
+  - ../../../../_shared/components/sync-wave/wave-11
+  - ../../../../_shared/components/goldilocks/enabled
+  - ../../../../_shared/components/poddisruptionbudget/1
+  - ../../../../_shared/components/scheduling/avoid-i915
+
+labels:
+  - pairs:
+      environment: prod

--- a/argocd/overlays/prod/apps/mongodb-shared.yaml
+++ b/argocd/overlays/prod/apps/mongodb-shared.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mongodb-shared
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: prod-stable
+    path: apps/04-databases/mongodb-shared/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: databases
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/overlays/prod/apps/nightscout.yaml
+++ b/argocd/overlays/prod/apps/nightscout.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nightscout
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "11"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/charchess/vixens.git
+    targetRevision: prod-stable
+    path: apps/10-home/nightscout/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: nightscout
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -39,6 +39,7 @@ resources:
   - apps/nfs-storage.yaml
   - apps/mail-gateway.yaml
   - apps/homeassistant.yaml
+  - apps/nightscout.yaml
   - apps/mosquitto.yaml
   - apps/mealie.yaml
   - apps/birdnet-go.yaml

--- a/argocd/overlays/prod/kustomization.yaml
+++ b/argocd/overlays/prod/kustomization.yaml
@@ -100,6 +100,7 @@ resources:
   - apps/external-dns-unifi.yaml
   - apps/external-dns-unifi-secrets.yaml
   - apps/mariadb-shared.yaml
+  - apps/mongodb-shared.yaml
   - apps/penpot.yaml
   - apps/vikunja.yaml
   # - apps/robusta.yaml  # disabled 2026-03-05 — reporting-only, OOMKilling, no local value


### PR DESCRIPTION
## Summary

**Step 1 — mongodb-shared** (`apps/04-databases/mongodb-shared/`)
- MongoDB 8.0 StatefulSet dans `databases` namespace
- Pattern identique à `mariadb-shared` : mongodump backup sidecar → MinIO (`vixens-prod-mongodb-shared`), percona metrics exporter (port 9216)
- PVC iSCSI 10Gi (`synelia-iscsi-retain`), priorityClass `vixens-critical`

**Step 2 — nightscout** (`apps/10-home/nightscout/`)
- Nightscout 15.0.2 dans `nightscout` namespace
- Connecté à `mongodb-shared.databases.svc.cluster.local:27017`
- Ingress HTTPS `nightscout.truxonline.com` via Traefik + Let's Encrypt
- `AUTH_DEFAULT_ROLES=denied` (login requis), TZ Europe/Paris, unités mmol, 24h

## Infisical
- `/apps/04-databases/mongodb-shared` (prod) : `MONGO_INITDB_ROOT_USERNAME/PASSWORD` + `LITESTREAM_*` ✅
- `/apps/10-home/nightscout` (prod) : `API_SECRET` + `MONGODB_URI` ✅

## Test plan

- [ ] `mongodb-shared` pod `3/3 Running` dans `databases`
- [ ] `nightscout` pod `1/1 Running` dans `nightscout`
- [ ] `https://nightscout.truxonline.com` accessible, login requis
- [ ] xDrip+ → Nightscout Sync → données visibles
- [ ] Intégration Home Assistant → Nightscout → capteur glycémie

Closes #3037

🤖 Generated with [Claude Code](https://claude.com/claude-code)