### PR TITLE
fix(netbird-router): image netbirdio/netbird + backup-profile ephemeral

### DIFF
--- a/apps/40-network/netbird/base/router.yaml
+++ b/apps/40-network/netbird/base/router.yaml
@@ -59,9 +59,13 @@ spec:
             failureThreshold: 3
             timeoutSeconds: 10
           volumeMounts:
+            - name: netbird-data
+              mountPath: /var/lib/netbird
             - name: tun
               mountPath: /dev/net/tun
       volumes:
+        - name: netbird-data
+          emptyDir: {}
         - name: tun
           hostPath:
             path: /dev/net/tun

--- a/apps/40-network/netbird/base/router.yaml
+++ b/apps/40-network/netbird/base/router.yaml
@@ -19,6 +19,7 @@ spec:
       labels:
         app: netbird-router
         vixens.io/sizing.router: V-nano
+        vixens.io/backup-profile: "ephemeral"
       annotations:
         vixens.io/fast-start: "true"
     spec:
@@ -33,7 +34,7 @@ spec:
         runAsGroup: 0
       containers:
         - name: router
-          image: netbirdio/client:0.70.4
+          image: netbirdio/netbird:0.70.4
           securityContext:
             capabilities:
               add: ["NET_ADMIN"]
@@ -52,10 +53,11 @@ spec:
               value: "info"
           livenessProbe:
             exec:
-              command: ["netbird", "status"]
+              command: ["netbird", "status", "--json"]
             initialDelaySeconds: 60
             periodSeconds: 30
             failureThreshold: 3
+            timeoutSeconds: 10
           volumeMounts:
             - name: tun
               mountPath: /dev/net/tun


### PR DESCRIPTION
Fix post-déploiement suite aux erreurs observées :
- `netbirdio/client:0.70.4` n'existe pas → remplacé par `netbirdio/netbird:0.70.4`
- Label `vixens.io/backup-profile: ephemeral` manquant (violation Kyverno policy Emerald)

🤖 Generated with [Claude Code](https://claude.com/claude-code)