### PR TITLE
fix(netbird-router): bypass Kyverno security mutation for privileged WireGuard pod

### DIFF
--- a/apps/40-network/netbird/base/router.yaml
+++ b/apps/40-network/netbird/base/router.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     vpa.kubernetes.io/updateMode: "Off"
   labels:
+    app.kubernetes.io/managed-by: argocd
 spec:
   replicas: 1
   revisionHistoryLimit: 3
@@ -48,6 +49,9 @@ spec:
               wait
           securityContext:
             privileged: true
+            allowPrivilegeEscalation: true
+            capabilities:
+              drop: []
           env:
             - name: NB_SETUP_KEY
               valueFrom:
@@ -66,6 +70,13 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 30
             failureThreshold: 3
+            timeoutSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["netbird", "status", "--json"]
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 5
             timeoutSeconds: 10
           volumeMounts:
             - name: netbird-data

--- a/apps/40-network/netbird/base/router.yaml
+++ b/apps/40-network/netbird/base/router.yaml
@@ -23,6 +23,7 @@ spec:
         vixens.io/backup-profile: "ephemeral"
       annotations:
         vixens.io/fast-start: "true"
+        vixens.io/explicitly-allow-root: "true"
     spec:
       priorityClassName: vixens-low
       tolerations:
@@ -49,9 +50,6 @@ spec:
               wait
           securityContext:
             privileged: true
-            allowPrivilegeEscalation: true
-            capabilities:
-              drop: []
           env:
             - name: NB_SETUP_KEY
               valueFrom:


### PR DESCRIPTION
## Summary
- Add `vixens.io/explicitly-allow-root: "true"` pod annotation to bypass `mutate-security-context` Kyverno policy
- Policy injects `allowPrivilegeEscalation: false` unconditionally, which is incompatible with `privileged: true` (Kubernetes API rejects the combination)
- WireGuard requires privileged mode for raw socket creation and sysctl manipulation

## Test plan
- [ ] Pod creates successfully (no `FailedCreate` events)
- [ ] Pod reaches Running state
- [ ] `netbird status` returns connected
- [ ] Router peer visible in NetBird dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)