### PR TITLE
fix(nightscout): increase liveness initialDelay to 120s

### DIFF
--- a/apps/10-home/nightscout/base/deployment.yaml
+++ b/apps/10-home/nightscout/base/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             httpGet:
               path: /api/v1/status
               port: http
-            initialDelaySeconds: 30
+            initialDelaySeconds: 120
             periodSeconds: 30
             timeoutSeconds: 10
             failureThreshold: 3
@@ -67,7 +67,7 @@ spec:
             httpGet:
               path: /api/v1/status
               port: http
-            initialDelaySeconds: 15
+            initialDelaySeconds: 60
             periodSeconds: 15
             timeoutSeconds: 5
             failureThreshold: 3


### PR DESCRIPTION
## Summary
- Nightscout (Node.js v16) takes 90-120s to start: MongoDB connection, index setup, authorization
- liveness `initialDelaySeconds: 30` fires before app is ready → 3 failures → pod killed in restart loop
- Raised liveness delay to 120s, readiness to 60s

## Root cause
Node.js startup on peach (Talos seccomp overhead) + MongoDB index creation takes >90s total. The 30s initial delay was too aggressive.

## Test plan
- [ ] Pod reaches Running+Ready without restart loop
- [ ] Nightscout accessible at https://nightscout.truxonline.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)