### PR TITLE
feat(frigate): migrate prod PVCs to XFS StorageClass

### DIFF
--- a/apps/20-media/frigate/overlays/prod/pvc-patch.yaml
+++ b/apps/20-media/frigate/overlays/prod/pvc-patch.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "7"
 spec:
-  storageClassName: synelia-iscsi-retain
+  storageClassName: synelia-iscsi-xfs-retain
   resources:
     requests:
       storage: 50Gi
@@ -16,7 +16,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: frigate-cache-pvc
 spec:
-  storageClassName: synelia-iscsi-retain
+  storageClassName: synelia-iscsi-xfs-retain
   resources:
     requests:
       storage: 10Gi


### PR DESCRIPTION
## Summary

- Migrate `frigate-config-pvc` and `frigate-cache-pvc` from `synelia-iscsi-retain` (ext4) to `synelia-iscsi-xfs-retain` (XFS)
- XFS returns `EIO` on I/O error instead of ext4 silent `emergency_ro` remount — issues are detectable in minutes
- DataAngel backups (litestream SQLite + rclone `/config`) on MinIO S3 ensure safe migration

## Migration procedure (after merge + prod-stable)

1. Delete existing PVCs: `kubectl delete pvc -n media frigate-config-pvc frigate-cache-pvc`
2. Delete associated PVs (with `Retain` policy, PV stays Bound after PVC deletion)
3. ArgoCD recreates PVCs on `synelia-iscsi-xfs-retain` with `formatOptions=-K`
4. DataAngel init container restores from S3 (SQLite via litestream, config via rclone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated storage backend configuration for the Frigate application to use an alternative iSCSI storage class for improved persistence handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->