### PR TITLE
fix(frigate): add cleanup-cache init container to remove stale ZMQ socket

### DIFF
--- a/apps/20-media/frigate/base/deployment.yaml
+++ b/apps/20-media/frigate/base/deployment.yaml
@@ -46,6 +46,12 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /config
+      - name: cleanup-cache
+        image: busybox:1.37.0
+        command: ["sh", "-c", "rm -f /tmp/cache/comms /tmp/cache/.comms"]
+        volumeMounts:
+        - name: cache
+          mountPath: /tmp/cache
       - name: validate-config
         image: python:3.14-alpine
         command:


### PR DESCRIPTION
## Summary

- Add `cleanup-cache` init container to delete `/tmp/cache/comms` before frigate starts
- Frigate was crashlooping (264 restarts) because the ZMQ IPC socket file persists on the `frigate-cache-pvc` across pod restarts
- On restart, frigate tries to bind `ipc:///tmp/cache/comms` and gets `ZMQError: Address already in use`

## Root cause

`frigate-cache-pvc` is a persistent iSCSI PVC. When frigate crashes, the ZMQ socket file `/tmp/cache/comms` is left behind. On the next start, `InterProcessCommunicator.__init__` tries to bind the same path and fails immediately.

## Fix

New init container `cleanup-cache` (busybox) runs before `validate-config` and removes the stale socket files. Simple, targeted, no side effects on the cache data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)