### PR TITLE
fix(dns): split-horizon apex — truxonline.com A 192.168.201.70 in UniFi

### DIFF
--- a/apps/40-network/external-dns-unifi/values/prod.yaml
+++ b/apps/40-network/external-dns-unifi/values/prod.yaml
@@ -3,11 +3,6 @@
 txtOwnerId: prod-unifi
 domainFilters:
   - truxonline.com
-# Skip ingresses with target: truxonline.com — those point to the public apex
-# domain and create CNAMEs resolving to the external IP instead of the internal
-# Traefik LB. Gandi handles external DNS for these. UniFi records for public
-# services must be added manually as CNAME → vixens.truxonline.com.
-annotationFilter: "external-dns.alpha.kubernetes.io/target notin (truxonline.com)"
 resources:
   requests:
     cpu: 20m


### PR DESCRIPTION
## Problème

Les ingresses avec `external-dns.alpha.kubernetes.io/target: truxonline.com` créaient des CNAMEs vers `truxonline.com` dans UniFi, qui résolvait vers l'IP publique (217.70.184.38) au lieu du LB Traefik interne (192.168.201.70).

Un premier fix (annotationFilter) avait été appliqué dans #3063 mais c'était un workaround : external-dns-unifi ne gérait plus ces services du tout.

## Fix réel

Ajout de `truxonline.com A 192.168.201.70` dans UniFi DNS (split-horizon sur le domaine apex). Désormais :
- `nightscout.truxonline.com CNAME truxonline.com` → résout vers `192.168.201.70` (Traefik) en interne ✓
- `stalwart.truxonline.com CNAME truxonline.com` → idem ✓
- `sakapuss.truxonline.com CNAME truxonline.com` → idem ✓ (A record + TXT supprimés, external-dns recrée CNAME)

External-dns-unifi reprend la gestion normale de tous les ingresses.

## Actions hors-git déjà effectuées via API UniFi
- Suppression des CNAME `nightscout`, `stalwart` vers `truxonline.com` (wrong)
- Suppression du A record `sakapuss` + TXT ownership (pour permettre recréation CNAME)
- Création `truxonline.com A 192.168.201.70`

Supersedes #3063 (annotationFilter revert inclus dans ce commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated DNS configuration to enable external-dns management for truxonline.com in the production environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->