### PR TITLE
fix(openclaw): curl --fail for python-build-standalone, revert glibc-incompatible copy (v11)

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -60,7 +60,7 @@ spec:
           args:
             - |
               set -e
-              TOOLS_VERSION="10"
+              TOOLS_VERSION="11"
               if [ -f /data/tools/.installed-version ] && [ "$(cat /data/tools/.installed-version)" = "$TOOLS_VERSION" ]; then
                 echo "Tools v$TOOLS_VERSION already present, skipping reinstall"
               else
@@ -77,12 +77,9 @@ spec:
                   ldd /usr/bin/$bin 2>/dev/null | grep "=>" | awk '{print $3}' | xargs -I {} cp {} /data/tools/lib/ 2>/dev/null || true
                 done
                 cp -r /usr/lib/x86_64-linux-gnu/* /data/tools/lib/ 2>/dev/null || true
-                # Copy Debian python3 directly — avoids external download (python-build-standalone was unreliable)
-                mkdir -p /data/tools/python/bin /data/tools/python/lib
-                cp /usr/bin/python3.13 /data/tools/python/bin/python3.13
-                cp -r /usr/lib/python3.13 /data/tools/python/lib/ 2>/dev/null || true
-                cp -r /usr/lib/python3 /data/tools/python/lib/ 2>/dev/null || true
-                ln -sf /data/tools/python/bin/python3.13 /data/tools/python/bin/python3
+                # Install portable Python via python-build-standalone (glibc 2.17+, compatible with bookworm 2.36)
+                curl -fsSLo /tmp/python.tar.gz "https://github.com/indygreg/python-build-standalone/releases/download/20250408/cpython-3.13.3+20250408-x86_64-unknown-linux-gnu-install_only.tar.gz"
+                tar -xzf /tmp/python.tar.gz -C /data/tools/ && rm /tmp/python.tar.gz
                 ln -sf /data/tools/python/bin/python3 /data/tools/bin/python3
                 ln -sf /data/tools/python/bin/python3.13 /data/tools/bin/python3.13
                 curl -sLo /data/tools/bin/kubectl "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"


### PR DESCRIPTION
## Problème

v10 copiait le python3 Debian trixie (glibc 2.38) dans openclaw/bookworm (glibc 2.36) → incompatible.

## Fix

Revient à python-build-standalone (glibc 2.17+, compatible bookworm 2.36) mais avec `curl -f` (`--fail`) pour que les erreurs HTTP soient rattrapées par `set -e` au lieu de créer un symlink cassé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated toolset provisioning version tracking in deployment configuration.
  * Modified Python 3.13 installation approach to use portable distribution instead of system binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->