### PR TITLE
fix(cnp): allow kubelet health probes — add host entity to 36 CNPs

### DIFF
--- a/apps/02-monitoring/snmp-exporter/base/cilium-networkpolicy.yaml
+++ b/apps/02-monitoring/snmp-exporter/base/cilium-networkpolicy.yaml
@@ -9,6 +9,8 @@ spec:
     matchLabels:
       app.kubernetes.io/name: snmp-exporter
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring

--- a/apps/04-databases/redis-shared/base/cilium-networkpolicy.yaml
+++ b/apps/04-databases/redis-shared/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: redis-shared
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: auth

--- a/apps/20-media/amule/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/amule/base/cilium-networkpolicy.yaml
@@ -9,6 +9,8 @@ spec:
     matchLabels:
       app.kubernetes.io/name: amule
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/20-media/birdnet-go/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/birdnet-go/base/cilium-networkpolicy.yaml
@@ -9,6 +9,8 @@ spec:
     matchLabels:
       app.kubernetes.io/name: birdnet-go
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/20-media/booklore/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/booklore/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: booklore
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/20-media/bookshelf/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/bookshelf/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: bookshelf
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/20-media/frigate/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/frigate/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: frigate
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/20-media/hydrus-client/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/hydrus-client/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: hydrus-client
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/20-media/jellyfin/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/jellyfin/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: jellyfin
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/20-media/jellyseerr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/jellyseerr/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: jellyseerr
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/20-media/music-assistant/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/music-assistant/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: music-assistant
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/20-media/mylar/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/mylar/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: mylar
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/20-media/prowlarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/prowlarr/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: prowlarr
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/20-media/pyload/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/pyload/base/cilium-networkpolicy.yaml
@@ -9,6 +9,8 @@ spec:
     matchLabels:
       app.kubernetes.io/name: pyload
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/20-media/qbittorrent/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/qbittorrent/base/cilium-networkpolicy.yaml
@@ -9,6 +9,8 @@ spec:
     matchLabels:
       app.kubernetes.io/name: qbittorrent
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/20-media/radarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/radarr/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: radarr
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/20-media/sonarr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/sonarr/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: sonarr
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/20-media/whisparr/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/whisparr/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: whisparr
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/40-network/adguard-home/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/adguard-home/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: adguard-home
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/60-services/firefly-iii-importer/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/firefly-iii-importer/base/cilium-networkpolicy.yaml
@@ -9,6 +9,8 @@ spec:
     matchLabels:
       app.kubernetes.io/name: firefly-iii-importer
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/60-services/g4f/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/g4f/base/cilium-networkpolicy.yaml
@@ -9,6 +9,8 @@ spec:
     matchLabels:
       app.kubernetes.io/name: g4f
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/60-services/gluetun/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/gluetun/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: gluetun
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/60-services/n8n/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/n8n/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: n8n
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/60-services/openclaw/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/openclaw/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: openclaw
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/60-services/sakapuss/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/sakapuss/base/cilium-networkpolicy.yaml
@@ -9,6 +9,8 @@ spec:
     matchLabels:
       app.kubernetes.io/name: sakapuss-backend
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/60-services/vaultwarden/base/cilium-networkpolicy.yaml
+++ b/apps/60-services/vaultwarden/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: vaultwarden
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/70-tools/changedetection/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/changedetection/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: changedetection
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/70-tools/headlamp/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/headlamp/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: headlamp
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/70-tools/homepage/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/homepage/base/cilium-networkpolicy.yaml
@@ -9,6 +9,8 @@ spec:
     matchLabels:
       app.kubernetes.io/name: homepage
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/70-tools/linkwarden/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/linkwarden/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: linkwarden
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/70-tools/netbox/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/netbox/base/cilium-networkpolicy.yaml
@@ -8,6 +8,12 @@ spec:
     matchLabels:
       app: netbox
   ingress:
+    - fromEntities:
+        - host
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/70-tools/nexterm/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/nexterm/base/cilium-networkpolicy.yaml
@@ -9,6 +9,8 @@ spec:
     matchLabels:
       app.kubernetes.io/name: nexterm
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/70-tools/nocodb/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/nocodb/base/cilium-networkpolicy.yaml
@@ -9,6 +9,8 @@ spec:
     matchLabels:
       app.kubernetes.io/name: nocodb
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/70-tools/trilium/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/trilium/base/cilium-networkpolicy.yaml
@@ -9,6 +9,8 @@ spec:
     matchLabels:
       app.kubernetes.io/name: trilium
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/70-tools/vikunja/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/vikunja/base/cilium-networkpolicy.yaml
@@ -9,6 +9,8 @@ spec:
     matchLabels:
       app.kubernetes.io/name: vikunja
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik

--- a/apps/99-test/whoami/base/cilium-networkpolicy.yaml
+++ b/apps/99-test/whoami/base/cilium-networkpolicy.yaml
@@ -8,6 +8,8 @@ spec:
     matchLabels:
       app: whoami
   ingress:
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik


### PR DESCRIPTION
## Summary

- **Root cause**: Under Cilium default-deny (enabled 2026-04-18), kubelet HTTP/TCP liveness probes originate from the node (`host` entity) and were blocked by all CNPs that only specified `fromEndpoints` selectors (traefik, monitoring, etc.)
- **Impact**: ~35 apps cycling in a ~7-min loop — startup probe fails 30×10s=300s, Kubernetes sends SIGTERM, app exits 0, restarts. Manifested as netbox `1/2 Ready, 3 restarts in 22 minutes`
- **Fix**: Add `fromEntities: [host]` as first ingress rule in each affected CNP (36 files total incl. netbox)

## Affected apps (36)

`snmp-exporter`, `redis-shared`, `amule`, `birdnet-go`, `booklore`, `bookshelf`, `frigate`, `hydrus-client`, `jellyfin`, `jellyseerr`, `music-assistant`, `mylar`, `prowlarr`, `pyload`, `qbittorrent`, `radarr`, `sonarr`, `whisparr`, `adguard-home`, `firefly-iii-importer`, `g4f`, `gluetun`, `n8n`, `openclaw`, `sakapuss`, `vaultwarden`, `changedetection`, `headlamp`, `homepage`, `linkwarden`, `nexterm`, `nocodb`, `trilium`, `vikunja`, `whoami`, `netbox`

## Test plan

- [ ] After merge → dev sync: verify netbox no longer cycles (`kubectl get pod -n tools -w`)
- [ ] Check openclaw, n8n, vaultwarden liveness probe events clear
- [ ] Verify no unexpected traffic allowed (host entity = kubelet only, trusted infra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated network policies across all services to allow host-to-service traffic, enhancing communication pathways in the deployment infrastructure.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charchess/vixens/pull/3077)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->