### PR TITLE
fix(netbird): inject DataStoreEncryptionKey from secret, remove IdpSkipTlsVerify

### DIFF
--- a/apps/40-network/netbird/base/management.yaml
+++ b/apps/40-network/netbird/base/management.yaml
@@ -66,8 +66,7 @@ spec:
                   "AuthAudience": "$AUTH_AUDIENCE",
                   "AuthKeysLocation": "$AUTH_KEYS_LOCATION",
                   "OIDCConfigEndpoint": "$AUTH_OIDC_CONFIG_ENDPOINT",
-                  "IdpSignKeyRefreshEnabled": true,
-                  "IdpSkipTlsVerify": true
+                  "IdpSignKeyRefreshEnabled": true
                 },
                 "DeviceAuthorizationFlow": {
                   "Provider": "hosted",

--- a/apps/40-network/netbird/overlays/prod/patches.yaml
+++ b/apps/40-network/netbird/overlays/prod/patches.yaml
@@ -52,6 +52,11 @@ spec:
               value: "https://netbird-signal.truxonline.com"
             - name: NETBIRD_RELAY_ENDPOINT
               value: "https://netbird-relay.truxonline.com"
+            - name: NETBIRD_DATASTORE_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: netbird-secrets
+                  key: NETBIRD_DATASTORE_ENCRYPTION_KEY
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Fixes #3112

## Summary
- **Critique**: Inject `NETBIRD_DATASTORE_ENCRYPTION_KEY` from `netbird-secrets` (synced via Infisical) to prevent key regeneration on pod restart — the `emptyDir` init-config was overwriting `management.json` each restart causing users to be unreadable from PostgreSQL
- **Basse**: Remove `IdpSkipTlsVerify: true` from management.json template — Authentik uses a valid LetsEncrypt cert in prod

## Pre-requisites
- Key added to Infisical prod `/apps/40-network/netbird` as `NETBIRD_DATASTORE_ENCRYPTION_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled TLS certificate verification for identity provider authentication, improving security posture.

* **Security Improvements**
  * Datastore encryption key is now securely managed through Kubernetes secrets instead of hardcoded configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->