### PR TITLE
fix(netbird): route netbird-api ingress to port 80 (HTTP REST) instead of 33073 (gRPC)

### DIFF
--- a/apps/40-network/netbird/overlays/prod/ingress.yaml
+++ b/apps/40-network/netbird/overlays/prod/ingress.yaml
@@ -55,7 +55,7 @@ spec:
               service:
                 name: netbird-management
                 port:
-                  number: 33073
+                  number: 80
   tls:
     - hosts:
         - netbird-api.truxonline.com


### PR DESCRIPTION
Fixes #3109

## Summary
- `netbird-api` ingress was routing to port 33073 (gRPC backward compat) instead of port 80 (HTTP REST → targetPort 8080)
- This caused all REST API calls from the NetBird UI to hit the gRPC server and return HTTP 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated traffic routing configuration for the netbird-api endpoint to use an alternative service port, ensuring proper connection handling while maintaining existing TLS and security settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->