### PR TITLE
fix(openclaw): install python3 via python-build-standalone (glibc 2.17+)

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -60,7 +60,7 @@ spec:
           args:
             - |
               set -e
-              TOOLS_VERSION="8"
+              TOOLS_VERSION="9"
               if [ -f /data/tools/.installed-version ] && [ "$(cat /data/tools/.installed-version)" = "$TOOLS_VERSION" ]; then
                 echo "Tools v$TOOLS_VERSION already present, skipping reinstall"
               else
@@ -77,9 +77,11 @@ spec:
                   ldd /usr/bin/$bin 2>/dev/null | grep "=>" | awk '{print $3}' | xargs -I {} cp {} /data/tools/lib/ 2>/dev/null || true
                 done
                 cp -r /usr/lib/x86_64-linux-gnu/* /data/tools/lib/ 2>/dev/null || true
-                # Copy python3 binary and stdlib
-                cp /usr/bin/python3* /data/tools/bin/ 2>/dev/null || true
-                cp -r /usr/lib/python3* /data/tools/lib/ 2>/dev/null || true
+                # Install portable Python via python-build-standalone (self-contained, glibc 2.17+)
+                curl -sLo /tmp/python.tar.gz "https://github.com/indygreg/python-build-standalone/releases/download/20250408/cpython-3.13.3+20250408-x86_64-unknown-linux-gnu-install_only.tar.gz"
+                tar -xzf /tmp/python.tar.gz -C /data/tools/ && rm /tmp/python.tar.gz
+                ln -sf /data/tools/python/bin/python3 /data/tools/bin/python3
+                ln -sf /data/tools/python/bin/python3.13 /data/tools/bin/python3.13
                 curl -sLo /data/tools/bin/kubectl "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
                 chmod +x /data/tools/bin/kubectl
                 curl -sLo /tmp/rclone.zip https://downloads.rclone.org/rclone-current-linux-amd64.zip


### PR DESCRIPTION
## Summary
- Replace broken `cp /usr/bin/python3*` (from debian:trixie, glibc 2.38) with python-build-standalone cpython-3.13.3
- Standalone build bundles its own libs, requires only glibc >= 2.17 — works in bookworm (2.36)
- TOOLS_VERSION bumped 8 → 9 to force reinstall on next pod restart

**Root cause:** init container is `debian:trixie` (glibc 2.38); openclaw container is `node:24-bookworm` (glibc 2.36). Copying the system python3 binary across gave: `GLIBC_2.38' not found`.

## Test plan
- [ ] Pod restarts, install-tools reinitializes (TOOLS_VERSION=9)
- [ ] No GLIBC error in init container logs
- [ ] `python3 --version` works in openclaw container
- [ ] Lisa reports Python available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend infrastructure tooling configuration and provisioning process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->