### PR TITLE
fix(frigate): sync-wave 7 on config-pvc prevents ArgoCD WaitForFirstConsumer deadlock

### DIFF
--- a/apps/20-media/frigate/overlays/prod/pvc-patch.yaml
+++ b/apps/20-media/frigate/overlays/prod/pvc-patch.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: frigate-config-pvc
+  annotations:
+    argocd.argoproj.io/sync-wave: "7"
 spec:
   storageClassName: synelia-iscsi-retain
   resources:


### PR DESCRIPTION
## Summary

- WaitForFirstConsumer PVC in wave 0 blocks ArgoCD from ever applying the Deployment (wave 7)
- PVC cannot bind until a pod is created; pod cannot be created until Deployment is applied
- This was a silent deadlock discovered during the 2026-04-24 prod incident
- Adding `argocd.argoproj.io/sync-wave: "7"` to frigate-config-pvc puts it in the same wave as the Deployment

## How to apply

- [ ] Merge to main → auto-promote to prod-stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)