### PR TITLE
fix(netbird): replace liveness initialDelay with startupProbe (10min tolerance)

### DIFF
--- a/apps/40-network/netbird/overlays/prod/patches.yaml
+++ b/apps/40-network/netbird/overlays/prod/patches.yaml
@@ -27,16 +27,20 @@ spec:
               value: "https://authentik.truxonline.com/application/o/netbird/.well-known/openid-configuration"
       containers:
         - name: management
+          startupProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 60
           livenessProbe:
             tcpSocket:
               port: 8080
-            initialDelaySeconds: 120
             periodSeconds: 10
             failureThreshold: 3
           readinessProbe:
             tcpSocket:
               port: 8080
-            initialDelaySeconds: 30
             periodSeconds: 5
             failureThreshold: 3
           env:


### PR DESCRIPTION
## Summary

Geolocation DB download (`geonames_*.db`) blocks netbird-management from binding on `:8080` for >2 minutes. Increasing `initialDelaySeconds` to 120s wasn't enough.

Replace with a `startupProbe` (`failureThreshold: 60 × periodSeconds: 10` = 10min max) — liveness probe doesn't fire until startup completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)