### PR TITLE
feat(dataangel): snapshot-interval env var mapping + HA 24h interval

### DIFF
--- a/apps/10-home/homeassistant/base/deployment.yaml
+++ b/apps/10-home/homeassistant/base/deployment.yaml
@@ -29,6 +29,7 @@ spec:
         vixens.io/fast-start: "true"
         dataangel.io/metrics-port: "9090"
         dataangel.io/restore-timeout: "90m"
+        dataangel.io/snapshot-interval: "24h"
         vixens.io/explicitly-allow-root: "true"
     spec:
       securityContext:

--- a/apps/_shared/components/dataangel/kustomization.yaml
+++ b/apps/_shared/components/dataangel/kustomization.yaml
@@ -51,6 +51,10 @@ patches:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.annotations['dataangel.io/rclone-interval']
+            - name: DATA_GUARD_SNAPSHOT_INTERVAL
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['dataangel.io/snapshot-interval']
             - name: DATA_GUARD_RESTORE_TIMEOUT
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
## Summary

- Add `DATA_GUARD_SNAPSHOT_INTERVAL` env var mapping to the shared DataAngel Kustomize component (annotation → env var, same pattern as other fields)
- Enable `dataangel.io/snapshot-interval: "24h"` on Home Assistant to cap litestream WAL chain length

## Why

Root cause action item from [post-mortem 2026-05-10](../docs/post-mortems/2026-05-10-ha-dataangel-wal-corruption-restore-timeout.md): HA's WAL chain grew to 7000+ entries over time because no snapshot interval was configured. A 24h snapshot resets the generation and caps the chain to ≤24h of WALs, bounding:
- Restore time (only replay ≤24h of WALs instead of weeks)
- Blast radius of WAL corruption (only lose ≤24h of history instead of the whole chain)

`DATA_GUARD_SNAPSHOT_INTERVAL` is already implemented in DataAngel source (sha-2957234) with default 24h — the annotation was just missing from the Kustomize component like `DATA_GUARD_RESTORE_TIMEOUT` was before PR #3186.

## Test plan
- [ ] CI passes
- [ ] Verify HA pod includes `DATA_GUARD_SNAPSHOT_INTERVAL=24h` env var after deploy
- [ ] Verify litestream generates snapshots after 24h in backup mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)