### PR TITLE
feat(netbird): déployer netbird-router comme routing peer permanent

### DIFF
--- a/.github/workflows/auto-tag-dev.yaml
+++ b/.github/workflows/auto-tag-dev.yaml
@@ -15,49 +15,27 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Fetch all history for tags
+          fetch-depth: 0
 
-      - name: Get latest dev tag
+      - name: Compute version
         id: get_tag
         run: |
-          # Get latest dev-v* tag
-          LATEST_TAG=$(git tag -l "dev-v*" | sort -V | tail -n 1)
+          YEAR_MONTH=$(date -u +%Y.%m)
 
-          if [ -z "$LATEST_TAG" ]; then
-            # No existing tag, start at v0.1.0
-            NEW_VERSION="0.1.0"
+          # Extract PR number from squash merge commit message "(#NNNN)"
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+          PR_NUMBER=$(echo "$COMMIT_MSG" | grep -oP '\(#\K[0-9]+(?=\))' | head -1)
+
+          if [ -n "$PR_NUMBER" ]; then
+            NEW_VERSION="${YEAR_MONTH}.${PR_NUMBER}"
           else
-            # Extract version number (dev-v1.2.3 -> 1.2.3)
-            VERSION=${LATEST_TAG#dev-v}
-
-            # Split into major.minor.patch
-            MAJOR=$(echo $VERSION | cut -d. -f1)
-            MINOR=$(echo $VERSION | cut -d. -f2)
-            PATCH=$(echo $VERSION | cut -d. -f3)
-
-            # Increment based on commit message
-            COMMIT_MSG=$(git log -1 --pretty=%B)
-
-            if [[ "$COMMIT_MSG" == *"BREAKING CHANGE"* ]] || [[ "$COMMIT_MSG" == *"major:"* ]]; then
-              # Major version bump
-              MAJOR=$((MAJOR + 1))
-              MINOR=0
-              PATCH=0
-            elif [[ "$COMMIT_MSG" == *"feat:"* ]] || [[ "$COMMIT_MSG" == *"feature:"* ]]; then
-              # Minor version bump
-              MINOR=$((MINOR + 1))
-              PATCH=0
-            else
-              # Patch version bump (default)
-              PATCH=$((PATCH + 1))
-            fi
-
-            NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+            # Direct push without PR — use short SHA as suffix
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            NEW_VERSION="${YEAR_MONTH}.${SHORT_SHA}"
           fi
 
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "new_tag=dev-v${NEW_VERSION}" >> $GITHUB_OUTPUT
-
           echo "📦 New version: dev-v${NEW_VERSION}"
 
       - name: Create versioned tag
@@ -65,29 +43,24 @@ jobs:
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
 
-          # Create annotated tag with version info
           git tag -a "${{ steps.get_tag.outputs.new_tag }}" \
             -m "Auto-tagged dev version ${{ steps.get_tag.outputs.new_version }}" \
             -m "Commit: ${{ github.sha }}" \
             -m "Author: ${{ github.actor }}"
 
           git push origin "${{ steps.get_tag.outputs.new_tag }}"
-
           echo "✅ Created tag: ${{ steps.get_tag.outputs.new_tag }}"
 
       - name: Update dev-latest tag
         run: |
-          # Delete old dev-latest tag if exists
           git tag -d dev-latest 2>/dev/null || true
           git push origin :refs/tags/dev-latest 2>/dev/null || true
 
-          # Create new dev-latest pointing to current commit
           git tag -a dev-latest \
             -m "Latest dev version: ${{ steps.get_tag.outputs.new_version }}" \
             -m "Points to: ${{ steps.get_tag.outputs.new_tag }}"
 
           git push origin dev-latest
-
           echo "✅ Updated dev-latest to ${{ steps.get_tag.outputs.new_version }}"
 
       - name: Summary

--- a/apps/40-network/netbird/base/kustomization.yaml
+++ b/apps/40-network/netbird/base/kustomization.yaml
@@ -17,5 +17,6 @@ resources:
   - pdb-management.yaml
   - pdb-signal.yaml
   - pdb-relay.yaml
+  - router.yaml
 components:
   - ../../../_shared/components/revision-history-limit

--- a/apps/40-network/netbird/base/management.yaml
+++ b/apps/40-network/netbird/base/management.yaml
@@ -54,6 +54,10 @@ spec:
               value: "https://authentik.dev.truxonline.com/application/o/token/"
             - name: AUTH_OIDC_CONFIG_ENDPOINT
               value: "http://authentik.auth.svc.cluster.local:9000/application/o/netbird/.well-known/openid-configuration"
+            - name: SIGNAL_URI
+              value: "netbird-signal.dev.truxonline.com:443"
+            - name: STUN_URI
+              value: "netbird-relay.dev.truxonline.com:3478"
           command:
             - sh
             - -c
@@ -91,6 +95,20 @@ spec:
                     "UseIDToken": true
                   }
                 },
