### PR TITLE
fix(netbird): inject DataStoreEncryptionKey into management.json via init-config

### DIFF
--- a/apps/40-network/netbird/base/management.yaml
+++ b/apps/40-network/netbird/base/management.yaml
@@ -93,7 +93,8 @@ spec:
                 },
                 "DatastoreConfig": {
                   "Engine": "postgres"
-                }
+                },
+                "DataStoreEncryptionKey": "$NETBIRD_DATASTORE_ENCRYPTION_KEY"
               }
               EOF
           volumeMounts:

--- a/apps/40-network/netbird/overlays/prod/patches.yaml
+++ b/apps/40-network/netbird/overlays/prod/patches.yaml
@@ -9,6 +9,11 @@ spec:
       initContainers:
         - name: init-config
           env:
+            - name: NETBIRD_DATASTORE_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: netbird-encryption-key
+                  key: NETBIRD_DATASTORE_ENCRYPTION_KEY
             - name: AUTH_ISSUER
               value: "https://authentik.truxonline.com/application/o/netbird/"
             - name: AUTH_KEYS_LOCATION
@@ -52,11 +57,6 @@ spec:
               value: "https://netbird-signal.truxonline.com"
             - name: NETBIRD_RELAY_ENDPOINT
               value: "https://netbird-relay.truxonline.com"
-            - name: NETBIRD_DATASTORE_ENCRYPTION_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: netbird-secrets
-                  key: NETBIRD_DATASTORE_ENCRYPTION_KEY
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Fixes #3112

## Summary
PR #3113 was insufficient — `NETBIRD_DATASTORE_ENCRYPTION_KEY` env var is ignored by NetBird at runtime. The key must be written directly into `management.json`.

This PR injects `NETBIRD_DATASTORE_ENCRYPTION_KEY` from the `netbird-encryption-key` secret into the `init-config` init container, which writes it directly into the JSON template as `DataStoreEncryptionKey`. No more regeneration on restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)