### PR TITLE
fix(netbird): add databases egress + increase liveness probe delay to 120s

### DIFF
--- a/apps/40-network/netbird/base/cilium-networkpolicy.yaml
+++ b/apps/40-network/netbird/base/cilium-networkpolicy.yaml
@@ -32,16 +32,25 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: networking
   egress:
-    # netbird-management → authentik OIDC (via external LB IP = world)
+    # netbird-management → authentik OIDC + geolocation DB download (world)
     - toEntities:
         - world
       toPorts:
         - ports:
             - port: "443"
               protocol: TCP
+            - port: "80"
+              protocol: TCP
     - toEntities:
         - kube-apiserver
-    # netbird-management → databases (SQLite via PVC, no DB egress needed)
+    # netbird-management → postgres (databases namespace)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: networking

--- a/apps/40-network/netbird/overlays/prod/patches.yaml
+++ b/apps/40-network/netbird/overlays/prod/patches.yaml
@@ -27,6 +27,18 @@ spec:
               value: "https://authentik.truxonline.com/application/o/netbird/.well-known/openid-configuration"
       containers:
         - name: management
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 120
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            failureThreshold: 3
           env:
             - name: NETBIRD_DOMAIN_NAME
               value: "netbird.truxonline.com"


### PR DESCRIPTION
## Summary

After fixing Authentik OIDC (PR #3087), netbird-management progresses further but still crashes:
- Needs egress to `databases:5432` (PostgreSQL store engine)
- Needs egress to `world:80` (geolocation DB download from MaxMind)
- Liveness probe kills pod after 60s — geolocation download + OIDC + migrations take >60s on cold start

**Fix:** increase `initialDelaySeconds` 30→120s + add missing egress rules.

## Test plan

- [ ] netbird-management pod reaches Ready (2/2) and stays Running
- [ ] `geonames_*.db` downloaded and cached in PVC (subsequent restarts skip download)

🤖 Generated with [Claude Code](https://claude.com/claude-code)