### PR TITLE
fix(netbird-router): passer --setup-key explicitement à netbird up

### DIFF
--- a/apps/40-network/netbird/base/router.yaml
+++ b/apps/40-network/netbird/base/router.yaml
@@ -35,6 +35,15 @@ spec:
       containers:
         - name: router
           image: netbirdio/netbird:0.70.4
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              netbird service run &
+              sleep 10
+              netbird up --setup-key "$NB_SETUP_KEY" --management-url "$NB_MANAGEMENT_URL"
+              wait
           securityContext:
             capabilities:
               add: ["NET_ADMIN"]


### PR DESCRIPTION
L'entrypoint officiel `netbird-entrypoint.sh` appelle `netbird up` sans `--setup-key`.
La variable `NB_SETUP_KEY` n'est pas lue comme env var par le CLI netbird (contrairement à `NB_MANAGEMENT_URL`).

Fix: surcharge la commande container pour appeler explicitement `netbird up --setup-key $NB_SETUP_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)