### PR TITLE
fix(nightscout): add startupProbe (10min) for slow MongoDB index build

### DIFF
--- a/apps/10-home/nightscout/base/deployment.yaml
+++ b/apps/10-home/nightscout/base/deployment.yaml
@@ -56,11 +56,17 @@ spec:
           envFrom:
             - secretRef:
                 name: nightscout-secrets
+          startupProbe:
+            httpGet:
+              path: /api/v1/status
+              port: http
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 40
           livenessProbe:
             httpGet:
               path: /api/v1/status
               port: http
-            initialDelaySeconds: 120
             periodSeconds: 30
             timeoutSeconds: 10
             failureThreshold: 3
@@ -68,7 +74,6 @@ spec:
             httpGet:
               path: /api/v1/status
               port: http
-            initialDelaySeconds: 60
             periodSeconds: 15
             timeoutSeconds: 5
             failureThreshold: 3


### PR DESCRIPTION
## Summary
- Nightscout takes 3-5+ min to start on fresh PVC (MongoDB index creation on fresh DB)
- Fixed liveness initialDelay=120s still not enough — liveness was killing after 210s
- Added startupProbe with 40×15s=600s maximum, gates liveness/readiness until ready

## Test plan
- [ ] Pod reaches Running+Ready without restart loop
- [ ] https://nightscout.truxonline.com accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container deployment configuration with enhanced startup health verification and refined readiness probe behavior for improved application reliability during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->