### PR TITLE
fix(storage): add formatOptions=-K to XFS StorageClasses to skip BLKZEROOUT

### DIFF
--- a/apps/01-storage/synology-csi/base/storage-class.yaml
+++ b/apps/01-storage/synology-csi/base/storage-class.yaml
@@ -37,6 +37,8 @@ parameters:
   protocol: iscsi
   lunType: thin
   igroup: vixens-default-iscsi-group
+  # -K: skip TRIM/DISCARD on format — thin iSCSI LUNs hang indefinitely on DISCARD
+  formatOptions: "-K"
 reclaimPolicy: Retain
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
@@ -50,5 +52,7 @@ parameters:
   fsType: xfs
   protocol: iscsi
   lunType: thin
+  # -K: skip TRIM/DISCARD on format — thin iSCSI LUNs hang indefinitely on DISCARD
+  formatOptions: "-K"
 reclaimPolicy: Delete
 allowVolumeExpansion: true


### PR DESCRIPTION
## Summary

- Add `formatOptions: "-K"` to both XFS StorageClasses (`synelia-iscsi-xfs-retain` and `synelia-iscsi-xfs-delete`)
- `-K` skips the TRIM/DISCARD (BLKZEROOUT) step during `mkfs.xfs` formatting
- Without `-K`, Synology thin iSCSI LUNs hang indefinitely in D-state during format (WRITE SAME / BLKZEROOUT not supported)
- Discovered during HA prod XFS migration — mkfs.xfs blocked for hours at each AG boundary (125GiB, 187GiB…) before manual recovery with `mkfs.xfs -f -K`

## Root Cause

`mkfs.xfs -f` (without `-K`) sends DISCARD/UNMAP commands across the entire LUN before writing the filesystem superblock. Synology thin iSCSI LUNs return `EOPNOTSUPP` / `Invalid argument` on the `BLKZEROOUT` ioctl, causing the kernel process to block in uninterruptible D-state indefinitely.

## Test plan

- [x] XFS StorageClass `synelia-iscsi-xfs-retain` manually tested on HA prod (250Gi LUN formatted successfully with `-K`)
- [x] `blkid` confirmed `TYPE="xfs"` after format
- [x] CSI mount succeeded: `249.9G xfs` volume online

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated iSCSI storage class configurations to prevent timeout issues when formatting thin storage volumes. Added format options that skip unnecessary trim and discard operations during storage format operations, ensuring improved stability and reliability on thin-provisioned iSCSI LUNs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->