### PR TITLE
fix(cnp): correct amule/qbit ingress syntax, add docspell-joex startupProbe

### DIFF
--- a/apps/20-media/amule/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/amule/base/cilium-networkpolicy.yaml
@@ -19,7 +19,9 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-    - toPorts:
+    - fromEntities:
+        - world
+      toPorts:
         - ports:
             - port: "4662"
               protocol: TCP
@@ -27,8 +29,6 @@ spec:
               protocol: UDP
             - port: "4672"
               protocol: UDP
-    - toEntities:
-        - world
   egress:
     # amule → gluetun SOCKS5 proxy (P2P traffic tunneled through VPN)
     - toEndpoints:

--- a/apps/20-media/qbittorrent/base/cilium-networkpolicy.yaml
+++ b/apps/20-media/qbittorrent/base/cilium-networkpolicy.yaml
@@ -19,14 +19,14 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
-    - toPorts:
+    - fromEntities:
+        - world
+      toPorts:
         - ports:
             - port: "6881"
               protocol: TCP
             - port: "6881"
               protocol: UDP
-    - toEntities:
-        - world
   egress:
     # qbittorrent → world (P2P traffic, BitTorrent peers)
     - toEntities:

--- a/apps/60-services/docspell/overlays/prod/kustomization.yaml
+++ b/apps/60-services/docspell/overlays/prod/kustomization.yaml
@@ -14,6 +14,7 @@ patches:
   - path: patch-infisical-secrets.yaml
 patchesStrategicMerge:
   - patch-configmap.yaml
+  - patch-joex-startup.yaml
 resources:
   - ../../base
   - ingress.yaml

--- a/apps/60-services/docspell/overlays/prod/patch-joex-startup.yaml
+++ b/apps/60-services/docspell/overlays/prod/patch-joex-startup.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: docspell-joex
+spec:
+  template:
+    spec:
+      containers:
+        - name: joex
+          startupProbe:
+            httpGet:
+              path: /api/info/version
+              port: api
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /api/info/version
+              port: api
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3


### PR DESCRIPTION
## Summary
- **amule + qbittorrent CNP**: `toEntities: world` and standalone `toPorts` in `ingress` are invalid Cilium syntax — Cilium normalizes them away, causing permanent ArgoCD OutOfSync diff. Replaced with `fromEntities: world` + `toPorts` (correct inbound-from-internet syntax).
- **docspell-joex**: JVM with 252m CPU limit takes >150s to bind `/api/info/version`; base liveness probe (delay=60s + 3×30s) killed it before startup. Added startupProbe (failureThreshold: 30 × 10s = 5 min window) so liveness only fires after JVM is ready.

## Test plan
- [ ] amule ArgoCD app goes Synced (no more OutOfSync diff on CNP)
- [ ] qbittorrent ArgoCD app goes Synced
- [ ] docspell-joex pod starts and stays Running (no CrashLoopBackOff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Updated network connectivity policies for media services to improve traffic routing.
  * Enhanced health monitoring and startup reliability for the Docspell service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->