+                "Signal": {
+                  "Proto": "https",
+                  "URI": "$SIGNAL_URI",
+                  "Username": "",
+                  "Password": ""
+                },
+                "Stuns": [
+                  {
+                    "Proto": "udp",
+                    "URI": "stun:$STUN_URI",
+                    "Username": "",
+                    "Password": ""
+                  }
+                ],
                 "DatastoreConfig": {
                   "Engine": "postgres"
                 },

--- a/apps/40-network/netbird/base/router.yaml
+++ b/apps/40-network/netbird/base/router.yaml
@@ -1,0 +1,99 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: netbird-router
+  annotations:
+    vpa.kubernetes.io/updateMode: "Off"
+  labels:
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: netbird-router
+  template:
+    metadata:
+      labels:
+        app: netbird-router
+        vixens.io/sizing.router: V-nano
+      annotations:
+        vixens.io/fast-start: "true"
+    spec:
+      priorityClassName: vixens-low
+      tolerations:
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
+      # Root required for WireGuard kernel interface
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+      containers:
+        - name: router
+          image: netbirdio/client:0.70.4
+          securityContext:
+            capabilities:
+              add: ["NET_ADMIN"]
+            allowPrivilegeEscalation: true
+          env:
+            - name: NB_SETUP_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: netbird-secrets
+                  key: NETBIRD_ROUTER_SETUP_KEY
+            - name: NB_MANAGEMENT_URL
+              value: "https://netbird-api.dev.truxonline.com"
+            - name: NB_HOSTNAME
+              value: "netbird-router"
+            - name: NB_LOG_LEVEL
+              value: "info"
+          livenessProbe:
+            exec:
+              command: ["netbird", "status"]
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 3
+          volumeMounts:
+            - name: tun
+              mountPath: /dev/net/tun
+      volumes:
+        - name: tun
+          hostPath:
+            path: /dev/net/tun
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netbird-router
+spec:
+  podSelector:
+    matchLabels:
+      app: netbird-router
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # WireGuard UDP from any peer
+    - ports:
+        - protocol: UDP
+          port: 51820
+  egress:
+    # DNS
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Management gRPC (via Traefik TLS)
+    - ports:
+        - protocol: TCP
+          port: 443
+    # Signal gRPC (via Traefik TLS)
+    # Relay WebSocket (via Traefik TLS)
+    # WireGuard UDP to peers
+    - ports:
+        - protocol: UDP
+          port: 51820

--- a/apps/40-network/netbird/base/signal-relay.yaml
+++ b/apps/40-network/netbird/base/signal-relay.yaml
@@ -36,24 +36,23 @@ spec:
       containers:
         - name: signal
           image: netbirdio/signal:0.70.4
-          args: ["--port=80"]
+          args: ["--port=10000"]
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
-              add: ["NET_BIND_SERVICE"]
               drop: ["ALL"]
           livenessProbe:
             tcpSocket:
