### PR TITLE
fix(netbox): bypass KEDA, route directly to service

### DIFF
--- a/apps/70-tools/netbox/overlays/prod/ingress.yaml
+++ b/apps/70-tools/netbox/overlays/prod/ingress.yaml
@@ -23,7 +23,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: keda-interceptor-proxy
+                name: netbox
                 port:
                   number: 8080
   tls:


### PR DESCRIPTION
## Summary

- KEDA interceptor returns 502 for POST /login/ (GET works, POST doesn't)
- POST requests never reach netbox — blocked by KEDA interceptor
- Fix: route ingress directly to `netbox:8080` instead of `keda-interceptor-proxy`
- Netbox is an always-on tool, scale-to-zero not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)