### PR TITLE
feat(storage+homeassistant): XFS StorageClasses + HA prod migration

### DIFF
--- a/apps/01-storage/synology-csi/overlays/dev/kustomization.yaml
+++ b/apps/01-storage/synology-csi/overlays/dev/kustomization.yaml
@@ -47,7 +47,7 @@ patches:
         value: "vixens-dev-iscsi-group"
       - op: add
         path: /parameters/targetIps
-        value: "192.168.111.70,192.168.111.71"
+        value: "192.168.111.69"
     target:
       kind: StorageClass
       name: synelia-iscsi-xfs-retain
@@ -57,7 +57,7 @@ patches:
         value: "vixens-dev-iscsi-group"
       - op: add
         path: /parameters/targetIps
-        value: "192.168.111.70,192.168.111.71"
+        value: "192.168.111.69"
     target:
       kind: StorageClass
       name: synelia-iscsi-xfs-delete

--- a/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
+++ b/apps/10-home/homeassistant/overlays/prod/kustomization.yaml
@@ -21,6 +21,9 @@ patches:
       name: homeassistant-config
     patch: |-
       - op: replace
+        path: /spec/storageClassName
+        value: synelia-iscsi-xfs-retain
+      - op: replace
         path: /spec/resources/requests/storage
         value: 250Gi
   - path: resources-patch.yaml


### PR DESCRIPTION
## Summary

- Fix dev XFS StorageClasses to use `192.168.111.69` (not `.70/.71` unreachable from daphne)
- Migrate Home Assistant prod PVC from `synelia-iscsi-retain` (ext4) to `synelia-iscsi-xfs-retain` (XFS)

## Why XFS?

XFS returns `EIO` on I/O error instead of ext4's `emergency_ro`. During the 2026-04-30 incident, ext4 volumes went read-only and weren't detected for 17 hours. XFS failures are detectable in minutes.

## Migration plan for prod HA PVC (manual steps after merge)

PVC `storageClassName` is immutable:
1. Scale down HA prod
2. Delete PVC `homeassistant-config` in namespace `homeassistant`
3. Promote `prod-stable` → ArgoCD recreates PVC with XFS
4. DataAngel restores `/config` from MinIO `vixens-prod-homeassistant`

## Test plan

- [x] XFS StorageClasses deployed and working on dev
- [x] HA dev ran on XFS volume (`df -Th` confirmed `xfs`)
- [ ] Prod migration after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated storage configuration settings for Synology CSI and Home Assistant deployments to optimize storage management and consistency across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->