### PR TITLE
fix(dataangel): inject DATA_GUARD_RESTORE_TIMEOUT env var from annotation

### DIFF
--- a/apps/_shared/components/dataangel/kustomization.yaml
+++ b/apps/_shared/components/dataangel/kustomization.yaml
@@ -51,6 +51,10 @@ patches:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.annotations['dataangel.io/rclone-interval']
+            - name: DATA_GUARD_RESTORE_TIMEOUT
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['dataangel.io/restore-timeout']
             - name: DATA_GUARD_METRICS_PORT
               value: "9090"
             - name: DATA_GUARD_METRICS_ENABLED


### PR DESCRIPTION
## Summary

- `dataangel.io/restore-timeout` annotation existed on pods but was never mapped to `DATA_GUARD_RESTORE_TIMEOUT` env var in the shared Kustomize component
- DataAngel read `os.Getenv("DATA_GUARD_RESTORE_TIMEOUT")` with default `"30m"` — annotation was silently ignored
- HomeAssistant was stuck in an init loop: 13k WAL files → ~55min restore > 30m timeout

## Fix

Add `DATA_GUARD_RESTORE_TIMEOUT` to `apps/_shared/components/dataangel/kustomization.yaml`, mapped from the pod annotation via fieldRef. Apps without the annotation get an empty string, which DataAngel treats as the 30m default.

## Test plan

- [ ] HomeAssistant pod starts with `DATA_GUARD_RESTORE_TIMEOUT=90m` env var
- [ ] DataAngel logs show `timeout: 1h30m0s` instead of `timeout: 30m0s`
- [ ] Restore completes within 90m

🤖 Generated with [Claude Code](https://claude.com/claude-code)