### PR TITLE
fix(netbox): increase startup probe to 10min

### DIFF
--- a/apps/70-tools/netbox/base/deployment.yaml
+++ b/apps/70-tools/netbox/base/deployment.yaml
@@ -78,7 +78,7 @@ spec:
             httpGet:
               path: /
               port: http
-            failureThreshold: 30
+            failureThreshold: 60
             periodSeconds: 10
             timeoutSeconds: 5
           livenessProbe:


### PR DESCRIPTION
## Summary

- Startup probe `failureThreshold: 30 × 10s = 5min` was too short
- Netbox needs >5min on cold start (DB migrations + index creation on PostgreSQL)
- Increased to `failureThreshold: 60` (10min max)

🤖 Generated with [Claude Code](https://claude.com/claude-code)