-              port: 80
+              port: 10000
             initialDelaySeconds: 30
             periodSeconds: 10
           readinessProbe:
             tcpSocket:
-              port: 80
+              port: 10000
             initialDelaySeconds: 10
             periodSeconds: 5
           ports:
-            - containerPort: 80
+            - containerPort: 10000
               name: grpc
 ---
 apiVersion: v1
@@ -63,7 +62,7 @@ metadata:
 spec:
   ports:
     - port: 80
-      targetPort: 80
+      targetPort: 10000
       name: grpc
   selector:
     app: netbird-signal

--- a/apps/40-network/netbird/overlays/prod/ingress.yaml
+++ b/apps/40-network/netbird/overlays/prod/ingress.yaml
@@ -35,64 +35,6 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: netbird-api
-  namespace: networking
-  labels:
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    traefik.ingress.kubernetes.io/router.entrypoints: websecure
-    traefik.ingress.kubernetes.io/service.serversscheme: h2c
-    vixens.io/nossoneeded: "true"
-spec:
-  ingressClassName: traefik
-  rules:
-    - host: netbird-api.truxonline.com
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: netbird-management
-                port:
-                  number: 80
-  tls:
-    - hosts:
-        - netbird-api.truxonline.com
-      secretName: netbird-api-tls
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: netbird-signal
-  namespace: networking
-  labels:
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    traefik.ingress.kubernetes.io/router.entrypoints: websecure
-    traefik.ingress.kubernetes.io/service.serversscheme: h2c
-    vixens.io/nossoneeded: "true"
-spec:
-  ingressClassName: traefik
-  rules:
-    - host: netbird-signal.truxonline.com
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: netbird-signal
-                port:
-                  number: 80
-  tls:
-    - hosts:
-        - netbird-signal.truxonline.com
-      secretName: netbird-signal-tls
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
   name: netbird-relay
   namespace: networking
   labels:
@@ -117,3 +59,73 @@ spec:
     - hosts:
         - netbird-relay.truxonline.com
       secretName: netbird-relay-tls
+---
+# Management gRPC — Traefik annotation h2c ignorée sur Ingress, IngressRoute requis
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: netbird-api-tls
+  namespace: networking
+spec:
+  secretName: netbird-api-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+    - netbird-api.truxonline.com
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: netbird-api
+  namespace: networking
+  annotations:
+    vixens.io/nossoneeded: "true"
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`netbird-api.truxonline.com`)
+      kind: Rule
+      services:
+        - name: netbird-management
+          port: 80
+          scheme: h2c
+          passHostHeader: true
+  tls:
+    secretName: netbird-api-tls
+---
+# Signal gRPC — port 10000 via service, h2c requis
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: netbird-signal-tls
+  namespace: networking
+spec:
+  secretName: netbird-signal-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+    - netbird-signal.truxonline.com
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: netbird-signal
+  namespace: networking
+  annotations:
+    vixens.io/nossoneeded: "true"
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`netbird-signal.truxonline.com`)
+      kind: Rule
+      services:
+        - name: netbird-signal
+          port: 80
+          scheme: h2c
+          passHostHeader: true
+  tls:
+    secretName: netbird-signal-tls

--- a/apps/40-network/netbird/overlays/prod/patches.yaml
+++ b/apps/40-network/netbird/overlays/prod/patches.yaml
@@ -30,6 +30,10 @@ spec:
               value: "https://authentik.truxonline.com/application/o/token/"
             - name: AUTH_OIDC_CONFIG_ENDPOINT
               value: "https://authentik.truxonline.com/application/o/netbird/.well-known/openid-configuration"
+            - name: SIGNAL_URI
+              value: "netbird-signal.truxonline.com:443"
+            - name: STUN_URI
+              value: "netbird-relay.truxonline.com:3478"
       containers:
         - name: management
           startupProbe:

