### PR TITLE
fix(nightscout): add vixens-medium priority to enable preemption

### DIFF
--- a/apps/10-home/nightscout/base/deployment.yaml
+++ b/apps/10-home/nightscout/base/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: nightscout
         vixens.io/sizing.nightscout: V-micro
+        vixens.io/priority-class: vixens-medium
       annotations:
         reloader.stakater.com/auto: "true"
         vixens.io/fast-start: "true"


### PR DESCRIPTION
## Summary
- Cluster at 99-100% memory requests on all nodes; nightscout can't schedule
- Nightscout has no priorityClass (priority 0) so no preemption victims found
- Adding `vixens-medium` (priority 10000) allows it to preempt `vixens-low` (priority 0) pods

## Semantic justification
Nightscout is a CGM health monitoring app; it has higher importance than amule/netbird/vikunja (vixens-low).

🤖 Generated with [Claude Code](https://claude.com/claude-code)