### PR TITLE
fix(openclaw): update python-build-standalone URL (astral-sh, 20260414, v12)

### DIFF
--- a/apps/60-services/openclaw/base/deployment.yaml
+++ b/apps/60-services/openclaw/base/deployment.yaml
@@ -60,7 +60,7 @@ spec:
           args:
             - |
               set -e
-              TOOLS_VERSION="11"
+              TOOLS_VERSION="12"
               if [ -f /data/tools/.installed-version ] && [ "$(cat /data/tools/.installed-version)" = "$TOOLS_VERSION" ]; then
                 echo "Tools v$TOOLS_VERSION already present, skipping reinstall"
               else
@@ -78,7 +78,7 @@ spec:
                 done
                 cp -r /usr/lib/x86_64-linux-gnu/* /data/tools/lib/ 2>/dev/null || true
                 # Install portable Python via python-build-standalone (glibc 2.17+, compatible with bookworm 2.36)
-                curl -fsSLo /tmp/python.tar.gz "https://github.com/indygreg/python-build-standalone/releases/download/20250408/cpython-3.13.3+20250408-x86_64-unknown-linux-gnu-install_only.tar.gz"
+                curl -fsSLo /tmp/python.tar.gz "https://github.com/astral-sh/python-build-standalone/releases/download/20260414/cpython-3.13.13%2B20260414-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
                 tar -xzf /tmp/python.tar.gz -C /data/tools/ && rm /tmp/python.tar.gz
                 ln -sf /data/tools/python/bin/python3 /data/tools/bin/python3
                 ln -sf /data/tools/python/bin/python3.13 /data/tools/bin/python3.13


### PR DESCRIPTION
Repo migré de `indygreg` → `astral-sh`, release `20250408` n'existe plus.
Mise à jour vers `cpython-3.13.13+20260414` install_only_stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python 3.13 provisioning method in deployment configuration, now using prebuilt standalone archive instead of copying Debian-provided libraries.
  * Incremented tools version identifier from 10 to 12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->