### PR TITLE
fix(cnp): cert-manager webhook ingress — add remote-node for kube-apiserver

### DIFF
--- a/apps/00-infra/cert-manager/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/cert-manager/base/cilium-networkpolicy.yaml
@@ -59,8 +59,10 @@ spec:
       app.kubernetes.io/name: webhook
       app.kubernetes.io/instance: cert-manager
   ingress:
+    # kube-apiserver calls webhook for admission — may arrive as remote-node when apiserver is on another node
     - fromEntities:
         - kube-apiserver
+        - remote-node
       toPorts:
         - ports:
             - port: "10250"

--- a/apps/00-infra/cert-manager/extra/cilium-networkpolicy.yaml
+++ b/apps/00-infra/cert-manager/extra/cilium-networkpolicy.yaml
@@ -59,8 +59,10 @@ spec:
       app.kubernetes.io/name: webhook
       app.kubernetes.io/instance: cert-manager
   ingress:
+    # kube-apiserver calls webhook for admission — may arrive as remote-node when apiserver is on another node
     - fromEntities:
         - kube-apiserver
+        - remote-node
       toPorts:
         - ports:
             - port: "10250"


### PR DESCRIPTION
## Summary
Hubble drops: `remote-node → cert-manager-webhook:10250 Policy denied`

The `fromEntities: kube-apiserver` rule doesn't catch admission webhook calls when the kube-apiserver runs on a different node — Cilium identifies them as `remote-node` instead of `kube-apiserver`.

Result: cert-manager controller gets `context deadline exceeded` calling `cert-manager-webhook.cert-manager.svc:443/mutate`, blocking all certificate issuance.

Adds `remote-node` to the allowed ingress sources on port 10250.

## Test plan
- [ ] No more `remote-node → cert-manager-webhook:10250 Policy denied` drops in Hubble
- [ ] `kubectl describe clusterissuer letsencrypt-prod` → Ready: True
- [ ] `kubectl get certificate -n nightscout` → READY: True

🤖 Generated with [Claude Code](https://claude.com/claude-code)