### PR TITLE
fix(homeassistant): increase DataAngel restore timeout to 90m

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         reloader.stakater.com/auto: "true"
         vixens.io/fast-start: "true"
         dataangel.io/metrics-port: "9090"
+        dataangel.io/restore-timeout: "90m"
         vixens.io/explicitly-allow-root: "true"
     spec:
       securityContext:

--- a/docs/post-mortems/2026-05-01-ha-frigate-iscsi-ext4-to-xfs.md
+++ b/docs/post-mortems/2026-05-01-ha-frigate-iscsi-ext4-to-xfs.md
@@ -1,0 +1,81 @@
+# Post-Mortem : HA + Frigate iSCSI ext4 emergency_ro → migration XFS (2026-05-01)
+
+**Sévérité :** P1 — Home Assistant non fonctionnel, Frigate en CrashLoop (264 restarts)  
+**Durée :** ~4h (détection ~00:00 UTC+2, recovery Home Assistant ~00:51, Frigate ~02:30)  
+**Nœuds affectés :** `sakapuss` (prod, HA), `sakapuss` (prod, Frigate)  
+**Volumes affectés :** `homeassistant-config` (ext4, `/dev/sd?`), `frigate-config-pvc` + `frigate-cache-pvc` (ext4)
+
+---
+
+## Timeline
+
+| Heure | Événement |
+|-------|-----------|
+| ~23:00 | HA entre en `emergency_ro` (ext4 I/O error sur iSCSI) — homeassistant pod en CrashLoop |
+| 00:00 | Détection — DataAngel init container en cours de WAL restore (litestream replay) |
+| 00:25 | WAL replay terminé (25 min) — démarrage de `PRAGMA integrity_check` sur 2.6 GB SQLite |
+| 00:51 | integrity_check terminé (26 min) — rclone sync, boot HA → `2/2 Running`, https://homeassistant.truxonline.com 200 OK |
+| ~01:00 | Investigation Frigate — 264 restarts, erreur ZMQ `ipc:///tmp/cache/comms: Address already in use` |
+| ~01:15 | Root cause ZMQ identifié : socket IPC persistant sur PVC `frigate-cache-pvc` ext4 en `emergency_ro` |
+| ~01:30 | Fix ZMQ : init container `cleanup-cache` ajouté (`rm -f /tmp/cache/comms /tmp/cache/.comms`) → PR #3152 |
+| ~01:45 | Décision migration XFS pour les PVCs Frigate (ext4 emergency_ro cassé, XFS retourne EIO immédiatement) |
+| ~02:00 | Migration PVCs Frigate vers `synelia-iscsi-xfs-retain` → PR #3153 |
+| ~02:10 | Deadlock WaitForFirstConsumer détecté : `frigate-config-pvc` (wave 7) attend que `frigate-cache-pvc` (wave 0) soit Bound, mais `frigate-cache-pvc` attend un pod, qui attend `frigate-config-pvc` |
+| ~02:15 | Déblocage manuel : `kubectl apply` de `frigate-config-pvc` pour briser le deadlock circulaire |
+| ~02:20 | DataAngel restore Frigate depuis S3 MinIO |
+| ~02:30 | Frigate `2/2 Running`, 0 restarts — https://frigate.truxonline.com 200 OK |
+| ~01:00 | PR #3151 : `formatOptions: "-K"` ajouté aux StorageClasses XFS (skip BLKZEROOUT sur thin LUNs) |
+
+---
+
+## Root Cause
+
+### 1. ext4 emergency_ro
+Le filesystem ext4 d'iSCSI bascule en `read-only` silencieux sur erreur I/O, plutôt que de retourner EIO. Cela corrompt l'état des applications sans erreur explicite (ZMQ socket orphelin, base de données inaccessible).
+
+### 2. ZMQ socket orphelin sur PVC
+Le socket IPC `/tmp/cache/comms` de Frigate persiste sur le PVC `frigate-cache-pvc` entre les redémarrages. Si le PVC est en `emergency_ro`, le `rm` du socket échoue (EROFS), empêchant le binding ZMQ → crash immédiat au démarrage.
+
+### 3. Deadlock WaitForFirstConsumer
+`frigate-config-pvc` avait `argocd.argoproj.io/sync-wave: "7"`, empêchant ArgoCD de le créer avant que `frigate-cache-pvc` (wave 0) soit Bound. Mais `frigate-cache-pvc` utilise `WaitForFirstConsumer` → ne bind que quand un pod est schedulé → le pod ne peut pas scheduler car `frigate-config-pvc` n'existe pas encore → deadlock.
+
+### 4. XFS StorageClass BLKZEROOUT hang
+La StorageClass `synelia-iscsi-xfs-retain` ne passait pas `formatOptions: "-K"`, ce qui causait `mkfs.xfs` à appeler `BLKZEROOUT` sur les thin LUNs Synology → hang indéfini (BLKZEROOUT non supporté sur thin LUNs Synology). Corrigé en PR #3151.
+
+---
+
+## Fix
+
+1. **PR #3151** : `formatOptions: "-K"` ajouté à `synelia-iscsi-xfs-retain` et `synelia-iscsi-xfs-delete` dans `apps/01-storage/synology-csi/base/storage-class.yaml`
+2. **PR #3152** : Init container `cleanup-cache` ajouté à Frigate (`rm -f /tmp/cache/comms /tmp/cache/.comms`) avant `validate-config`
+3. **PR #3153** : PVCs Frigate migrés de `synelia-iscsi-retain` (ext4) vers `synelia-iscsi-xfs-retain` (XFS)
+4. **Déblocage manuel** : `kubectl apply` de `frigate-config-pvc` pour briser le deadlock ArgoCD wave/WaitForFirstConsumer
+
+---
+
+## Lessons Learned
+
+### ext4 vs XFS sur iSCSI
+- **ext4** : remonte silencieusement en `read-only` (`emergency_ro`) sur erreur I/O — applications continuent sans le savoir
+- **XFS** : retourne `EIO` immédiatement sur erreur I/O — application crashe proprement, DataAngel peut restaurer
+- **Décision** : migrer tous les PVCs critiques vers XFS progressivement (voir ADR)
+
+### ZMQ socket IPC sur PVC persistant
+Un socket IPC persistant sur PVC est une bombe à retardement si le PVC entre en `emergency_ro`. L'init container `cleanup-cache` le supprime avant le démarrage, mais il vaut mieux utiliser `emptyDir` pour les sockets IPC ou le répertoire `/dev/shm` (déjà en Memory). Solution long terme : Frigate devrait utiliser `/dev/shm` pour les sockets ZMQ.
+
+### Deadlock ArgoCD wave + WaitForFirstConsumer
+Si un PVC A (wave N) dépend d'un PVC B (wave 0) via `WaitForFirstConsumer`, et que le pod a besoin des deux, ArgoCD créera B mais ne créera pas A avant que B soit Bound — deadlock si B ne bind qu'avec un pod qui a besoin de A.
+
+**Fix structurel** : supprimer `sync-wave` des PVCs ou utiliser `volumeBindingMode: Immediate` pour les PVCs de config statiques.
+
+### Ordre de migration DataAngel
+Migrer le PVC AVANT de réparer le ZMQ socket permet à DataAngel de restaurer depuis S3 sur un volume XFS propre.
+
+---
+
+## Action Items
+
+- [ ] Documenter la stratégie de migration ext4 → XFS dans un ADR
+- [ ] Supprimer `argocd.argoproj.io/sync-wave` de `frigate-config-pvc` (évite le deadlock)
+- [ ] Envisager `emptyDir` ou `/dev/shm` pour les sockets ZMQ Frigate (pas de PVC)
+- [ ] Inventorier les PVCs encore sur `synelia-iscsi-retain` (ext4) et planifier la migration XFS

