### PR TITLE
fix(docspell): disable consumedir sidecar (ghcr.io image 403)

### DIFF
--- a/apps/60-services/docspell/overlays/prod/kustomization.yaml
+++ b/apps/60-services/docspell/overlays/prod/kustomization.yaml
@@ -15,6 +15,7 @@ patches:
 patchesStrategicMerge:
   - patch-configmap.yaml
   - patch-joex-startup.yaml
+  - patch-disable-consumedir.yaml
 resources:
   - ../../base
   - ingress.yaml

--- a/apps/60-services/docspell/overlays/prod/patch-disable-consumedir.yaml
+++ b/apps/60-services/docspell/overlays/prod/patch-disable-consumedir.yaml
@@ -1,0 +1,13 @@
+---
+# consumedir disabled: ghcr.io/docspell/dsc image is no longer publicly
+# accessible (403). Re-enable once a working image is found.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: docspell-restserver
+spec:
+  template:
+    spec:
+      containers:
+        - name: consumedir
+          $patch: delete


### PR DESCRIPTION
## Summary
- `ghcr.io/docspell/dsc:v0.43.0` returns 403 on ghcr.io token exchange — image is no longer publicly accessible
- Removes `consumedir` sidecar via `$patch: delete` in prod overlay, unblocking pod startup
- docspell works normally (web upload, API); only NFS inbox auto-import is disabled

## Test plan
- [ ] docspell-restserver pod starts 1/1 Running
- [ ] https://docspell.truxonline.com accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)