### PR TITLE
revert(netbox): restore KEDA interceptor routing

### DIFF
--- a/apps/70-tools/netbox/overlays/prod/ingress.yaml
+++ b/apps/70-tools/netbox/overlays/prod/ingress.yaml
@@ -23,7 +23,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: netbox
+                name: keda-interceptor-proxy
                 port:
                   number: 8080
   tls:


### PR DESCRIPTION
## Summary

- Reverts bypass from #3081
- Bypassing KEDA broke scale-to-zero (no interceptor traffic → KEDA scales to 0 → 404)
- The POST 502 was transient during pod restart loop / probe fix rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)