### PR TITLE
fix(mongodb-shared): mongodb-exporter distroless — use native args

### DIFF
--- a/apps/04-databases/mongodb-shared/base/statefulset.yaml
+++ b/apps/04-databases/mongodb-shared/base/statefulset.yaml
@@ -141,9 +141,8 @@ spec:
             timeoutSeconds: 5
         - name: mongodb-exporter
           image: percona/mongodb_exporter:0.42.0
-          command: ["/bin/sh", "-c"]
           args:
-            - exec /mongodb_exporter --mongodb.uri="mongodb://$MONGO_INITDB_ROOT_USERNAME:$MONGO_INITDB_ROOT_PASSWORD@localhost:27017/admin?authSource=admin"
+            - --mongodb.uri=mongodb://$(MONGO_INITDB_ROOT_USERNAME):$(MONGO_INITDB_ROOT_PASSWORD)@localhost:27017/admin?authSource=admin
           env:
             - name: MONGO_INITDB_ROOT_USERNAME
               valueFrom:


### PR DESCRIPTION
## Summary
`percona/mongodb_exporter:0.42.0` is a distroless image — no `/bin/sh`. The `command: ["/bin/sh", "-c"]` caused `StartError: exec: "/bin/sh": stat /bin/sh: no such file or directory`.

Fix: remove shell wrapper, pass `--mongodb.uri` directly via `args` using Kubernetes native env var substitution `$(VAR_NAME)`.

## Test plan
- [ ] CI passes
- [ ] Promote to prod
- [ ] `mongodb-exporter` container reaches `Running`
- [ ] `mongodb-shared-0` pod `3/3 Running`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized MongoDB exporter deployment configuration by refining container execution parameters and environment variable substitution within the Kubernetes StatefulSet definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->