### PR TITLE
fix(netbox): minReplicas=1, never scale to zero

### DIFF
--- a/apps/70-tools/netbox/overlays/prod/httpscaledobject.yaml
+++ b/apps/70-tools/netbox/overlays/prod/httpscaledobject.yaml
@@ -15,6 +15,6 @@ spec:
     service: netbox
     port: 8080
   replicas:
-    min: 0
+    min: 1
     max: 1
   scaledownPeriod: 600


### PR DESCRIPTION
## Summary

- Netbox startup takes 5+ min (DB migrations, index creation)
- KEDA interceptor timeout < 5min → 502 → KEDA scales back to 0 → loop
- Fix: `minReplicas: 1` — KEDA still manages max scale but never kills the pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)