### PR TITLE
fix(cnp): add world egress for crowdsec-agent and netbird-management

### DIFF
--- a/apps/00-infra/crowdsec/base/cilium-networkpolicy.yaml
+++ b/apps/00-infra/crowdsec/base/cilium-networkpolicy.yaml
@@ -22,6 +22,13 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
+    # crowdsec-agent → world (CrowdSec Hub: version.crowdsec.net, hub updates)
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
 ---
 # crowdsec-lapi — reçoit des requêtes de Traefik (bouncer), agents crowdsec et monitoring
 apiVersion: cilium.io/v2

--- a/apps/40-network/netbird/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/netbird/base/cilium-networkpolicy.yaml
@@ -15,3 +15,33 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: netbird-management
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: netbird-management
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: networking
+  egress:
+    # netbird-management → authentik OIDC (via external LB IP = world)
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    - toEntities:
+        - kube-apiserver
+    # netbird-management → databases (SQLite via PVC, no DB egress needed)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: networking


### PR DESCRIPTION
## Summary

Both apps broken since default-deny hardening (2026-04-18):

- **crowdsec-agent**: CrashLoopBackOff — missing egress to `version.crowdsec.net:443` for Hub updates. Added `world:443` egress to existing agent CNP.
- **netbird-management**: CrashLoopBackOff — no CNP at all. TLS handshake timeout to `authentik.truxonline.com` (OIDC config endpoint). Added CNP with `world:443` + `kube-apiserver` egress + networking namespace ingress/egress.

## Test plan

- [ ] crowdsec-agent pod restarts and stays Running
- [ ] netbird-management pod starts without OIDC timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)