### PR TITLE
fix(synology-csi): add egress CNP rules for DSM API + iSCSI (broken since default-deny)

### DIFF
--- a/apps/01-storage/synology-csi/base/cilium-networkpolicy.yaml
+++ b/apps/01-storage/synology-csi/base/cilium-networkpolicy.yaml
@@ -13,6 +13,23 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+    - toCIDR:
+        - 192.168.111.69/32
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
 ---
 # synology-csi-node — node driver (iSCSI mount)
 apiVersion: cilium.io/v2
@@ -28,6 +45,25 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+    - toCIDR:
+        - 192.168.111.69/32
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
+            - port: "3260"
+              protocol: TCP
 ---
 # iscsi-lock-cleanup — DaemonSet lock management
 apiVersion: cilium.io/v2
@@ -43,3 +79,22 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+    - toCIDR:
+        - 192.168.111.69/32
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
+            - port: "3260"
+              protocol: TCP


### PR DESCRIPTION
## Summary
- Add egress rules to all 3 synology-csi CNPs (controller, node, iscsi-lock-cleanup)
- **Root cause**: default-deny hardening (PRs #3008–#3022) blocked all egress from `synology-csi` namespace — no egress rules were ever added
- **Impact**: new PVC provisioning broken since default-deny activation; existing Bound PVCs unaffected (already mounted)
- **Symptom**: `mongodb-shared-0` PVC stuck `Pending` for 18h with `Couldn't find any host available to create Volume`

## Egress rules added
| Target | Port | Who |
|--------|------|-----|
| `192.168.111.69` (NAS DSM API) | 5000/TCP | controller, node, lock-cleanup |
| `192.168.111.69` (iSCSI) | 3260/TCP | node, lock-cleanup |
| kube-apiserver | — | controller |
| kube-dns | 53/UDP | all |

## Test plan
- [ ] PR passes CI
- [ ] Promote to prod-stable
- [ ] ArgoCD syncs `synology-csi` app → CNP updated
- [ ] `data-mongodb-shared-0` PVC transitions to `Bound`
- [ ] `mongodb-shared-0` pod reaches `Running`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced network policies for Synology CSI storage components with new egress traffic controls.
  * Policies now manage connections to the Kubernetes API server, DNS services, and designated infrastructure addresses.
  * Workload-specific port configurations ensure proper communication for controller, node, and cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->