### PR TITLE
fix(nightscout): use tcpSocket probes (AUTH_DEFAULT_ROLES=denied → 401)

### DIFF
--- a/apps/10-home/nightscout/base/deployment.yaml
+++ b/apps/10-home/nightscout/base/deployment.yaml
@@ -57,23 +57,20 @@ spec:
             - secretRef:
                 name: nightscout-secrets
           startupProbe:
-            httpGet:
-              path: /api/v1/status
-              port: http
+            tcpSocket:
+              port: 1337
             periodSeconds: 15
             timeoutSeconds: 5
             failureThreshold: 40
           livenessProbe:
-            httpGet:
-              path: /api/v1/status
-              port: http
+            tcpSocket:
+              port: 1337
             periodSeconds: 30
-            timeoutSeconds: 10
+            timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
-            httpGet:
-              path: /api/v1/status
-              port: http
+            tcpSocket:
+              port: 1337
             periodSeconds: 15
             timeoutSeconds: 5
             failureThreshold: 3


### PR DESCRIPTION
## Summary
- Root cause found: `AUTH_DEFAULT_ROLES: denied` causes `/api/v1/status` to return 401
- All HTTP probes were failing with `HTTP probe failed with statuscode: 401`
- Replaced httpGet probes with tcpSocket probes on port 1337

## Test plan
- [ ] Pod reaches Running+Ready without restart loop
- [ ] https://nightscout.truxonline.com accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)