### PR TITLE
fix(mongodb-shared): replace slow mongosh probes with bash TCP port check

### DIFF
--- a/apps/04-databases/mongodb-shared/base/statefulset.yaml
+++ b/apps/04-databases/mongodb-shared/base/statefulset.yaml
@@ -68,30 +68,27 @@ spec:
           startupProbe:
             exec:
               command:
-                - mongosh
-                - --quiet
-                - --eval
-                - "db.adminCommand('ping')"
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
+                - bash
+                - -c
+                - "exec 3<>/dev/tcp/127.0.0.1/27017"
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 60
           livenessProbe:
             exec:
               command:
-                - mongosh
-                - --quiet
-                - --eval
-                - "db.adminCommand('ping')"
+                - bash
+                - -c
+                - "exec 3<>/dev/tcp/127.0.0.1/27017"
             periodSeconds: 20
-            timeoutSeconds: 5
+            timeoutSeconds: 3
             failureThreshold: 3
           readinessProbe:
             exec:
               command:
-                - mongosh
-                - --quiet
-                - --eval
-                - "db.adminCommand('ping')"
+                - bash
+                - -c
+                - "exec 3<>/dev/tcp/127.0.0.1/27017"
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3


### PR DESCRIPTION
## Problem

`mongosh` (Node.js) takes 30–55s to start on the `peach` control-plane node due to Talos seccomp overhead. The 5s probe timeout always fires first, keeping `mongodb-shared-0` in a perpetual startup probe kill loop.

Even with `DO_NOT_TRACK=1` (previous fix), `mongosh --nodb` takes **34s** — pure Node.js startup, no DB connection involved.

## Fix

Replace all three probes with a lightweight bash `/dev/tcp` check:
```bash
exec 3<>/dev/tcp/127.0.0.1/27017
```
- ~1ms execution time
- No Node.js, no mongosh, no external network calls
- Correctly fails if MongoDB is not listening
- Startup probe: failureThreshold=60 × 5s = 5min total (covers journal recovery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)