### PR TITLE
fix(netbox): bypass KEDA interceptor (POST bug, minReplicas=1)

### DIFF
--- a/apps/70-tools/netbox/overlays/prod/ingress.yaml
+++ b/apps/70-tools/netbox/overlays/prod/ingress.yaml
@@ -23,7 +23,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: keda-interceptor-proxy
+                name: netbox
                 port:
                   number: 8080
   tls:


### PR DESCRIPTION
## Summary

- KEDA HTTP add-on v0.13.0 silently drops POST /login/ → 502, GET works
- POST never reaches netbox (confirmed via access logs)
- minReplicas already set to 1 in #3083 → scale-to-zero already disabled
- Bypassing interceptor has no behavioral impact, fixes POST 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend service routing configuration to maintain optimal performance and reliability of the netbox application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->