### PR TITLE
fix(keda+netbox): upgrade http-add-on 0.14.0, re-enable scale-to-zero after 2h

### DIFF
--- a/apps/00-infra/keda-http-addon/values/common.yaml
+++ b/apps/00-infra/keda-http-addon/values/common.yaml
@@ -26,7 +26,7 @@ interceptor:
     min: 1
     max: 1
     # Stirling-PDF cold-start: ~40s JWT key gen + ~2min Spring Boot = ~3min total
-    waitTimeout: 300s
+    waitTimeout: 600s
   resources:
     requests:
       cpu: 10m

--- a/apps/70-tools/netbox/overlays/prod/httpscaledobject.yaml
+++ b/apps/70-tools/netbox/overlays/prod/httpscaledobject.yaml
@@ -15,6 +15,6 @@ spec:
     service: netbox
     port: 8080
   replicas:
-    min: 1
+    min: 0
     max: 1
-  scaledownPeriod: 600
+  scaledownPeriod: 7200

--- a/apps/70-tools/netbox/overlays/prod/ingress.yaml
+++ b/apps/70-tools/netbox/overlays/prod/ingress.yaml
@@ -23,7 +23,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: netbox
+                name: keda-interceptor-proxy
                 port:
                   number: 8080
   tls:

--- a/apps/70-tools/netbox/overlays/prod/keda-interceptor-svc.yaml
+++ b/apps/70-tools/netbox/overlays/prod/keda-interceptor-svc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keda-interceptor-proxy
+  namespace: tools
+spec:
+  type: ExternalName
+  externalName: keda-add-ons-http-interceptor-proxy.keda.svc.cluster.local
+  ports:
+    - port: 8080
+      protocol: TCP

--- a/apps/70-tools/netbox/overlays/prod/kustomization.yaml
+++ b/apps/70-tools/netbox/overlays/prod/kustomization.yaml
@@ -21,3 +21,4 @@ resources:
   - ingress.yaml
   - infisical-redis-secret.yaml
   - httpscaledobject.yaml
+  - keda-interceptor-svc.yaml

--- a/argocd/overlays/prod/apps/keda-http-addon.yaml
+++ b/argocd/overlays/prod/apps/keda-http-addon.yaml
@@ -13,7 +13,7 @@ spec:
   sources:
     - repoURL: https://kedacore.github.io/charts
       chart: keda-add-ons-http
-      targetRevision: 0.13.0
+      targetRevision: 0.14.0
       helm:
         valueFiles:
           - $values/apps/00-infra/keda-http-addon/values/common.yaml


### PR DESCRIPTION
## Summary

- Upgrade KEDA HTTP add-on 0.13.0 → 0.14.0 (fixes POST 502 bug: `KEDA_HTTP_RESPONSE_HEADER_TIMEOUT` 500ms → 300s default)
- Restore netbox ingress → `keda-interceptor-proxy` (undo #3084 bypass)
- Add `keda-interceptor-svc` ExternalName service in `tools` namespace
- Set netbox `minReplicas: 0`, `scaledownPeriod: 7200` (scale-to-zero after 2h inactivity)
- Raise interceptor `waitTimeout` 300s → 600s for netbox cold-start margin

## Root cause of previous POST 502

KEDA HTTP add-on v0.13.0 had `KEDA_HTTP_RESPONSE_HEADER_TIMEOUT=500ms`. Netbox POST /login/ (CSRF + DB + session) took >500ms → interceptor dropped the connection → 502. v0.14.0 defaults this to 300s.

## Test plan

- [ ] KEDA HTTP add-on pods restart on 0.14.0 image
- [ ] Netbox login (GET + POST) works via interceptor
- [ ] Netbox scales to 0 after 2h inactivity
- [ ] Netbox wakes up on first request (browser waits ~3-5min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)