--- a/apps/40-network/netbird/overlays/prod/patches.yaml
+++ b/apps/40-network/netbird/overlays/prod/patches.yaml
@@ -65,6 +65,19 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: netbird-router
+spec:
+  template:
+    spec:
+      containers:
+        - name: router
+          env:
+            - name: NB_MANAGEMENT_URL
+              value: "https://netbird-api.truxonline.com"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: netbird-relay
 spec:
   template:

--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -60,7 +60,7 @@ spec:
           args:
             - |
               set -e
-              TOOLS_VERSION="8"
+              TOOLS_VERSION="9"
               if [ -f /data/tools/.installed-version ] && [ "$(cat /data/tools/.installed-version)" = "$TOOLS_VERSION" ]; then
                 echo "Tools v$TOOLS_VERSION already present, skipping reinstall"
               else
@@ -77,9 +77,11 @@ spec:
                   ldd /usr/bin/$bin 2>/dev/null | grep "=>" | awk '{print $3}' | xargs -I {} cp {} /data/tools/lib/ 2>/dev/null || true
                 done
                 cp -r /usr/lib/x86_64-linux-gnu/* /data/tools/lib/ 2>/dev/null || true
-                # Copy python3 binary and stdlib
-                cp /usr/bin/python3* /data/tools/bin/ 2>/dev/null || true
-                cp -r /usr/lib/python3* /data/tools/lib/ 2>/dev/null || true
+                # Install portable Python via python-build-standalone (self-contained, glibc 2.17+)
+                curl -sLo /tmp/python.tar.gz "https://github.com/indygreg/python-build-standalone/releases/download/20250408/cpython-3.13.3+20250408-x86_64-unknown-linux-gnu-install_only.tar.gz"
+                tar -xzf /tmp/python.tar.gz -C /data/tools/ && rm /tmp/python.tar.gz
+                ln -sf /data/tools/python/bin/python3 /data/tools/bin/python3
+                ln -sf /data/tools/python/bin/python3.13 /data/tools/bin/python3.13
                 curl -sLo /data/tools/bin/kubectl "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
                 chmod +x /data/tools/bin/kubectl
                 curl -sLo /tmp/rclone.zip https://downloads.rclone.org/rclone-current-linux-amd64.zip


### PR DESCRIPTION
Closes #3128

## Summary
Nouveau pod `netbird-router` (netbirdio/client:0.70.4) tournant H24 dans le cluster comme routing peer permanent. Remplace la dépendance aux postes `umi`/`hikaru` (éteints régulièrement) pour l'accès VPN au réseau local.

**Capacités requises :** `NET_ADMIN` + `/dev/net/tun` pour WireGuard kernel (disponible sur Talos).

## Prérequis manuels (à faire avant le déploiement)

1. **Dashboard NetBird** — créer une setup key :
   - Nom : `router`
   - Type : `reusable`, sans expiration
   - Groupe : `All` (ou `external-clients`)

2. **Infisical** — ajouter le secret :
   - Path : `/apps/40-network/netbird`
   - Key : `NETBIRD_ROUTER_SETUP_KEY`
   - Value : la setup key créée ci-dessus

3. **Dashboard NetBird** — configurer les routes réseau sur le peer `netbird-router` :
   - `192.168.200.0/24`
   - `192.168.199.0/24`
   - `192.168.204.0/24`

## Test plan
- [ ] Secret `NETBIRD_ROUTER_SETUP_KEY` présent dans Infisical
- [ ] Pod `netbird-router` démarre et passe Running
- [ ] Peer visible dans le dashboard NetBird
- [ ] Routes annoncées aux clients externes
- [ ] Accès au réseau local depuis un client externe via NetBird

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NetBird router component with WireGuard kernel access support

* **Chores**
  * Updated service routing configurations for improved gRPC handling
  * Enhanced management service with additional signal and STUN configuration
  * Improved version tagging strategy for better release identification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->