### PR TITLE
fix(mongodb-shared): remove root initContainer blocking pod startup

### DIFF
--- a/apps/04-databases/mongodb-shared/base/statefulset.yaml
+++ b/apps/04-databases/mongodb-shared/base/statefulset.yaml
@@ -46,15 +46,6 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
-      initContainers:
-        - name: init-data-dir
-          image: busybox:1.37
-          command: ["sh", "-c", "mkdir -p /data/db && chown -R 999:999 /data/db"]
-          securityContext:
-            runAsUser: 0
-          volumeMounts:
-            - name: data
-              mountPath: /data/db
       containers:
         - name: mongodb
           image: mongo:8.0

--- a/apps/04-databases/mongodb-shared/base/statefulset.yaml
+++ b/apps/04-databases/mongodb-shared/base/statefulset.yaml
@@ -33,6 +33,15 @@ spec:
         runAsGroup: 999
         fsGroup: 999
         fsGroupChangePolicy: OnRootMismatch
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - peach
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists

--- a/apps/70-tools/netbox/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/netbox/base/cilium-networkpolicy.yaml
@@ -17,3 +17,30 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
+  egress:
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            app.kubernetes.io/name: postgresql-shared
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            app: redis-shared
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP


### PR DESCRIPTION
## Summary

- Removes `init-data-dir` initContainer that ran as `runAsUser: 0`, which conflicts with `runAsNonRoot: true` pod policy (Kyverno enforcement)
- The `fsGroup: 999` + `fsGroupChangePolicy: OnRootMismatch` on the pod spec handles volume ownership correctly without a privileged init container

## Context

After iSCSI volume mount finally succeeded, the mongodb pod was stuck in `Init:CreateContainerConfigError` because the busybox init container violated the non-root pod security policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted MongoDB pod scheduling to enforce node affinity constraints, pinning deployment to designated infrastructure node.
  * Simplified MongoDB startup process by modifying container initialization steps.
  * Enhanced NetBox network policies to enable required outbound connectivity to database, cache, DNS, and Kubernetes API services for full application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->