### PR TITLE
fix(cnp): add egress to cert-manager controller (DefaultDeny regression)

### DIFF
--- a/apps/00-infra/cert-manager/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/cert-manager/base/cilium-networkpolicy.yaml
@@ -14,6 +14,22 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # cert-manager → kube-apiserver (manage Certificate/Secret/CertificateRequest resources)
+    - toEntities:
+        - kube-apiserver
+    # cert-manager → world (ACME: Let's Encrypt, DNS-01 Gandi API)
+    - toEntities:
+        - world
+    # cert-manager → gandi webhook (DNS-01 solver, same namespace)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: cert-manager
+            app.kubernetes.io/name: cert-manager-webhook-gandi
+      toPorts:
+        - ports:
+            - port: "8443"
+              protocol: TCP
 ---
 # cert-manager cainjector
 apiVersion: cilium.io/v2


### PR DESCRIPTION
## Summary
- cert-manager controller had zero egress rules since DefaultDeny activation
- Blocked from reaching: Let's Encrypt ACME API, kube-apiserver, Gandi DNS-01 webhook
- `letsencrypt-prod` ClusterIssuer stuck NotReady for 20h with i/o timeout
- All prod certificates (nightscout + others) failing to renew/issue

## Fix
Add egress rules to cert-manager controller CNP:
- `toEntities: kube-apiserver` — manage Certificate/Secret resources
- `toEntities: world` — Let's Encrypt ACME + Gandi DNS API
- `toEndpoints: cert-manager-webhook-gandi:8443` — DNS-01 solver

## Test plan
- [ ] `kubectl describe clusterissuer letsencrypt-prod` → Status: True / Ready
- [ ] `kubectl get certificate -n nightscout` → READY: True
- [ ] `kubectl get certificate -A` → all certs Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)