### PR TITLE
fix(netbird): IngressRoute h2c pour management+signal, corriger port signal 10000

### DIFF
--- a/apps/40-network/netbird/base/signal-relay.yaml
+++ b/apps/40-network/netbird/base/signal-relay.yaml
@@ -36,24 +36,23 @@ spec:
       containers:
         - name: signal
           image: netbirdio/signal:0.70.4
-          args: ["--port=80"]
+          args: ["--port=10000"]
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
-              add: ["NET_BIND_SERVICE"]
               drop: ["ALL"]
           livenessProbe:
             tcpSocket:
-              port: 80
+              port: 10000
             initialDelaySeconds: 30
             periodSeconds: 10
           readinessProbe:
             tcpSocket:
-              port: 80
+              port: 10000
             initialDelaySeconds: 10
             periodSeconds: 5
           ports:
-            - containerPort: 80
+            - containerPort: 10000
               name: grpc
 ---
 apiVersion: v1
@@ -63,7 +62,7 @@ metadata:
 spec:
   ports:
     - port: 80
-      targetPort: 80
+      targetPort: 10000
       name: grpc
   selector:
     app: netbird-signal

--- a/apps/40-network/netbird/overlays/prod/ingress.yaml
+++ b/apps/40-network/netbird/overlays/prod/ingress.yaml
@@ -35,64 +35,6 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: netbird-api
-  namespace: networking
-  labels:
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    traefik.ingress.kubernetes.io/router.entrypoints: websecure
-    traefik.ingress.kubernetes.io/service.serversscheme: h2c
-    vixens.io/nossoneeded: "true"
-spec:
-  ingressClassName: traefik
-  rules:
-    - host: netbird-api.truxonline.com
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: netbird-management
-                port:
-                  number: 80
-  tls:
-    - hosts:
-        - netbird-api.truxonline.com
-      secretName: netbird-api-tls
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: netbird-signal
-  namespace: networking
-  labels:
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    traefik.ingress.kubernetes.io/router.entrypoints: websecure
-    traefik.ingress.kubernetes.io/service.serversscheme: h2c
-    vixens.io/nossoneeded: "true"
-spec:
-  ingressClassName: traefik
-  rules:
-    - host: netbird-signal.truxonline.com
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: netbird-signal
-                port:
-                  number: 80
-  tls:
-    - hosts:
-        - netbird-signal.truxonline.com
-      secretName: netbird-signal-tls
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
   name: netbird-relay
   namespace: networking
   labels:
@@ -117,3 +59,73 @@ spec:
     - hosts:
         - netbird-relay.truxonline.com
       secretName: netbird-relay-tls
+---
+# Management gRPC — Traefik annotation h2c ignorée sur Ingress, IngressRoute requis
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: netbird-api-tls
+  namespace: networking
+spec:
+  secretName: netbird-api-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+    - netbird-api.truxonline.com
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: netbird-api
+  namespace: networking
+  annotations:
+    vixens.io/nossoneeded: "true"
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`netbird-api.truxonline.com`)
+      kind: Rule
+      services:
+        - name: netbird-management
+          port: 80
+          scheme: h2c
+          passHostHeader: true
+  tls:
+    secretName: netbird-api-tls
+---
+# Signal gRPC — port 10000 via service, h2c requis
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: netbird-signal-tls
+  namespace: networking
+spec:
+  secretName: netbird-signal-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+    - netbird-signal.truxonline.com
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: netbird-signal
+  namespace: networking
+  annotations:
+    vixens.io/nossoneeded: "true"
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`netbird-signal.truxonline.com`)
+      kind: Rule
+      services:
+        - name: netbird-signal
+          port: 80
+          scheme: h2c
+          passHostHeader: true
+  tls:
+    secretName: netbird-signal-tls

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -60,7 +60,7 @@ spec:
           args:
             - |
               set -e
-              TOOLS_VERSION="8"
+              TOOLS_VERSION="9"
               if [ -f /data/tools/.installed-version ] && [ "$(cat /data/tools/.installed-version)" = "$TOOLS_VERSION" ]; then
                 echo "Tools v$TOOLS_VERSION already present, skipping reinstall"
               else
@@ -77,9 +77,11 @@ spec:
                   ldd /usr/bin/$bin 2>/dev/null | grep "=>" | awk '{print $3}' | xargs -I {} cp {} /data/tools/lib/ 2>/dev/null || true
                 done
                 cp -r /usr/lib/x86_64-linux-gnu/* /data/tools/lib/ 2>/dev/null || true
-                # Copy python3 binary and stdlib
-                cp /usr/bin/python3* /data/tools/bin/ 2>/dev/null || true
-                cp -r /usr/lib/python3* /data/tools/lib/ 2>/dev/null || true
+                # Install portable Python via python-build-standalone (self-contained, glibc 2.17+)
+                curl -sLo /tmp/python.tar.gz "https://github.com/indygreg/python-build-standalone/releases/download/20250408/cpython-3.13.3+20250408-x86_64-unknown-linux-gnu-install_only.tar.gz"
+                tar -xzf /tmp/python.tar.gz -C /data/tools/ && rm /tmp/python.tar.gz
+                ln -sf /data/tools/python/bin/python3 /data/tools/bin/python3
+                ln -sf /data/tools/python/bin/python3.13 /data/tools/bin/python3.13
                 curl -sLo /data/tools/bin/kubectl "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
                 chmod +x /data/tools/bin/kubectl
                 curl -sLo /tmp/rclone.zip https://downloads.rclone.org/rclone-current-linux-amd64.zip


### PR DESCRIPTION
Closes #3123

## Summary
- Remplace les Ingress `netbird-api` et `netbird-signal` par des **IngressRoute Traefik** avec `scheme: h2c` explicite — l'annotation `traefik.ingress.kubernetes.io/service.serversscheme: h2c` sur Ingress Kubernetes n'est pas respectée par Traefik
- Ajoute des **Certificate** cert-manager pour gérer les TLS secrets (IngressRoute ne supporte pas l'annotation cert-manager nativement)
- Corrige le port du signal : container `--port=10000`, service `targetPort: 10000`, probes 10000, retire `NET_BIND_SERVICE` (plus nécessaire pour port > 1024)
- Dashboard et relay conservent leurs Ingress classiques (HTTP/1.1 suffisant)

## Test plan
- [ ] ArgoCD sync netbird sans erreur
- [ ] Certificats netbird-api-tls et netbird-signal-tls émis par cert-manager
- [ ] Clients NetBird se connectent (management + signal)
- [ ] Dashboard accessible sur netbird.truxonline.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Infrastructure Updates**
  * NetBird signal service updated to use port 10000 with refreshed health checks
  * API/signal routing enhanced with improved certificate management and explicit h2c protocol support
  * Python tools updated to version 9 with new provisioning method

<!-- end of auto-generated comment: release notes by coderabbit.ai -->