### PR TITLE
fix(netbird-router): privileged + seccomp Unconfined pour WireGuard

### DIFF
--- a/apps/40-network/netbird/base/router.yaml
+++ b/apps/40-network/netbird/base/router.yaml
@@ -28,10 +28,12 @@ spec:
         - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
-      # Root required for WireGuard kernel interface
+      # Root + privileged requis pour WireGuard (raw sockets + sysctl)
       securityContext:
         runAsUser: 0
         runAsGroup: 0
+        seccompProfile:
+          type: Unconfined
       containers:
         - name: router
           image: netbirdio/netbird:0.70.4
@@ -45,9 +47,7 @@ spec:
               netbird up --setup-key "$NB_SETUP_KEY" --management-url "$NB_MANAGEMENT_URL"
               wait
           securityContext:
-            capabilities:
-              add: ["NET_ADMIN"]
-            allowPrivilegeEscalation: true
+            privileged: true
           env:
             - name: NB_SETUP_KEY
               valueFrom:

--- a/apps/40-network/netbird/base/router.yaml
+++ b/apps/40-network/netbird/base/router.yaml
@@ -35,6 +35,15 @@ spec:
       containers:
         - name: router
           image: netbirdio/netbird:0.70.4
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              netbird service run &
+              sleep 10
+              netbird up --setup-key "$NB_SETUP_KEY" --management-url "$NB_MANAGEMENT_URL"
+              wait
           securityContext:
             capabilities:
               add: ["NET_ADMIN"]


### PR DESCRIPTION
NET_ADMIN seul insuffisant pour WireGuard dans Kubernetes sur Talos :
- `failed to create ipv4 raw socket: operation not permitted` → NET_RAW requis
- `write sysctl net.ipv4.conf.all.src_valid_mark: read-only file system` → SYS_ADMIN requis

Fix : conteneur `privileged: true` + seccompProfile `Unconfined` au niveau pod.
Justifié pour un routing peer WireGuard (cas d'usage réseau système).

🤖 Generated with [Claude Code](https://claude.com/claude-code)