### PR TITLE
fix(openclaw): copy Debian python3 instead of unreliable python-build-standalone

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -60,7 +60,7 @@ spec:
           args:
             - |
               set -e
-              TOOLS_VERSION="9"
+              TOOLS_VERSION="10"
               if [ -f /data/tools/.installed-version ] && [ "$(cat /data/tools/.installed-version)" = "$TOOLS_VERSION" ]; then
                 echo "Tools v$TOOLS_VERSION already present, skipping reinstall"
               else
@@ -77,9 +77,12 @@ spec:
                   ldd /usr/bin/$bin 2>/dev/null | grep "=>" | awk '{print $3}' | xargs -I {} cp {} /data/tools/lib/ 2>/dev/null || true
                 done
                 cp -r /usr/lib/x86_64-linux-gnu/* /data/tools/lib/ 2>/dev/null || true
-                # Install portable Python via python-build-standalone (self-contained, glibc 2.17+)
-                curl -sLo /tmp/python.tar.gz "https://github.com/indygreg/python-build-standalone/releases/download/20250408/cpython-3.13.3+20250408-x86_64-unknown-linux-gnu-install_only.tar.gz"
-                tar -xzf /tmp/python.tar.gz -C /data/tools/ && rm /tmp/python.tar.gz
+                # Copy Debian python3 directly — avoids external download (python-build-standalone was unreliable)
+                mkdir -p /data/tools/python/bin /data/tools/python/lib
+                cp /usr/bin/python3.13 /data/tools/python/bin/python3.13
+                cp -r /usr/lib/python3.13 /data/tools/python/lib/ 2>/dev/null || true
+                cp -r /usr/lib/python3 /data/tools/python/lib/ 2>/dev/null || true
+                ln -sf /data/tools/python/bin/python3.13 /data/tools/python/bin/python3
                 ln -sf /data/tools/python/bin/python3 /data/tools/bin/python3
                 ln -sf /data/tools/python/bin/python3.13 /data/tools/bin/python3.13
                 curl -sLo /data/tools/bin/kubectl "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"


### PR DESCRIPTION
## Problème

`curl` sans `--fail` téléchargeait silencieusement une page d'erreur GitHub. `tar` échouait, mais `ln -sf` créait quand même un symlink cassé (`/data/tools/bin/python3 → /data/tools/python/bin/python3` inexistant). Python3 inaccessible pour les agents.

## Fix

Copie directement le python3.13 Debian (déjà installé par apt-get dans le même init container). Pas de dépendance réseau externe, pas de GitHub download.

TOOLS_VERSION bumped to 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped tools cache version, which will trigger tool reinstallation on next run
  * Updated Python environment setup to use offline Debian-based Python 3.13

<!-- end of auto-generated comment: release notes by coderabbit.ai -->