### PR TITLE
fix(mongodb-shared): ServiceMonitor + init-data-dir initContainer

### DIFF
--- a/apps/04-databases/mongodb-shared/base/kustomization.yaml
+++ b/apps/04-databases/mongodb-shared/base/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - networkpolicy.yaml
   - cilium-networkpolicy.yaml
   - pdb.yaml
+  - servicemonitor.yaml

--- a/apps/04-databases/mongodb-shared/base/servicemonitor.yaml
+++ b/apps/04-databases/mongodb-shared/base/servicemonitor.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: mongodb-shared
+  labels:
+    app: mongodb-shared
+spec:
+  selector:
+    matchLabels:
+      app: mongodb-shared
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 60s

--- a/apps/04-databases/mongodb-shared/base/statefulset.yaml
+++ b/apps/04-databases/mongodb-shared/base/statefulset.yaml
@@ -37,6 +37,15 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      initContainers:
+        - name: init-data-dir
+          image: busybox:1.37
+          command: ["sh", "-c", "mkdir -p /data/db && chown -R 999:999 /data/db"]
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: data
+              mountPath: /data/db
       containers:
         - name: mongodb
           image: mongo:8.0


### PR DESCRIPTION
## Summary
- Add `ServiceMonitor` targeting port 9216 (mongodb-exporter metrics) — fixes `check-servicemonitor` Kyverno audit violation
- Add `init-data-dir` initContainer (busybox, runs as root to chown `/data/db` to UID 999) — fixes `check-restore-init` Kyverno audit violation

Both policies are `Audit` mode (non-blocking), but this brings `mongodb-shared` to Emerald/Gold tier compliance.

> **Note:** The pod is currently `Pending` due to the Synology NAS DSM API being unreachable (`192.168.111.69:5000` i/o timeout) — the 10Gi iSCSI LUN cannot be provisioned until the NAS recovers.

## Test plan
- [ ] PR passes Validation Summary check
- [ ] ArgoCD syncs `mongodb-shared` app (once NAS is back)
- [ ] mongodb-shared-0 pod reaches `Running` state
- [ ] No Kyverno PolicyViolation events on next pod creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Prometheus metrics monitoring to enable automated collection of database performance data at regular intervals.

* **Chores**
  * Enhanced pod startup with automatic data directory initialization and proper permission management.
  * Updated deployment configuration to support monitoring infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->