### PR TITLE
fix(keda): set scaledownPeriod to 7200s (2h) for all HTTP scaled apps

### DIFF
--- a/apps/20-media/jellyseerr/overlays/prod/httpscaledobject.yaml
+++ b/apps/20-media/jellyseerr/overlays/prod/httpscaledobject.yaml
@@ -17,4 +17,4 @@ spec:
   replicas:
     min: 0
     max: 1
-  scaledownPeriod: 300
+  scaledownPeriod: 7200

--- a/apps/40-network/netvisor/overlays/prod/httpscaledobject.yaml
+++ b/apps/40-network/netvisor/overlays/prod/httpscaledobject.yaml
@@ -17,4 +17,4 @@ spec:
   replicas:
     min: 0
     max: 1
-  scaledownPeriod: 300
+  scaledownPeriod: 7200

--- a/apps/60-services/docspell/overlays/prod/httpscaledobject-restserver.yaml
+++ b/apps/60-services/docspell/overlays/prod/httpscaledobject-restserver.yaml
@@ -17,4 +17,4 @@ spec:
   replicas:
     min: 0
     max: 1
-  scaledownPeriod: 300
+  scaledownPeriod: 7200

--- a/apps/70-tools/headlamp/overlays/prod/httpscaledobject.yaml
+++ b/apps/70-tools/headlamp/overlays/prod/httpscaledobject.yaml
@@ -17,4 +17,4 @@ spec:
   replicas:
     min: 0
     max: 1
-  scaledownPeriod: 300
+  scaledownPeriod: 7200

--- a/apps/70-tools/it-tools/overlays/prod/httpscaledobject.yaml
+++ b/apps/70-tools/it-tools/overlays/prod/httpscaledobject.yaml
@@ -17,4 +17,4 @@ spec:
   replicas:
     min: 0
     max: 1
-  scaledownPeriod: 300
+  scaledownPeriod: 7200

--- a/apps/70-tools/linkwarden/overlays/prod/httpscaledobject.yaml
+++ b/apps/70-tools/linkwarden/overlays/prod/httpscaledobject.yaml
@@ -17,4 +17,4 @@ spec:
   replicas:
     min: 0
     max: 1
-  scaledownPeriod: 300
+  scaledownPeriod: 7200

--- a/apps/70-tools/penpot/overlays/prod/keda-scaledobjects.yaml
+++ b/apps/70-tools/penpot/overlays/prod/keda-scaledobjects.yaml
@@ -18,7 +18,7 @@ spec:
   replicas:
     min: 0
     max: 1
-  scaledownPeriod: 300
+  scaledownPeriod: 7200
 ---
 # Backend: scales in sync with frontend (external-push from same HTTPScaledObject)
 apiVersion: keda.sh/v1alpha1

--- a/apps/70-tools/radar/overlays/prod/httpscaledobject.yaml
+++ b/apps/70-tools/radar/overlays/prod/httpscaledobject.yaml
@@ -17,4 +17,4 @@ spec:
   replicas:
     min: 0
     max: 1
-  scaledownPeriod: 300
+  scaledownPeriod: 7200

--- a/apps/70-tools/stirling-pdf/overlays/prod/httpscaledobject.yaml
+++ b/apps/70-tools/stirling-pdf/overlays/prod/httpscaledobject.yaml
@@ -17,4 +17,4 @@ spec:
   replicas:
     min: 0
     max: 1
-  scaledownPeriod: 300
+  scaledownPeriod: 7200


### PR DESCRIPTION
## Summary
- Raises `scaledownPeriod` from 300s (5 min) → 7200s (2h) on all `HTTPScaledObject` resources, consistent with netbox
- Affected: stirling-pdf, netvisor, headlamp, radar, it-tools, linkwarden, docspell-restserver, jellyseerr, penpot (×3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network policies to use source-based entity matching for improved traffic control
  * Extended scale-down periods from 5 to 120 minutes across multiple services for optimized resource management
  * Added startup and liveness health checks to docspell for improved reliability and recovery
  * Updated service deployment configurations with additional patches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->