### PR TITLE
fix(external-dns-unifi): skip ingresses with target:truxonline.com to fix split-horizon DNS

### DIFF
--- a/apps/40-network/external-dns-unifi/values/prod.yaml
+++ b/apps/40-network/external-dns-unifi/values/prod.yaml
@@ -3,6 +3,11 @@
 txtOwnerId: prod-unifi
 domainFilters:
   - truxonline.com
+# Skip ingresses with target: truxonline.com — those point to the public apex
+# domain and create CNAMEs resolving to the external IP instead of the internal
+# Traefik LB. Gandi handles external DNS for these. UniFi records for public
+# services must be added manually as CNAME → vixens.truxonline.com.
+annotationFilter: "external-dns.alpha.kubernetes.io/target notin (truxonline.com)"
 resources:
   requests:
     cpu: 20m


### PR DESCRIPTION
## Problème

`external-dns-unifi` pickup les ingresses avec `external-dns.alpha.kubernetes.io/target: truxonline.com` (annotation destinée à Gandi pour le DNS externe) et crée des CNAME vers `truxonline.com` dans UniFi. Résultat : ces hostnames résolvent vers l'IP publique (217.70.184.38) au lieu du LB Traefik interne (192.168.201.70) → split-horizon DNS cassé.

De plus, `sakapuss.truxonline.com` avait un A record (correct) que external-dns voulait remplacer par un CNAME → conflit 400 → **tout le batch échoue** → nightscout et d'autres records jamais créés (548 erreurs consécutives).

## Fix

Ajout d'`annotationFilter: "external-dns.alpha.kubernetes.io/target notin (truxonline.com)"` sur external-dns-unifi prod : il ignore désormais les ingresses avec ce target.

- Gandi continue de gérer le DNS externe pour ces services
- Les records UniFi existants pour les services "publics" sont préservés (upsert-only)
- Les nouveaux services publics (`target: truxonline.com`) doivent avoir leur CNAME `→ vixens.truxonline.com` ajouté manuellement dans UniFi

## Actions manuelles requises post-merge

Corriger dans UniFi DNS (Settings → DNS Records) :
- `nightscout.truxonline.com` : CNAME `truxonline.com` → `vixens.truxonline.com`
- `stalwart.truxonline.com` : CNAME `truxonline.com` → `vixens.truxonline.com`

Closes #3055

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DNS record generation for specific ingresses to prevent pointing to incorrect external IP addresses, ensuring DNS properly routes to the intended internal load balancer targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->