### PR TITLE
fix(nightscout): lower prod memory request to 128Mi

### DIFF
--- a/apps/10-home/nightscout/overlays/prod/kustomization.yaml
+++ b/apps/10-home/nightscout/overlays/prod/kustomization.yaml
@@ -5,6 +5,12 @@ namespace: nightscout
 resources:
   - ../../base
   - ingress.yaml
+
+patches:
+  - path: resources.yaml
+    target:
+      kind: Deployment
+      name: nightscout
 components:
   - ../../../../_shared/components/infisical/env-prod
   - ../../../../_shared/components/sync-wave/wave-11

--- a/apps/10-home/nightscout/overlays/prod/resources.yaml
+++ b/apps/10-home/nightscout/overlays/prod/resources.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nightscout
+spec:
+  template:
+    spec:
+      containers:
+        - name: nightscout
+          resources:
+            requests:
+              memory: 128Mi


### PR DESCRIPTION
## Summary
- Add resource patch in prod overlay to set nightscout container memory request to 128Mi
- Old pod had VPA in-place-reduced requests of 128Mi; new pod template defaults to 256Mi (V-small)
- Cluster at 99-105% memory overcommit — 256Mi request won't fit on any node

## Test plan
- [ ] Pod schedules and reaches Running state in prod
- [ ] Liveness/readiness probes pass (INSECURE_USE_HTTP=true already in place via PR #3054)

🤖 Generated with [Claude Code](https://claude.com/claude-code)