### PR TITLE
fix: remove hardcoded peach nodeAffinity from mongodb and sakapuss

### DIFF
--- a/apps/04-databases/mongodb-shared/base/statefulset.yaml
+++ b/apps/04-databases/mongodb-shared/base/statefulset.yaml
@@ -33,15 +33,6 @@ spec:
         runAsGroup: 999
         fsGroup: 999
         fsGroupChangePolicy: OnRootMismatch
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/hostname
-                    operator: In
-                    values:
-                      - peach
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists

--- a/apps/60-services/sakapuss/overlays/prod/backend-node-affinity.yaml
+++ b/apps/60-services/sakapuss/overlays/prod/backend-node-affinity.yaml
@@ -5,13 +5,4 @@ metadata:
   name: sakapuss-backend
 spec:
   template:
-    spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/hostname
-                    operator: In
-                    values:
-                      - peach
+    spec: {}


### PR DESCRIPTION
## Summary

- Remove `required hostname=peach` nodeAffinity from `mongodb-shared` StatefulSet base
- Remove `required hostname=peach` nodeAffinity from `sakapuss-backend` prod overlay

## Why

Peach's iSCSI stack deadlocked after a node crash (2026-04-25). The NAS has stale
iSCSI sessions for peach's initiator IQN that prevent new session establishment.
Both apps were hardcoded to run only on peach, making them unable to recover.

With these affinities removed, pods can reschedule to other nodes (pearl/powder)
where iSCSI works correctly. Data is safe on NAS LUNs (no nodeAffinity on PVs).

The peach taint `iscsi-broken=true:NoSchedule` is in place to prevent re-scheduling
there until the NAS sessions clear. This taint will be removed once peach's iSCSI
is functional again.

## Test plan
- [ ] mongodb-shared-0 schedules to non-peach node and starts
- [ ] sakapuss-backend schedules to non-peach node and starts
- [ ] After promote to prod-stable, verify both apps running in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Adjusted deployment configuration settings to enhance pod placement flexibility within the cluster infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->