--- a/docs/post-mortems/2026-05-02-hydrus-iscsi-multiattach-zombie.md
+++ b/docs/post-mortems/2026-05-02-hydrus-iscsi-multiattach-zombie.md
@@ -1,0 +1,149 @@
+# Post-Mortem : Hydrus iSCSI Multi-Attach zombie session (2026-05-02)
+
+**Sévérité :** P2 — Hydrus Client inaccessible depuis 18h+  
+**Durée :** 18h+ (dernier restart 2026-05-01 19:49 UTC+2 → fix 2026-05-02 ~13:10 UTC)  
+**Nœud affecté :** `poison` (session zombie), `powder` (pod schedulé mais bloqué)  
+**Volume affecté :** `hydrus-client-config-pvc` (ext4, PV `pvc-40661ded-1800-48ad-b3fe-ddcf1ec302c5`)
+
+---
+
+## Timeline
+
+| Heure | Événement |
+|-------|-----------|
+| 2026-05-01 19:49 | Pod hydrus-client recréé sur `powder` après force-delete |
+| 19:49+ | Pod bloqué en `Init:0/1` — kubelet powder : `unmounted volumes=[config], unattached volumes=[config], context deadline exceeded` |
+| 18h+ | kube-controller-manager (sur `poison`) : `VerifyVolumesAreAttached: nil spec for volume 87b05d98...` toutes les 60s |
+| 18h+ | Aucun VolumeAttachment créé pour `pvc-40661ded` |
+| 2026-05-02 12:48 | kube-controller-manager : `Multi-Attach error: volume already exclusively attached to "poison"` |
+| 12:55 | Diagnostic confirmé : `87b05d98` dans `poison.status.volumesInUse` ET `poison.status.volumesAttached`, mais aucun pod sur poison ne l'utilise |
+| 12:55 | CSI node pod (poison) : `NodeUnstageVolume` pour `87b05d98` toutes les ~2min, session iSCSI qui connect/disconnect |
+| 12:58 | Pod debug privilégié créé sur poison → répertoire stale trouvé : `/var/lib/kubelet/plugins/kubernetes.io/csi/csi.san.synology.com/1d56e109.../globalmount/` |
+| 12:58 | Répertoire stale supprimé (pas de mount actif) |
+| 13:00 | `poison.status.volumesInUse` se vide automatiquement (kubelet détecte la suppression) |
+| 13:01 | VolumeAttachment créé sur `powder` → `attached: true` en 39s |
+| 13:01 | iSCSI login sur powder (90s de délai — session reconstituée) |
+| 13:02 | DataAngel démarre — validation 4 bases SQLite (~35min total) |
+| 13:37 | DataAngel terminé — pull image ghcr.io/hydrusnetwork/hydrus:v670 (15min, 893 MB) |
+| 13:52 | Pod `2/2 Running`, 0 restarts |
+
+---
+
+## Root Cause
+
+### Session iSCSI zombie sur `poison`
+
+Le pod hydrus-client a précédemment tourné sur `poison`. Lors d'un redémarrage, le kubelet sur `poison` a tenté de démonter (`NodeUnstageVolume`) le volume CSI, mais le driver Synology a retourné `OK` sans supprimer le répertoire de staging kubelet :
+
+```
+/var/lib/kubelet/plugins/kubernetes.io/csi/csi.san.synology.com/1d56e109.../globalmount/
+```
+
+**Conséquence en cascade :**
+
+1. Le répertoire existe → kubelet `poison` pense le volume toujours stagé → le signale dans `volumesInUse` → node status mis à jour → `poison.status.volumesAttached` conserve `87b05d98`
+
+2. kube-controller-manager (attach-detach controller) voit le volume comme attaché à `poison` → refuse de créer un VolumeAttachment pour `powder` (violation RWO)
+
+3. L'erreur `nil spec` se produit car le controller essaie de vérifier le volume dans son ASW (actual state of world) mais ne parvient pas à reconstruire la VolumeSpec depuis l'entrée stale du node status
+
+4. Cycle infini : `NodeUnstageVolume` → session manquante (`doesn't exist`) → driver retourne OK → répertoire non supprimé → kubelet retry dans 2min → loop
+
+### Pourquoi la session n'a pas été nettoyée
+
+Le driver CSI Synology retourne `OK` sur `NodeUnstageVolume` quand la session iSCSI n'existe pas, sans supprimer le répertoire de staging. C'est un bug du driver qui devrait supprimer le répertoire même en l'absence de session active.
+
+---
+
+## Fix
+
+```bash
+# 1. Créer un pod debug privilégié sur poison
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: iscsi-cleanup-poison
+  namespace: kube-system
+spec:
+  nodeName: poison
+  tolerations:
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
+  volumes:
+  - name: kubelet
+    hostPath:
+      path: /var/lib/kubelet
+  containers:
+  - name: cleanup
+    image: busybox:1.37.0
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - name: kubelet
+      mountPath: /var/lib/kubelet
+    command: ["rm", "-rf", "/var/lib/kubelet/plugins/kubernetes.io/csi/csi.san.synology.com/1d56e109.../"]
+EOF
+
+# 2. Supprimer le pod debug
+kubectl delete pod -n kube-system iscsi-cleanup-poison
+
+# 3. Attendre que kubelet vide volumesInUse (~60s)
+# 4. VolumeAttachment créé automatiquement sur le bon nœud
+```
+
+---
+
+## Diagnostic
+
+Commandes clés pour identifier ce type de zombie :
+
+```bash
+# Vérifier si un PVC est signalé attaché à un nœud sans VolumeAttachment correspondant
+kubectl get volumeattachment | grep <pvc-name>  # doit retourner une ligne
+kubectl get node <node> -o jsonpath='{.status.volumesAttached}'  # vs VolumeAttachments
+
+# Trouver l'erreur dans kube-controller-manager
+kubectl logs -n kube-system kube-controller-manager-<leader> | grep "nil spec for volume"
+kubectl logs -n kube-system kube-controller-manager-<leader> | grep "Multi-Attach error"
+
+# Vérifier le répertoire stale sur le nœud (via pod debug privilégié)
+ls /var/lib/kubelet/plugins/kubernetes.io/csi/csi.san.synology.com/
+```
+
+---
+
+## Lessons Learned
+
+### Bug driver CSI Synology : NodeUnstageVolume incomplet
+
+Le driver ne supprime pas le répertoire de staging quand la session iSCSI n'existe plus. Cela laisse un répertoire orphelin qui fait croire au kubelet que le volume est toujours stagé.
+
+**Workaround** : suppression manuelle via pod debug privilégié.
+
+**Fix structurel** : contribuer un fix upstream au driver CSI Synology, ou créer un job de cleanup périodique qui vérifie les répertoires CSI staging sans session iSCSI active.
+
+### Diagnostic de Multi-Attach zombie
+
+L'erreur `nil spec for volume` dans le kube-controller-manager est le premier signal. Elle indique que le controller essaie de vérifier un volume dans son ASW mais ne peut pas reconstruire sa spec — souvent causé par un nœud ayant le volume dans `volumesAttached` sans VolumeAttachment correspondant.
+
+Vérifier immédiatement :
+1. `kubectl get volumeattachment` — le VolumeAttachment existe-t-il ?
+2. `kubectl get node <node> -o jsonpath='{.status.volumesAttached}'` — sur quel nœud le volume est-il listé ?
+3. Y a-t-il un pod actif sur ce nœud utilisant ce PVC ?
+
+### Impact de la durée
+
+18h de downtime pour Hydrus Client, une application non-critique. L'absence d'alerte proactive sur `Init:0/1` prolongé a retardé le diagnostic.
+
+**Action** : ajouter une alerte Prometheus sur `kube_pod_init_container_status_running == 0` pendant > 30 minutes.
+
+---
+
+## Action Items
+
+- [ ] Bug report upstream driver CSI Synology : `NodeUnstageVolume` doit supprimer le répertoire de staging même si la session iSCSI est absente
+- [ ] Alerte : `kube_pod_init_container_status_running == 0` pendant > 30min (exclude dataangel restore)
+- [ ] Script de diagnostic : détecter les volumes dans `volumesAttached` sans VolumeAttachment correspondant
+- [ ] Procédure documentée dans `docs/troubleshooting/iscsi-zombie-session.md`


### PR DESCRIPTION
## Summary

- 13 184 WAL files en S3 avec **1 seul snapshot** dans la génération litestream → restore dépasse le timeout par défaut de 30min
- À ~240 WALs/min, la restore complète prend ~55min + snapshot → 90min est la valeur safe
- Long terme : forcer un nouveau snapshot litestream une fois HA redémarré pour réduire la chaîne WAL

## Test plan

- [ ] PR mergée → ArgoCD déploie sur dev
- [ ] Promote prod-stable → HA pod redémarre avec timeout 90m
- [ ] DataAngel complète la restore sans timeout
- [ ] HA démarre 2/2 Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added post-mortem documentation for storage migration incident affecting Home Assistant and Frigate, including timeline, root causes, and remediation steps.
  * Added post-mortem documentation for Hydrus storage multi-attach incident, including diagnostic procedures and lessons learned.

* **Chores**
  * Updated deployment configuration settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charchess/vixens/pull/3184)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->