### PR TITLE
fix(cnp): add keda namespace to KEDA HTTP scaled apps, complete penpot CNP

### DIFF
--- a/apps/70-tools/it-tools/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/it-tools/base/cilium-networkpolicy.yaml
@@ -12,6 +12,8 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik
+        - matchLabels:
+            io.kubernetes.pod.namespace: keda
       toPorts:
         - ports:
             - port: "8080"

--- a/apps/70-tools/penpot/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/penpot/base/cilium-networkpolicy.yaml
@@ -2,6 +2,25 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
+  name: penpot-frontend
+spec:
+  endpointSelector:
+    matchLabels:
+      app: penpot-frontend
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: traefik
+        - matchLabels:
+            io.kubernetes.pod.namespace: keda
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
   name: penpot-backend
 spec:
   endpointSelector:
@@ -11,7 +30,71 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik
+        - matchLabels:
+            io.kubernetes.pod.namespace: keda
+        - matchLabels:
+            io.kubernetes.pod.namespace: tools
       toPorts:
         - ports:
             - port: "6060"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+            - port: "6379"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: tools
+      toPorts:
+        - ports:
+            - port: "6061"
+              protocol: TCP
+    - toEntities:
+        - kube-apiserver
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: penpot-exporter
+spec:
+  endpointSelector:
+    matchLabels:
+      app: penpot-exporter
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: tools
+      toPorts:
+        - ports:
+            - port: "6061"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: tools
+      toPorts:
+        - ports:
+            - port: "6060"
+              protocol: TCP
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
               protocol: TCP

--- a/apps/70-tools/radar/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/radar/base/cilium-networkpolicy.yaml
@@ -12,6 +12,8 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik
+        - matchLabels:
+            io.kubernetes.pod.namespace: keda
       toPorts:
         - ports:
             - port: "9280"

--- a/apps/70-tools/stirling-pdf/base/cilium-networkpolicy.yaml
+++ b/apps/70-tools/stirling-pdf/base/cilium-networkpolicy.yaml
@@ -12,6 +12,8 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: traefik
+        - matchLabels:
+            io.kubernetes.pod.namespace: keda
       toPorts:
         - ports:
             - port: "8080"


### PR DESCRIPTION
## Summary
Apps scaled to zero by KEDA HTTP add-on had missing or incomplete CiliumNetworkPolicy rules that would block them after wake-up:

- **it-tools, radar, stirling-pdf**: `keda` namespace missing from ingress → KEDA interceptor can't forward requests after scale-from-zero
- **penpot**: frontend and exporter CNPs were missing entirely; backend CNP missing `keda` ingress and all egress; now added:
  - frontend: ingress traefik+keda
  - backend: ingress traefik+keda+tools, egress to databases (5432/6379) + exporter (6061) + world:443
  - exporter: ingress from tools, egress to backend (6060) + world:443

## Test plan
- [ ] it-tools wakes up on first request
- [ ] radar wakes up on first request
- [ ] stirling-pdf wakes up on first request
- [ ] penpot all 3 components wake up and connect to DB/Redis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Updates**
  * Expanded network connectivity policies across tools to enable autoscaling and improved service coordination.
  * Enhanced inter-service communication rules to improve system reliability and performance.
  * Strengthened network access controls to ensure secure and efficient communication between components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->