### PR TITLE
fix(cnp): add egress to cert-manager-webhook-gandi (DefaultDeny regression)

### DIFF
--- a/apps/00-infra/cert-manager-webhook-gandi/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/base/cilium-networkpolicy.yaml
@@ -20,3 +20,7 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
+  egress:
+    # gandi webhook → api.gandi.net (DNS-01 TXT record management)
+    - toEntities:
+        - world


### PR DESCRIPTION
## Summary
cert-manager-webhook-gandi had no egress rules — blocked from reaching `api.gandi.net` for DNS-01 TXT record creation.

Symptom: challenge pending with `Post "https://api.gandi.net/v5/livedns/...": context deadline exceeded`.

## Test plan
- [ ] `kubectl get challenge -n nightscout` → State: valid
- [ ] `kubectl get certificate -n nightscout` → READY: True

🤖 Generated with [Claude Code](https://claude.com/claude-code)