### PR TITLE
fix(mongodb-shared): disable mongosh telemetry to fix startup probe kill loop

### DIFF
--- a/apps/04-databases/mongodb-shared/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/mongodb-shared/base/cilium-networkpolicy.yaml
@@ -15,3 +15,20 @@ spec:
         - ports:
             - port: "27017"
               protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "9000"
+              protocol: TCP

--- a/apps/04-databases/mongodb-shared/base/statefulset.yaml
+++ b/apps/04-databases/mongodb-shared/base/statefulset.yaml
@@ -63,6 +63,8 @@ spec:
                 secretKeyRef:
                   name: mongodb-shared-credentials
                   key: MONGO_INITDB_ROOT_PASSWORD
+            - name: DO_NOT_TRACK
+              value: "1"
           startupProbe:
             exec:
               command:


### PR DESCRIPTION
## Problem

After PVC reprovisioning, `mongodb-shared-0` was stuck in a startup probe kill loop.

**Root cause**: `mongosh` phones home to telemetry.mongodb.com on every invocation. With Cilium default-deny in prod, the outbound TCP connection is silently dropped, causing a ~50s wait per probe call — the probe has a 5s timeout → always fails → container killed after 300s → loop.

## Fix

- Add `DO_NOT_TRACK: "1"` env var to the mongodb container so mongosh skips telemetry on every probe call
- Add egress rules to `CiliumNetworkPolicy`: DNS (53/UDP) + HTTPS+S3 (443+9000/TCP) so `db-backup` can reach MinIO for backups

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MongoDB network policies to enable DNS resolution and external service connectivity.
  * Configured MongoDB instances to disable telemetry tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->