### PR TITLE
fix(nightscout): add INSECURE_USE_HTTP=true to fix liveness probe kill loop

### DIFF
--- a/apps/10-home/nightscout/base/deployment.yaml
+++ b/apps/10-home/nightscout/base/deployment.yaml
@@ -50,6 +50,8 @@ spec:
               value: Europe/Paris
             - name: ENABLE
               value: careportal basal dbsize rawbg iob cob cage iage sage boluscalc cors
+            - name: INSECURE_USE_HTTP
+              value: "true"
           envFrom:
             - secretRef:
                 name: nightscout-secrets

--- a/docs/post-mortems/2026-04-17-homeassistant-iscsi-crash.md
+++ b/docs/post-mortems/2026-04-17-homeassistant-iscsi-crash.md
@@ -1,0 +1,94 @@
+# Post-Mortem : Home Assistant — Crash iSCSI + récupération LUN
+
+**Date :** 2026-04-17  
+**Durée de l'incident :** ~16:49 UTC → ~17:47 UTC (~1h)  
+**Cluster :** prod  
+**App affectée :** `homeassistant` (namespace `homeassistant`)  
+**Node initial :** powder | **Node final :** peach  
+**Auteur :** Claude Code + charchess  
+**Résultat final :** ✅ `2/2 Running`, `200 OK`, données intactes
+
+---
+
+## 1. CE QUI S'EST PASSÉ
+
+### Déclencheur
+
+À **~16:49 UTC**, le NAS Synology (192.168.111.69) a perdu plusieurs sessions iSCSI simultanément. Les logs kernel des nodes montrent `device offline error` sur plusieurs devices (`/dev/sda`, `/dev/sdf`, etc.). La cause côté NAS est inconnue (storage check automatique ? overload ? redémarrage partiel ?).
+
+### Cascade
+
+1. **Session iSCSI HA coupée** sur powder en plein I/O → le kernel voit le block device disparaître.
+2. **NodeStageVolume déclenché** par kubelet pour re-monter le LUN. Le NAS répond, mais **la session iSCSI est à nouveau interrompue pendant l'e2fsck** → timeout gRPC CSI → kubelet marque le montage échoué.
+3. **Loop infernale** : kubelet retente avec backoff exponentiel, mais chaque tentative timeout avant que le NAS soit stable → le pod reste bloqué en `Init:0/3`.
+4. **DSM port 5000 inaccessible** (`i/o timeout`) pendant la phase de récupération du NAS → le CSI controller ne peut plus provisionner de nouveaux LUNs.
+
+### Tentatives de récupération échouées
+
+- `e2fsck` manuel depuis un pod debug sur powder → échoué (`e2fsck cannot continue`, processus fantôme bloquant `/dev/sda`)
+- Cordon de powder → le pod se déplace sur peach, mais le NAS n'est toujours pas stable → mêmes timeouts NodeStageVolume
+
+---
+
+## 2. CE QUI A RÉSOLU L'INCIDENT
+
+### Filesystem réparé automatiquement
+
+À **17:01 UTC**, peach avait réussi un `NodeStageVolume` propre sur ce LUN (confirmé dans dmesg : `EXT4-fs (sda): mounted filesystem` à 16:59 → `unmounting filesystem` à 17:01). **Le filesystem était réparé à ce moment-là** sans intervention manuelle.
+
+### Récupération du PV (Retain policy)
+
+Le StorageClass `synelia-iscsi-retain` utilise `reclaimPolicy: Retain` → le PV et le LUN survivent à la suppression du PVC.
+
+1. Suppression du PVC `homeassistant-config` (géré par ArgoCD)
+2. Clear du `claimRef` sur le PV `pvc-39c56cda` (état `Released` → disponible)
+3. ArgoCD re-crée le PVC → il se rebind sur le même PV (même LUN `0d605bfe-6643-40cb-b28f-aba0d67a05ff`)
+
+**Aucun nouveau LUN n'a été créé. Les données sont intactes.**
+
+### Déblocage iSCSI manuel
+
+Le `NodeStageVolume` continuait à timeout sur peach malgré le NAS revenu (le port 3260 était ouvert, mais le login iSCSI n'arrivait pas dans le délai CSI gRPC). Solution :
+
+```bash
+kubectl -n synology-csi exec synology-csi-node-cl52h -c synology-csi-plugin -- \
+  iscsiadm -m node \
+  -T iqn.2000-01.com.synology:Synelia.pvc-39c56cda-68a8-4c75-956a-f0fd10be68f0 \
+  -p 192.168.111.69:3260 --login
+```
+
+Le CSI voit alors "session already exists" → NodeStageVolume passe instantanément → NodePublishVolume → volumes montés.
+
+### Dataangel restore
+
+L'init container `dataangel` s'est exécuté en mode restore :
+- DB `home-assistant_v2.db` (2.6 GB) déjà sur le disque, **clean shutdown détecté** → pas de WAL replay nécessaire
+- `rclone copy` des fichiers de config non-DB depuis `s3:vixens-prod-homeassistant/config` (MinIO synelia)
+- Init containers complétés → pod `2/2 Running`
+
+---
+
+## 3. CAUSES RACINES
+
+| # | Cause | Impact |
+|---|-------|--------|
+| 1 | **Incident Synology** (cause inconnue) | Sessions iSCSI coupées simultanément sur tous les nodes |
+| 2 | **NodeStageVolume timeout trop court** | Le CSI abandonne le login iSCSI avant que le NAS soit stabilisé → loop kubelet infinie |
+| 3 | **Pas de mécanisme de re-login iSCSI automatique** | Nécessite une intervention manuelle `iscsiadm --login` pour débloquer |
+
+---
+
+## 4. CE QUI A BIEN FONCTIONNÉ
+
+- **`reclaimPolicy: Retain`** → LUN et données survivent à la suppression du PVC
+- **Dataangel backup** → filet de sécurité (non nécessaire ici, DB intacte)
+- **Filesystem réparé automatiquement** par le premier NodeStageVolume propre sur peach
+- **CNP `host`/`remote-node` fix** (PR #2997, déployé dans cette même session) → readiness probe kubelet désormais correctement autorisée
+
+---
+
+## 5. ACTIONS PRÉVENTIVES
+
+- [ ] **Investiguer les logs DSM Synology** pour identifier la cause de la chute iSCSI à 16:49
+- [ ] **Alerte Prometheus** sur la perte de sessions iSCSI (métrique custom via `iscsiadm` ou node-exporter)
+- [ ] **Documenter la procédure de déblocage iSCSI** dans `docs/troubleshooting/` (login manuel quand NodeStageVolume timeout)

--- a/docs/post-mortems/2026-04-18-argocd-controller-oom-peach.md
+++ b/docs/post-mortems/2026-04-18-argocd-controller-oom-peach.md
@@ -1,0 +1,72 @@
+# Post-Mortem : ArgoCD Controller OOMKilled (peach node)
+
+**Date :** 2026-04-18  
+**Durée de l'incident :** ~20:00 UTC → ~21:00 UTC (~1h)  
+**Cluster :** prod
+
+---
+
+## Résumé
+
+Le contrôleur ArgoCD a été OOMKilled 18 fois sur le nœud `peach` (107% overcommit mémoire). Cela a bloqué la synchronisation de tous les ArgoCD Apps (openclaw n'était pas réconcilié), et par cascade, frigate restait en `Pending` (VPA à 6Gi bloquait le scheduling).
+
+---
+
+## Chronologie
+
+| Heure UTC | Événement |
+|-----------|-----------|
+| ~20:00 | ArgoCD controller OOMKilled sur peach (exit 137, 18 restarts) |
+| ~20:10 | Frigate Pending détecté — VPA requests = 6Gi (trop haut pour les nœuds) |
+| ~20:15 | Investigation : peach à 107% overcommit mémoire réel |
+| ~20:20 | Taint `memory=pressure:NoSchedule` posé sur peach |
+| ~20:25 | Pod controller replanifié sur pearl (3.4 GiB libre), stable |
+| ~20:30 | Taint retiré de peach |
+| ~20:40 | ArgoCD force-sync déclenché — openclaw réconcilié (PR #3027) |
+| ~21:00 | Frigate débloqué (dataAngel sha-2957234, VPA 2Gi) |
+
+---
+
+## Cause racine
+
+**Deux causes combinées :**
+
+1. **Overcommit mémoire sur peach** — 107% d'utilisation réelle. Le nœud avait trop de pods sans `limits` mémoire. L'OOM killer a ciblé argocd-controller (plus gros consommateur sans limits).
+
+2. **VPA openclaw à 6Gi** — Le VPA avait poussé la request mémoire d'openclaw à 6Gi (basé sur l'utilisation de mempalace). Cela saturait peach et bloquait frigate (aucun nœud ne pouvait accommoder 6Gi).
+
+---
+
+## Impact
+
+- ArgoCD ne réconciliait plus aucune application (controller crashait en boucle)
+- frigate en `Pending` depuis plusieurs heures
+- openclaw bloqué sur une ancienne révision (mempalace encore présent)
+
+---
+
+## Résolution
+
+1. **Taint peach** (`memory=pressure:NoSchedule`) → force la migration du controller vers pearl
+2. **Force-sync ArgoCD** pendant la courte fenêtre de stabilité → openclaw réconcilié
+3. **PR #3027** — suppression mempalace + VPA réduit à 2Gi
+4. **PR #3025** — dataAngel sha-2957234 (fix nil pointer panic iSCSI) → frigate débloqué
+
+---
+
+## Actions correctives
+
+| Action | Statut |
+|--------|--------|
+| Supprimer mempalace d'openclaw | ✅ PR #3027 mergé |
+| Réduire VPA cap openclaw à 2Gi | ✅ PR #3027 mergé |
+| Ajouter limits mémoire sur argocd-controller | ⬜ À faire |
+| Surveiller overcommit peach | ⬜ Alerte Grafana à créer |
+
+---
+
+## Leçons
+
+- Les pods sans `limits` mémoire sont vulnérables à l'OOM killer en cas de pression
+- Le VPA sans `maxAllowed` peut exploser les requests et bloquer le scheduling
+- Un taint temporaire est une technique rapide et réversible pour forcer la migration d'un pod critique

--- a/docs/post-mortems/2026-04-21-frigate-iscsi-sde-shutdown.md
+++ b/docs/post-mortems/2026-04-21-frigate-iscsi-sde-shutdown.md
@@ -1,0 +1,69 @@
+# Post-Mortem: Frigate iSCSI Mount Failure (sde shutdown loop)
+
+**Date:** 2026-04-21  
+**Duration:** ~14 hours (00:00 → 12:35 UTC)  
+**Severity:** High — Frigate NVR down in prod  
+**Node:** poison (192.168.111.194)  
+**Volume:** frigate-cache-pvc (`pvc-9d89a9b3-8cf9-4f6f-8d09-6938f471a918`, 10Gi iSCSI, `/dev/sde`)
+
+---
+
+## Summary
+
+Frigate failed to start in prod due to a cascading iSCSI mount failure on the `frigate-cache-pvc` volume. The ext4 filesystem on `/dev/sde` repeatedly entered `shutdown` mode due to iSCSI session drops, causing I/O errors. The root cause was a stale iSCSI session state combined with the Synology refusing `SendTargets` discovery requests after repeated reconnection attempts.
+
+---
+
+## Timeline
+
+| Time | Event |
+|------|-------|
+| 2026-04-17 21:44 | First `device offline error` on `/dev/sde` (correlated with `synology-csi-node` pod restart) |
+| 2026-04-21 00:00 | Frigate deployment updated (sizing fix) — pod rescheduled |
+| 00:11 | Second `device offline error` on sde → ext4 shutdown |
+| 00:45 | Third `device offline error` → ext4 shutdown again |
+| ~01:00 | iSCSI session manually logged out, fsck ran, filesystem repaired |
+| 01:00–12:30 | Repeated NodeStageVolume failures: Synology refusing discovery (`Connection to Discovery Address closed`), kubelet 2-min timeout exceeded |
+| 12:21 | Session confirmed clean (`Session doesn't exist` after logout) |
+| 12:31 | NodeStageVolume succeeds via pre-created node DB entry + direct login |
+| 12:35 | Frigate `2/2 Running` |
+
+---
+
+## Root Cause
+
+**Two compounding issues:**
+
+1. **Synology refusing iSCSI SendTargets discovery** after too many reconnection attempts from the same initiator. The CSI driver's NodeStageVolume flow does `iscsiadm -m discovery -t sendtargets` first; when the Synology closes this connection, the driver fails immediately instead of falling back to direct login.
+
+2. **Stale globalmount with `shutdown` flag** persisting across pod restarts. Once the ext4 filesystem enters shutdown mode (triggered by an iSCSI session drop), the mount path retains the `shutdown` flag even after the session reconnects. A `fsck` is required to clear the `orphan_present` flag.
+
+**Why sde specifically:** The `synology-csi-node` pod restarted on 2026-04-17, disrupting the iSCSI session for `sde` mid-write. This corrupted the journal and caused the initial `device offline` error chain. Other volumes (sdb, sdf, sdh) were not affected because their sessions survived the restart cleanly.
+
+---
+
+## Resolution
+
+1. `iscsiadm --logout` on the stale session
+2. `fsck.ext4 -y /dev/sde` via the `synology-csi-plugin` container (fixed `orphan_present` + journal)
+3. Manually created the iSCSI node DB entry (`--op new`) to bypass discovery
+4. Pre-logged in the session so NodeStageVolume found it ready
+5. Force-deleted stuck pod — CSI mounted cleanly on fresh attempt
+
+---
+
+## What Did NOT Work
+
+- Restarting `ext-iscsid` service on poison (session issue was not daemon-side)
+- Waiting for auto-retry (kubelet 2-min timeout consistently exceeded due to slow discovery)
+- `kubectl debug node/` (blocked by PodSecurity baseline policy)
+
+---
+
+## Action Items
+
+- [ ] Investigate why Synology refuses `SendTargets` discovery after repeated reconnects — consider increasing rate limits in DSM iSCSI settings
+- [ ] Add monitoring/alert on ext4 `shutdown` flag on iSCSI volumes (check `/proc/mounts` for `,shutdown` option)
+- [ ] Consider pre-seeding iSCSI node DB entries on `synology-csi-node` pod startup to avoid discovery dependency
+- [ ] Investigate the 2026-04-17 `synology-csi-node` pod restart root cause (see post-mortem `2026-04-17-homeassistant-iscsi-crash.md`)
+- [ ] Consider moving frigate-cache-pvc to NFS instead of iSCSI (cache data is reconstructible, NFS is more resilient)

--- a/docs/post-mortems/2026-04-24-mongodb-iscsi-pvc-recovery.md
+++ b/docs/post-mortems/2026-04-24-mongodb-iscsi-pvc-recovery.md
@@ -1,0 +1,73 @@
+# Post-Mortem : mongodb-shared-0 — Récupération PVC iSCSI + probe kill loop
+
+**Date :** 2026-04-24  
+**Durée de l'incident :** ~00:00 UTC → ~04:30 UTC (~4h30)  
+**Cluster :** prod  
+**Service impacté :** mongodb-shared (Nightscout)
+
+---
+
+## Résumé
+
+Après suppression et recréation du PVC `pvc-24f68afa` (suite à un blocage du pod précédent), `mongodb-shared-0` est resté bloqué dans une boucle de redémarrages pendant ~4h30. Trois problèmes distincts se sont enchaînés.
+
+---
+
+## Chronologie
+
+| Heure (UTC) | Événement |
+|-------------|-----------|
+| ~00:00 | PVC `pvc-b2d49d48` supprimé, nouveau PVC `pvc-24f68afa` créé |
+| ~00:30 | NodeStageVolume bloqué (iscsiadm thundering herd sur lock.write) |
+| ~00:34 | Sessions iSCSI nettoyées manuellement, NodeStageVolume réussi |
+| ~00:41 | MongoDB démarre mais startup probe timeout en boucle (exit 100 puis mongosh 55s) |
+| ~02:57 | PR #3051 mergé : `DO_NOT_TRACK=1` + egress CNP |
+| ~03:52 | PR #3052 mergé : probe mongosh → bash `/dev/tcp` |
+| ~04:05 | Filesystem `emergency_ro` puis `shutdown` sur `/dev/sdb` |
+| ~04:15 | e2fsck + remontage sur `/dev/sdh` (session125) |
+| ~04:26 | `mongodb-shared-0` atteint **3/3 Running** stable |
+
+---
+
+## Causes racines
+
+### 1. Thundering herd iscsiadm (lock.write)
+Plusieurs tentatives kubelet concurrentes de NodeStageVolume ont créé des files d'attente sur le fichier `lock.write` iSCSI, dépassant systématiquement le timeout gRPC de 2 minutes.
+
+**Fix :** Tuer les processus iscsiadm zombies, effacer le lock.write manuellement depuis le namespace mount d'iscsid (`/proc/30294/root/run/lock/iscsi/lock.write`).
+
+### 2. Mongosh startup probe timeout (Cilium default-deny + Talos seccomp)
+La probe `mongosh --quiet --eval "db.adminCommand('ping')"` prenait **30–55 secondes** à s'exécuter :
+- Cilium default-deny bloque les connexions egress de mongosh vers telemetry.mongodb.com (~25s timeout TCP silencieux)
+- Node.js (mongosh) prend **34s** à démarrer sur `peach` (control-plane) même avec `--nodb`, probablement dû au profil seccomp strict de Talos
+
+**Fix court terme :** `DO_NOT_TRACK=1` (PR #3051) réduit le délai à ~30s mais insuffisant.  
+**Fix définitif :** Remplacement de la probe mongosh par un check TCP bash `exec 3<>/dev/tcp/127.0.0.1/27017` (PR #3052) — ~1ms, aucun appel réseau.
+
+### 3. Filesystem emergency_ro / I/O errors sur /dev/sdb
+Après plusieurs kills forcés du pod MongoDB (pendant journal actif), ext4 a détecté des erreurs et remonté le volume en lecture seule (`emergency_ro`), puis le device `/dev/sdb` a complètement disparu (SCSI layer drop après trop d'erreurs I/O).
+
+La session iSCSI s'est automatiquement reconnectée sur un nouveau device (`session125 → /dev/sdh`).
+
+**Fix :** `e2fsck -y /dev/sdh` pour récupérer le journal, remontage manuel sur le staging path, puis suppression du pod pour déclencher un redémarrage propre.
+
+---
+
+## Actions préventives
+
+| Action | Priorité | Statut |
+|--------|----------|--------|
+| Remplacer toutes les probes mongosh par des checks TCP bash | Haute | ✅ Fait (PR #3052) |
+| Ajouter egress DNS + S3 au CNP mongodb-shared | Haute | ✅ Fait (PR #3051) |
+| Investiguer pourquoi Node.js prend 34s sur peach (seccomp Talos) | Moyenne | Open |
+| Configurer NAS pour n'exposer que les portails IPv4 iSCSI | Moyenne | Open |
+| Supprimer le target orphelin `pvc-b2d49d48` sur le NAS | Basse | Manuel (user) |
+
+---
+
+## Leçons
+
+1. **Mongosh est inadapté comme probe en environnement Cilium default-deny** — toujours utiliser des checks TCP ou des outils sans dépendances réseau pour les probes dans ce cluster.
+2. **Tuer un pod MongoDB en force corrompt le journal** — préférer un arrêt gracieux (`mongod --shutdown`) ou accepter que fsck sera nécessaire.
+3. **Le SCSI layer peut droper un device après trop d'erreurs I/O** — la reconnexion iSCSI assigne un nouveau device name ; le staging path reste valide mais vide.
+4. **Thundering herd iSCSI** → voir post-mortem 2026-04-17 pour la procédure de récupération.


### PR DESCRIPTION
## Problem

Nightscout crashes every ~4 minutes: `BASE_URL=https://...` activates an internal HTTP→HTTPS redirect middleware. The kubelet `httpGet` probe follows the 301 redirect and sends a TLS request to port 1337 (plain HTTP) → `http: server gave HTTP response to HTTPS client` → liveness probe kills the container.

## Fix

Add `INSECURE_USE_HTTP=true` to disable Nightscout's internal redirect. HTTPS is already handled by Traefik at the ingress layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive post-mortem documentation for infrastructure incidents, improving operational transparency and learning outcomes.

* **Chores**
  * Updated deployment configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->