### PR TITLE
feat(netbox): replace slurpit with netbox-unifi-sync

### DIFF
--- a/apps/70-tools/netbox/base/plugins-config.yaml
+++ b/apps/70-tools/netbox/base/plugins-config.yaml
@@ -12,7 +12,7 @@ data:
         "netbox_inventory",
         "netbox_security",
         "netbox_interface_synchronization",
-        "slurpit_netbox",
+        "netbox_unifi_sync",
         "netbox_floorplan",
     ]
 
@@ -30,6 +30,6 @@ data:
         "netbox_interface_synchronization": {
             "exclude_virtual_interfaces": True,
         },
-        "slurpit_netbox": {},
+        "netbox_unifi_sync": {},
         "netbox_floorplan": {},
     }

--- a/docker/netbox-plugins/requirements.txt
+++ b/docker/netbox-plugins/requirements.txt
@@ -3,5 +3,5 @@ netbox-plugin-dns==1.5.5
 netbox-inventory==2.5.0
 netbox-security==1.4.4
 netbox-interface-synchronization==4.5.1
-slurpit_netbox==1.3.3
+netbox-unifi-sync==0.3.23
 netbox-floorplan-plugin==0.9.1


### PR DESCRIPTION
## Summary

- Remove `slurpit_netbox` (plugin d'import générique, non utilisé)
- Add `netbox-unifi-sync==0.3.23` — sync UniFi Controller → NetBox (devices, interfaces, VLANs, WLANs, uplinks)
- Credentials à configurer dans NetBox UI après déploiement : **Plugins → UniFi Sync → Controllers**

## Configuration post-déploiement

1. Ouvrir https://netbox.truxonline.com
2. **Plugins → UniFi Sync → Controllers → Add**
3. Renseigner :
   - URL : `https://192.168.200.1` (UDM-SE)
   - API Key (à créer dans UniFi : Settings → System → API → Create API Key)
4. Lancer une sync manuelle pour valider
5. Créer un **Scheduled Job** pour sync automatique (ex: toutes les heures)

## Test plan

- [ ] Image Docker rebuild déclenché par GitHub Actions
- [ ] ArgoCD sync → NetBox redémarre avec le nouveau plugin chargé
- [ ] Pas d'erreur au démarrage (`kubectl logs -n tools netbox-...`)
- [ ] Menu **Plugins → UniFi Sync** visible dans NetBox UI
- [ ] Controller UDM ajouté et sync manuelle OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NetBox plugin configuration and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->