### PR TITLE
fix(netbox): add REDIS_PASSWORD to netbox-worker container

### DIFF
--- a/apps/70-tools/netbox/overlays/prod/deployment-patch.yaml
+++ b/apps/70-tools/netbox/overlays/prod/deployment-patch.yaml
@@ -40,3 +40,10 @@ spec:
               httpHeaders:
                 - name: Host
                   value: localhost
+        - name: netbox-worker
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: netbox-redis-credentials
+                  key: password


### PR DESCRIPTION
## Summary
- The `netbox-worker` (RQ worker) container was missing `REDIS_PASSWORD` in the prod overlay
- This caused `Authentication required` errors from Redis, putting the worker in CrashLoopBackOff
- The prod overlay already had the fix for the main `netbox` container but the worker sidecar (added in #3104) was not patched

## Test plan
- [ ] Worker container starts without CrashLoopBackOff
- [ ] UniFi Sync job can be triggered and completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented background job processing to enable asynchronous task execution, allowing the application to handle long-running operations independently while maintaining responsiveness
  * Configured dedicated worker processes for efficient management of queued tasks across the deployment infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->