### PR TITLE
fix(cnp): fix missing egress/ingress rules after DefaultDeny hardening

### DIFF
--- a/apps/10-home/homeassistant/base/cilium-networkpolicy.yaml
+++ b/apps/10-home/homeassistant/base/cilium-networkpolicy.yaml
@@ -25,3 +25,28 @@ spec:
         - ports:
             - port: "8123"
               protocol: TCP
+  egress:
+    # HA → Mosquitto (MQTT broker)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: mosquitto
+      toPorts:
+        - ports:
+            - port: "1883"
+              protocol: TCP
+    # HA → Frigate (API, WebSocket events, RTSP)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app: frigate
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
+            - port: "8554"
+              protocol: TCP
+            - port: "8555"
+              protocol: TCP
+    # HA → world (cloud integrations, webhooks, external APIs)
+    - toEntities:
+        - world

--- a/apps/20-media/birdnet-go/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/birdnet-go/base/cilium-networkpolicy.yaml
@@ -20,6 +20,17 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
   egress:
+    # birdnet-go → Frigate (API + RTSP streams for audio analysis)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app: frigate
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
+            - port: "8554"
+              protocol: TCP
     # birdnet-go → world (NAS/MinIO at 192.168.111.69:9000 for recordings)
     - toEntities:
         - world

--- a/apps/20-media/frigate/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/frigate/base/cilium-networkpolicy.yaml
@@ -18,3 +18,25 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+    # HA → Frigate (API, WebSocket events, RTSP)
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: homeassistant
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
+            - port: "8554"
+              protocol: TCP
+            - port: "8555"
+              protocol: TCP
+    # birdnet-go → Frigate (API + RTSP streams)
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: birdnet-go
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
+            - port: "8554"
+              protocol: TCP

--- a/apps/20-media/lidarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/lidarr/base/cilium-networkpolicy.yaml
@@ -25,3 +25,16 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # lidarr → Prowlarr (indexer searches)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app: prowlarr
+      toPorts:
+        - ports:
+            - port: "9696"
+              protocol: TCP
+    # lidarr → world (MusicBrainz, metadata APIs)
+    - toEntities:
+        - world

--- a/apps/20-media/mylar/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/mylar/base/cilium-networkpolicy.yaml
@@ -18,3 +18,16 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # mylar → Prowlarr (indexer searches)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app: prowlarr
+      toPorts:
+        - ports:
+            - port: "9696"
+              protocol: TCP
+    # mylar → world (Comic Vine, metadata APIs)
+    - toEntities:
+        - world

--- a/apps/20-media/prowlarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/prowlarr/base/cilium-networkpolicy.yaml
@@ -18,3 +18,11 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+    # *arr → Prowlarr (indexer searches)
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+      toPorts:
+        - ports:
+            - port: "9696"
+              protocol: TCP

--- a/apps/20-media/radarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/radarr/base/cilium-networkpolicy.yaml
@@ -18,3 +18,16 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # radarr → Prowlarr (indexer searches)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app: prowlarr
+      toPorts:
+        - ports:
+            - port: "9696"
+              protocol: TCP
+    # radarr → world (TMDB, metadata APIs)
+    - toEntities:
+        - world

--- a/apps/20-media/sonarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/sonarr/base/cilium-networkpolicy.yaml
@@ -18,3 +18,16 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # sonarr → Prowlarr (indexer searches)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app: prowlarr
+      toPorts:
+        - ports:
+            - port: "9696"
+              protocol: TCP
+    # sonarr → world (TVDB, TheTVDB, metadata APIs)
+    - toEntities:
+        - world

--- a/apps/20-media/whisparr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/whisparr/base/cilium-networkpolicy.yaml
@@ -18,3 +18,16 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # whisparr → Prowlarr (indexer searches)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app: prowlarr
+      toPorts:
+        - ports:
+            - port: "9696"
+              protocol: TCP
+    # whisparr → world (metadata APIs)
+    - toEntities:
+        - world


### PR DESCRIPTION
## Summary
Fixes 4 CNP gaps introduced by DefaultDeny activation (#3023 / PR #3018):

- **homeassistant** (#3048 + #3046): add egress → mosquitto:1883, frigate:5000/8554/8555, world
- **frigate**: add ingress from homeassistant (5000/8554/8555) and birdnet-go (5000/8554)
- **birdnet-go** (#3047): add egress → frigate:5000/8554 (RTSP streams for audio analysis)
- **prowlarr** (#3049): add ingress from media namespace on port 9696
- **sonarr/radarr/lidarr/mylar/whisparr** (#3049): add egress → prowlarr:9696 + world (metadata APIs)

Closes #3046, #3047, #3048, #3049

## Test plan
- [ ] HA: MQTT devices back online (entities not `unavailable`)
- [ ] HA: Frigate entities (cam_*_cat) back online
- [ ] birdnet-go: RTSP streams from Frigate accessible
- [ ] Sonarr/Radarr: indexer searches via Prowlarr working

🤖 Generated with [Claude Code](https://claude.com/claude-code)