### PR TITLE
fix(netbird-router): fix securityContext conflict blocking pod creation

### DIFF
--- a/apps/40-network/netbird/base/router.yaml
+++ b/apps/40-network/netbird/base/router.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     vpa.kubernetes.io/updateMode: "Off"
   labels:
+    app.kubernetes.io/managed-by: argocd
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -48,6 +49,9 @@ spec:
               wait
           securityContext:
             privileged: true
+            allowPrivilegeEscalation: true
+            capabilities:
+              drop: []
           env:
             - name: NB_SETUP_KEY
               valueFrom:
@@ -66,6 +70,13 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 30
             failureThreshold: 3
+            timeoutSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["netbird", "status", "--json"]
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 5
             timeoutSeconds: 10
           volumeMounts:
             - name: netbird-data


### PR DESCRIPTION
## Summary
- Fix `allowPrivilegeEscalation=false` + `privileged=true` conflict (Kyverno mutation injects `drop: ALL` + `allowPrivilegeEscalation: false` which is incompatible with `privileged: true`)
- Add `readinessProbe` (required by Kyverno `require-probes` policy)
- Add `app.kubernetes.io/managed-by: argocd` label (required by Kyverno label policy)

## Test plan
- [ ] Pod creates successfully (no `FailedCreate` events)
- [ ] Pod reaches Running state
- [ ] `netbird status` returns connected
- [ ] Router peer visible in NetBird dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)