### PR TITLE
fix(frigate): migrate config-pvc from local-path to synelia-iscsi-retain

### DIFF
--- a/apps/20-media/frigate/overlays/prod/pvc-patch.yaml
+++ b/apps/20-media/frigate/overlays/prod/pvc-patch.yaml
@@ -4,6 +4,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: frigate-config-pvc
 spec:
+  storageClassName: synelia-iscsi-retain
   resources:
     requests:
       storage: 50Gi


### PR DESCRIPTION
## Summary
- \`frigate-config-pvc\` utilisait \`local-path-delete\` qui bind un \`nodeAffinity\` dur au node de provisioning
- Frigate était coincé sur \`poison\` et impossible à reschedule si ce node manque de ressources
- Migration vers \`synelia-iscsi-retain\` (portable entre tous les nodes)

## Migration requise (une fois)
Après merge, supprimer le PVC existant pour qu'ArgoCD le recrée en iSCSI :
\`\`\`
kubectl delete pvc -n media frigate-config-pvc
\`\`\`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated storage configuration to ensure consistent settings across related services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->