### PR TITLE
fix(netbird): persist router identity via PVC instead of emptyDir

### DIFF
--- a/apps/40-network/netbird/base/kustomization.yaml
+++ b/apps/40-network/netbird/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - infra.yaml
   - management.yaml
   - pvc-data.yaml
+  - pvc-router-data.yaml
   - dashboard.yaml
   - signal-relay.yaml
   - ca-bundle.yaml

--- a/apps/40-network/netbird/base/pvc-router-data.yaml
+++ b/apps/40-network/netbird/base/pvc-router-data.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: netbird-router-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: synelia-iscsi-retain
+  resources:
+    requests:
+      storage: 1Gi

--- a/apps/40-network/netbird/base/router.yaml
+++ b/apps/40-network/netbird/base/router.yaml
@@ -86,7 +86,8 @@ spec:
               mountPath: /dev/net/tun
       volumes:
         - name: netbird-data
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: netbird-router-data
         - name: tun
           hostPath:
             path: /dev/net/tun


### PR DESCRIPTION
## Summary

- Remplace `emptyDir` par un PVC dédié (`netbird-router-data`, 1Gi) pour `/var/lib/netbird`
- Chaque restart créait un nouveau peer NetBird — ce fix le prévient

🤖 Generated with [Claude Code](https://claude.com/claude-code)