### PR TITLE
fix(cnp): add cert-manager-webhook-gandi CNP to prod overlay (GitOps)

### DIFF
--- a/apps/00-infra/cert-manager-webhook-gandi/overlays/prod/cilium-networkpolicy.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/overlays/prod/cilium-networkpolicy.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cert-manager-webhook-gandi
+  namespace: cert-manager
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: cert-manager-webhook-gandi
+  ingress:
+    - fromEntities:
+        - kube-apiserver
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "8443"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+  egress:
+    # gandi webhook → api.gandi.net (DNS-01 TXT record management)
+    - toEntities:
+        - world

--- a/apps/00-infra/cert-manager-webhook-gandi/overlays/prod/kustomization.yaml
+++ b/apps/00-infra/cert-manager-webhook-gandi/overlays/prod/kustomization.yaml
@@ -15,7 +15,11 @@ namespace: cert-manager
 # The InfisicalSecret (gandi-credentials-sync) is managed by a SEPARATE ArgoCD app:
 #   cert-manager-secrets → apps/00-infra/cert-manager-webhook-gandi/secrets/prod
 # Do NOT add resources: ../../base here (was causing SharedResourceWarning double ownership).
+# CNP is included directly as a standalone file to avoid double-ownership.
 #
+resources:
+  - cilium-networkpolicy.yaml
+
 patches:
   # Patch: Deployment-level annotations (ArgoCD wave, Goldilocks VPA)
   - patch: |-


### PR DESCRIPTION
## Summary
The `cert-manager-webhook-gandi` CNP (with egress → world for api.gandi.net) was applied via `kubectl apply` — a GitOps violation. selfHeal would have reverted it.

Proper fix: adds the CNP directly to `overlays/prod/cilium-networkpolicy.yaml` as a standalone resource to avoid the SharedResourceWarning double-ownership issue documented in the kustomization comment.

## Test plan
- [ ] ArgoCD cert-manager-webhook-gandi: Synced+Healthy
- [ ] `kubectl get ciliumnetworkpolicy cert-manager-webhook-gandi -n cert-manager -o jsonpath='{.spec.egress}'` shows world egress
- [ ] `kubectl get certificate -n nightscout` → READY: True (stays True after selfHeal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added network traffic policy for the certificate manager webhook service, enabling inbound connections on port 8443 from authorized sources and allowing outbound DNS management communications.
  * Updated infrastructure configuration to include the new network policy resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->